### PR TITLE
Add panel for controlling stepper motor

### DIFF
--- a/finesse/__main__.py
+++ b/finesse/__main__.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from platformdirs import user_log_path
 from PySide6.QtWidgets import QApplication
 
+from . import hardware  # noqa
 from . import config
 from .gui.main_window import MainWindow
 

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -1,7 +1,8 @@
 """Code for FINESSE's main GUI window."""
-from PySide6.QtWidgets import QMainWindow
+from PySide6.QtWidgets import QGridLayout, QMainWindow, QWidget
 
 from .serial_view import SerialPortControl
+from .stepper_motor_view import StepperMotorControl
 
 
 class MainWindow(QMainWindow):
@@ -12,6 +13,10 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("FINESSE")
 
+        # Setup for stepper motor control
+        stepper_motor = StepperMotorControl()
+
+        # Setup for serial port control
         devices = {
             "ST10": {"port": "COM5", "baud_rate": "9600"},
             "DP9800": {"port": "COM1", "baud_rate": "9600"},
@@ -21,4 +26,11 @@ class MainWindow(QMainWindow):
             ("COM1", "COM5", "COM7"),
             ("600", "9600", "115200"),
         )
-        self.setCentralWidget(serial_port)
+
+        layout = QGridLayout()
+        layout.addWidget(stepper_motor, 0, 0)
+        layout.addWidget(serial_port, 1, 0)
+
+        widget = QWidget()
+        widget.setLayout(layout)
+        self.setCentralWidget(widget)

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -11,11 +11,11 @@ class StepperMotorControl(QGroupBox):
         super().__init__("Target control")
 
         layout = QGridLayout()
-        zenith = QPushButton("ZENITH")
-        nadir = QPushButton("NADIR")
-        hot_bb = QPushButton("HOT_BB")
-        cold_bb = QPushButton("COLD_BB")
-        home = QPushButton("HOME")
+        zenith = self._create_stepper_button("ZENITH")
+        nadir = self._create_stepper_button("NADIR")
+        hot_bb = self._create_stepper_button("HOT_BB")
+        cold_bb = self._create_stepper_button("COLD_BB")
+        home = self._create_stepper_button("HOME")
         park = QPushButton("PARK")
         self.angle = QSpinBox()
         self.angle.setMaximum(359)
@@ -33,6 +33,14 @@ class StepperMotorControl(QGroupBox):
 
         self.setLayout(layout)
 
+    def _create_stepper_button(self, name: str) -> QPushButton:
+        btn = QPushButton(name)
+        btn.clicked.connect(lambda: self._preset_clicked(btn))  # type: ignore
+        return btn
+
+    def _preset_clicked(self, btn: QPushButton) -> None:
+        pub.sendMessage("stepper.move", step=btn.text().lower())
+
     def _goto_clicked(self) -> None:
         """Move stepper motor to specified position."""
-        pub.sendMessage("stepper.move", step_number=self.angle.value())
+        pub.sendMessage("stepper.move", step=self.angle.value())

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -36,21 +36,32 @@ class StepperMotorControl(QGroupBox):
         self.setLayout(layout)
 
     def _create_stepper_button(self, name: str) -> QPushButton:
+        """Create a button to move the motor to a preset position.
+
+        Args:
+            name: The name of the preset (will be converted to lowercase)
+        """
         btn = QPushButton(name)
         btn.clicked.connect(lambda: self._preset_clicked(btn))  # type: ignore
         return btn
 
-    def _set_last_clicked(self, btn: QPushButton) -> None:
+    def _set_selected_button(self, btn: QPushButton) -> None:
+        """Change the currently selected button, indicated by colour.
+
+        Args:
+            btn: The just-clicked button
+        """
         if self.last_clicked:
             self.last_clicked.setStyleSheet("")
         btn.setStyleSheet("background-color: blue")
         self.last_clicked = btn
 
     def _preset_clicked(self, btn: QPushButton) -> None:
-        self._set_last_clicked(btn)
+        """Move the stepper motor to preset position."""
+        self._set_selected_button(btn)
         pub.sendMessage("stepper.move", step=btn.text().lower())
 
     def _goto_clicked(self) -> None:
         """Move stepper motor to specified position."""
-        self._set_last_clicked(self.goto)
+        self._set_selected_button(self.goto)
         pub.sendMessage("stepper.move", step=self.angle.value())

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -1,4 +1,5 @@
 """Code for controlling the stepper motor which moves the mirror."""
+from pubsub import pub
 from PySide6.QtWidgets import QGridLayout, QGroupBox, QPushButton, QSpinBox
 
 
@@ -16,9 +17,10 @@ class StepperMotorControl(QGroupBox):
         cold_bb = QPushButton("COLD_BB")
         home = QPushButton("HOME")
         park = QPushButton("PARK")
-        angle = QSpinBox()
-        angle.setMaximum(359)
+        self.angle = QSpinBox()
+        self.angle.setMaximum(359)
         goto = QPushButton("GOTO")
+        goto.clicked.connect(self._goto_clicked)  # type: ignore
 
         layout.addWidget(zenith, 0, 0)
         layout.addWidget(nadir, 0, 1)
@@ -26,7 +28,11 @@ class StepperMotorControl(QGroupBox):
         layout.addWidget(cold_bb, 0, 3)
         layout.addWidget(home, 1, 0)
         layout.addWidget(park, 1, 1)
-        layout.addWidget(angle, 1, 2)
+        layout.addWidget(self.angle, 1, 2)
         layout.addWidget(goto, 1, 3)
 
         self.setLayout(layout)
+
+    def _goto_clicked(self) -> None:
+        """Move stepper motor to specified position."""
+        pub.sendMessage("stepper.move", step_number=self.angle.value())

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -16,7 +16,6 @@ class StepperMotorControl(QGroupBox):
         hot_bb = self._create_stepper_button("HOT_BB")
         cold_bb = self._create_stepper_button("COLD_BB")
         home = self._create_stepper_button("HOME")
-        park = QPushButton("PARK")
         self.angle = QSpinBox()
         self.angle.setMaximum(359)
         goto = QPushButton("GOTO")
@@ -27,7 +26,6 @@ class StepperMotorControl(QGroupBox):
         layout.addWidget(hot_bb, 0, 2)
         layout.addWidget(cold_bb, 0, 3)
         layout.addWidget(home, 1, 0)
-        layout.addWidget(park, 1, 1)
         layout.addWidget(self.angle, 1, 2)
         layout.addWidget(goto, 1, 3)
 

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -1,4 +1,6 @@
 """Code for controlling the stepper motor which moves the mirror."""
+from typing import Optional
+
 from pubsub import pub
 from PySide6.QtWidgets import QGridLayout, QGroupBox, QPushButton, QSpinBox
 
@@ -18,8 +20,10 @@ class StepperMotorControl(QGroupBox):
         home = self._create_stepper_button("HOME")
         self.angle = QSpinBox()
         self.angle.setMaximum(359)
-        goto = QPushButton("GOTO")
-        goto.clicked.connect(self._goto_clicked)  # type: ignore
+        self.goto = QPushButton("GOTO")
+        self.goto.clicked.connect(self._goto_clicked)  # type: ignore
+
+        self.last_clicked: Optional[QPushButton] = None
 
         layout.addWidget(zenith, 0, 0)
         layout.addWidget(nadir, 0, 1)
@@ -27,7 +31,7 @@ class StepperMotorControl(QGroupBox):
         layout.addWidget(cold_bb, 0, 3)
         layout.addWidget(home, 1, 0)
         layout.addWidget(self.angle, 1, 2)
-        layout.addWidget(goto, 1, 3)
+        layout.addWidget(self.goto, 1, 3)
 
         self.setLayout(layout)
 
@@ -36,9 +40,17 @@ class StepperMotorControl(QGroupBox):
         btn.clicked.connect(lambda: self._preset_clicked(btn))  # type: ignore
         return btn
 
+    def _set_last_clicked(self, btn: QPushButton) -> None:
+        if self.last_clicked:
+            self.last_clicked.setStyleSheet("")
+        btn.setStyleSheet("background-color: blue")
+        self.last_clicked = btn
+
     def _preset_clicked(self, btn: QPushButton) -> None:
+        self._set_last_clicked(btn)
         pub.sendMessage("stepper.move", step=btn.text().lower())
 
     def _goto_clicked(self) -> None:
         """Move stepper motor to specified position."""
+        self._set_last_clicked(self.goto)
         pub.sendMessage("stepper.move", step=self.angle.value())

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -1,0 +1,32 @@
+"""Code for controlling the stepper motor which moves the mirror."""
+from PySide6.QtWidgets import QGridLayout, QGroupBox, QPushButton, QSpinBox
+
+
+class StepperMotorControl(QGroupBox):
+    """A control showing buttons for moving the mirror to a target."""
+
+    def __init__(self) -> None:
+        """Create a new StepperMotorControl."""
+        super().__init__("Target control")
+
+        layout = QGridLayout()
+        zenith = QPushButton("ZENITH")
+        nadir = QPushButton("NADIR")
+        hot_bb = QPushButton("HOT_BB")
+        cold_bb = QPushButton("COLD_BB")
+        home = QPushButton("HOME")
+        park = QPushButton("PARK")
+        angle = QSpinBox()
+        angle.setMaximum(359)
+        goto = QPushButton("GOTO")
+
+        layout.addWidget(zenith, 0, 0)
+        layout.addWidget(nadir, 0, 1)
+        layout.addWidget(hot_bb, 0, 2)
+        layout.addWidget(cold_bb, 0, 3)
+        layout.addWidget(home, 1, 0)
+        layout.addWidget(park, 1, 1)
+        layout.addWidget(angle, 1, 2)
+        layout.addWidget(goto, 1, 3)
+
+        self.setLayout(layout)

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -1,0 +1,1 @@
+"""This module contains code for interfacing with different hardware devices."""

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -1,1 +1,5 @@
 """This module contains code for interfacing with different hardware devices."""
+from .dummy_stepper_motor import DummyStepperMotor
+
+# TODO: Replace with a real stepper motor device
+stepper = DummyStepperMotor(360)

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -1,7 +1,10 @@
 """Code for a fake stepper motor device."""
 import logging
+from typing import Union
 
 from pubsub import pub
+
+_PRESETS = ("zenith", "nadir", "hot_bb", "cold_bb", "home")
 
 
 class DummyStepperMotor:
@@ -13,23 +16,35 @@ class DummyStepperMotor:
         Args:
             steps_per_rotation: Number of motor steps for an entire rotation (360°)
         """
-        if steps_per_rotation <= 0:
-            raise ValueError("steps_per_rotation must be >0")
+        if steps_per_rotation < len(_PRESETS):
+            raise ValueError(f"steps_per_rotation must be >={len(_PRESETS)}")
 
         self.max_steps = steps_per_rotation - 1
         self.current_step = 0
 
         pub.subscribe(self.move_to, "stepper.move")
 
-    def move_to(self, step_number: int) -> None:
+    @staticmethod
+    def get_preset_angle(name: str) -> int:
+        """Get the angle for one of the preset positions.
+
+        Args:
+            name: Name of preset angle
+        """
+        return _PRESETS.index(name)
+
+    def move_to(self, step: Union[int, str]) -> None:
         """Move the motor to a specified rotation.
 
         Args:
-            step_number: The target step number
+            step: The target step number or the name of a preset
         """
-        if step_number < 0 or step_number > self.max_steps:
+        if isinstance(step, str):
+            step = DummyStepperMotor.get_preset_angle(step)
+
+        if step < 0 or step > self.max_steps:
             raise ValueError("step_number is out of range")
 
-        self.current_step = step_number
+        self.current_step = step
 
-        logging.info(f"Moving stepper motor to {step_number}")
+        logging.info(f"Moving stepper motor to {step}")

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -1,0 +1,35 @@
+"""Code for a fake stepper motor device."""
+import logging
+
+from pubsub import pub
+
+
+class DummyStepperMotor:
+    """A fake stepper motor device used for unit tests etc."""
+
+    def __init__(self, steps_per_rotation: int) -> None:
+        """Create a new DummyStepperMotor.
+
+        Args:
+            steps_per_rotation: Number of motor steps for an entire rotation (360°)
+        """
+        if steps_per_rotation <= 0:
+            raise ValueError("steps_per_rotation must be >0")
+
+        self.max_steps = steps_per_rotation - 1
+        self.current_step = 0
+
+        pub.subscribe(self.move_to, "stepper.move")
+
+    def move_to(self, step_number: int) -> None:
+        """Move the motor to a specified rotation.
+
+        Args:
+            step_number: The target step number
+        """
+        if step_number < 0 or step_number > self.max_steps:
+            raise ValueError("step_number is out of range")
+
+        self.current_step = step_number
+
+        logging.info(f"Moving stepper motor to {step_number}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -133,7 +133,7 @@ pydocstyle = ">=2.1"
 
 [[package]]
 name = "identify"
-version = "2.5.8"
+version = "2.5.9"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -311,6 +311,14 @@ python-versions = ">=3.6.8"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pypubsub"
+version = "4.0.3"
+description = "Python Publish-Subscribe Package"
+category = "main"
+optional = false
+python-versions = ">=3.3, <4"
+
+[[package]]
 name = "pyside6"
 version = "6.4.0.1"
 description = "Python bindings for the Qt cross-platform application and UI framework"
@@ -437,7 +445,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "setuptools"
-version = "65.5.1"
+version = "65.6.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -508,7 +516,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "d9191f20beed808840bf472bb4d51433be24e630dffe6d9500338a433a8a81be"
+content-hash = "0873e77851d4cab08bbc540bbcec30d2980059a279cb0c3b4003b5134b00b681"
 
 [metadata.files]
 attrs = [
@@ -623,8 +631,8 @@ flake8-docstrings = [
     {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
 ]
 identify = [
-    {file = "identify-2.5.8-py2.py3-none-any.whl", hash = "sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440"},
-    {file = "identify-2.5.8.tar.gz", hash = "sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58"},
+    {file = "identify-2.5.9-py2.py3-none-any.whl", hash = "sha256:a390fb696e164dbddb047a0db26e57972ae52fbd037ae68797e5ae2f4492485d"},
+    {file = "identify-2.5.9.tar.gz", hash = "sha256:906036344ca769539610436e40a684e170c3648b552194980bb7b617a8daeb9f"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -714,6 +722,9 @@ pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
+pypubsub = [
+    {file = "Pypubsub-4.0.3-py3-none-any.whl", hash = "sha256:7f716bae9388afe01ff82b264ba8a96a8ae78b42bb1f114f2716ca8f9e404e2a"},
+]
 pyside6 = [
     {file = "PySide6-6.4.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:a45ea81fa4d1fdb7aeb7250508b07fa209e6bfb26becf5b24751d3769cade292"},
     {file = "PySide6-6.4.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:90bb074469c37155c69fbfe85d85d23e52973df784bf7bc0d36c646ebdf985a4"},
@@ -801,8 +812,8 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 setuptools = [
-    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
-    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
+    {file = "setuptools-65.6.0-py3-none-any.whl", hash = "sha256:6211d2f5eddad8757bd0484923ca7c0a6302ebc4ab32ea5e94357176e0ca0840"},
+    {file = "setuptools-65.6.0.tar.gz", hash = "sha256:d1eebf881c6114e51df1664bc2c9133d022f78d12d5f4f665b9191f084e2862d"},
 ]
 shiboken6 = [
     {file = "shiboken6-6.4.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:491f3394c771e6da85b89ec39394da76b4e11d4ff697250f8ea26f0a08eb2471"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 python = ">=3.9,<3.12"
 PySide6 = "^6.4.0"
 platformdirs = "^2.5.4"
+pypubsub = "^4.0.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"

--- a/tests/test_stepper_motor.py
+++ b/tests/test_stepper_motor.py
@@ -3,6 +3,8 @@ import pytest
 
 from finesse.hardware.dummy_stepper_motor import DummyStepperMotor
 
+PRESETS = ("zenith", "nadir", "hot_bb", "cold_bb", "home")
+
 
 def test_constructor() -> None:
     """Check that the constructor only accepts values in permissible range."""
@@ -13,12 +15,12 @@ def test_constructor() -> None:
         DummyStepperMotor(-1)
 
     # Should work
-    DummyStepperMotor(1)
+    DummyStepperMotor(len(PRESETS))
 
 
-def test_move_to() -> None:
+def test_move_to_number() -> None:
     """Check that the stepper motor can be moved to valid positions."""
-    stepper = DummyStepperMotor(2)
+    stepper = DummyStepperMotor(len(PRESETS))
 
     # Check that we start at step 0
     assert stepper.current_step == 0
@@ -27,8 +29,21 @@ def test_move_to() -> None:
     with pytest.raises(ValueError):
         stepper.move_to(-1)
     with pytest.raises(ValueError):
-        stepper.move_to(2)
+        stepper.move_to(len(PRESETS))
 
     # Check that we can move to a valid position
     stepper.move_to(1)
     assert stepper.current_step == 1
+
+
+def test_move_to_preset() -> None:
+    """Check that the stepper motor can be moved to valid preset values."""
+    stepper = DummyStepperMotor(len(PRESETS))
+
+    # Check that we get an error for invalid presets
+    with pytest.raises(ValueError):
+        stepper.move_to("MADE UP")
+
+    # Check that we don't get error for valid presets
+    for name in PRESETS:
+        stepper.move_to(name)

--- a/tests/test_stepper_motor.py
+++ b/tests/test_stepper_motor.py
@@ -1,0 +1,34 @@
+"""Tests for DummyStepperMotor."""
+import pytest
+
+from finesse.hardware.dummy_stepper_motor import DummyStepperMotor
+
+
+def test_constructor() -> None:
+    """Check that the constructor only accepts values in permissible range."""
+    with pytest.raises(ValueError):
+        DummyStepperMotor(0)
+
+    with pytest.raises(ValueError):
+        DummyStepperMotor(-1)
+
+    # Should work
+    DummyStepperMotor(1)
+
+
+def test_move_to() -> None:
+    """Check that the stepper motor can be moved to valid positions."""
+    stepper = DummyStepperMotor(2)
+
+    # Check that we start at step 0
+    assert stepper.current_step == 0
+
+    # Out-of-range arguments
+    with pytest.raises(ValueError):
+        stepper.move_to(-1)
+    with pytest.raises(ValueError):
+        stepper.move_to(2)
+
+    # Check that we can move to a valid position
+    stepper.move_to(1)
+    assert stepper.current_step == 1


### PR DESCRIPTION
Closes #32.

This PR adds the panel for controlling the stepper motor (which is in the top left of the GUI for the old program). Users can click on one of the buttons to move to a preset angle specified by the name on the button or can go to a specific angle/step by choosing a number and clicking "GOTO". The background of the last-clicked button changes to blue, as was done in the old program.

In the process, I created a `DummyStepperMotor` class to support the functionality of the GUI. I know we said we wouldn't venture into making dummy devices in this sprint, but this seemed like the cleanest way to implement the GUI functionality. (Its implementation will no doubt change when we realise the actual stepper motor behaves a bit differently.) I put it in a separate `hardware` module and it communicates with the GUI using PyPubSub messages. This should keep the concerns neatly separated.