### PR TITLE
OPUS view

### DIFF
--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -1,6 +1,7 @@
 """Code for FINESSE's main GUI window."""
-from PySide6.QtWidgets import QMainWindow
+from PySide6.QtWidgets import QGridLayout, QGroupBox, QMainWindow, QWidget
 
+from .opus_view import OPUSControl
 from .serial_view import SerialPortControl
 
 
@@ -12,13 +13,22 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("FINESSE")
 
+        layout = QGridLayout()
+
         devices = {
             "ST10": {"port": "COM5", "baud_rate": "9600"},
             "DP9800": {"port": "COM1", "baud_rate": "9600"},
         }
-        serial_port = SerialPortControl(
+        serial_port: QGroupBox = SerialPortControl(
             devices,
             ("COM1", "COM5", "COM7"),
             ("600", "9600", "115200"),
         )
-        self.setCentralWidget(serial_port)
+        opus: QGroupBox = OPUSControl()
+
+        layout.addWidget(serial_port, 3, 0)
+        layout.addWidget(opus, 0, 1)
+
+        central = QWidget()
+        central.setLayout(layout)
+        self.setCentralWidget(central)

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -24,7 +24,7 @@ class MainWindow(QMainWindow):
             ("COM1", "COM5", "COM7"),
             ("600", "9600", "115200"),
         )
-        opus: QGroupBox = OPUSControl()
+        opus: QGroupBox = OPUSControl("127.0.0.1")
 
         layout.addWidget(serial_port, 3, 0)
         layout.addWidget(opus, 0, 1)

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -2,6 +2,8 @@
 import logging
 from functools import partial
 
+from PySide6.QtCore import QUrl
+from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QVBoxLayout
 
 
@@ -9,33 +11,60 @@ class OPUSControl(QGroupBox):
     """Class that monitors and control the OPUS interferometer."""
 
     _btn_actions = ("Status", "Cancel", "Start", "Stop", "Connect", "OPUS")
+    _status_info = ("Status code", "Description", "Error code", "Error description")
 
     def __init__(self) -> None:
         """Creates the widgets to monitor and control the OPUS interferometer."""
         super().__init__("OPUS client view")
 
+        self.status: QWebEngineView
         layout = self._create_controls()
         self.setLayout(layout)
 
     def _create_controls(self) -> QHBoxLayout:
-        """Creates the controls for the ports of the devices.
+        """Creates the controls for comunicating with the interferometer.
 
         Returns:
-            QHBoxLayout: The layout with the widgets.
+            QHBoxLayout: The layout with the buttons.
         """
-        layout = QVBoxLayout()
+        main_layout = QHBoxLayout()
+        main_layout.addLayout(self._create_buttons())
+        main_layout.addLayout(self._create_status_page())
+        return main_layout
+
+    def _create_buttons(self) -> QVBoxLayout:
+        """Creates the buttons.
+
+        Returns:
+            QHBoxLayout: The layout with the buttons.
+        """
+        btn_layout = QVBoxLayout()
         for action in self._btn_actions:
 
             button = QPushButton(action)
             button.released.connect(  # type: ignore
                 partial(self.on_button_clicked, action=action)
             )
-            layout.addWidget(button)
+            btn_layout.addWidget(button)
 
-        main_layout = QHBoxLayout()
-        main_layout.addLayout(layout)
+        return btn_layout
 
-        return main_layout
+    def _create_status_page(self) -> QVBoxLayout:
+        """Creates the status_page.
+
+        Returns:
+            QHBoxLayout: The layout with the buttons.
+        """
+        status_page = QGroupBox("Status")
+        self.status = QWebEngineView()
+
+        _layout = QVBoxLayout()
+        _layout.addWidget(self.status)
+        status_page.setLayout(_layout)
+
+        layout = QVBoxLayout()
+        layout.addWidget(status_page)
+        return layout
 
     def on_button_clicked(self, action: str) -> None:
         """Execute the given action by sending a message to the appropriate topic.
@@ -47,6 +76,15 @@ class OPUSControl(QGroupBox):
             action: Action to be executed.
         """
         logging.info(f"Action '{action}' executed!")
+
+    def display_status(self, url: str) -> None:
+        """Displays the new status provided by the url.
+
+        Args:
+            url: Where information with the new status is contained.
+        """
+        self.status.load(QUrl(url))
+        self.status.show()
 
 
 if __name__ == "__main__":

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -73,7 +73,7 @@ class OPUSControl(QGroupBox):
 
             button = QPushButton(name.capitalize())
             button.clicked.connect(  # type: ignore
-                partial(self.on_button_clicked, action=name.lower())
+                partial(self.on_acction_button_clicked, action=name.lower())
             )
             btn_layout.addWidget(button)
 
@@ -84,24 +84,6 @@ class OPUSControl(QGroupBox):
         btn_layout.addStretch()
 
         return btn_layout
-
-    def _create_status_page(self) -> QVBoxLayout:
-        """Creates the status_page.
-
-        Returns:
-            QHBoxLayout: The layout with the web view.
-        """
-        status_page = QGroupBox("Status")
-        self.status = QWebEngineView()
-        self.status.setMinimumSize(QSize(200, 200))
-
-        _layout = QVBoxLayout()
-        _layout.addWidget(self.status)
-        status_page.setLayout(_layout)
-
-        layout = QVBoxLayout()
-        layout.addWidget(status_page)
-        return layout
 
     def _create_log_area(self) -> QVBoxLayout:
         """Creates the log area for OPUS-related communication.
@@ -121,18 +103,36 @@ class OPUSControl(QGroupBox):
         layout.addWidget(log_box)
         return layout
 
+    def _create_status_page(self) -> QVBoxLayout:
+        """Creates the status_page.
+
+        Returns:
+            QHBoxLayout: The layout with the web view.
+        """
+        status_page = QGroupBox("Status")
+        self.status = QWebEngineView()
+        self.status.setMinimumSize(QSize(200, 200))
+
+        _layout = QVBoxLayout()
+        _layout.addWidget(self.status)
+        status_page.setLayout(_layout)
+
+        layout = QVBoxLayout()
+        layout.addWidget(status_page)
+        return layout
+
     def url(self, action: str) -> str:
         """Builds an URL out of the ip and the action.
 
         Args:
-            action (str): The action to use.
+            action: The action to use.
 
         Returns:
             str: The constructed URL
         """
         return f"http://{self.ip}/{self.commands[action]}"
 
-    def on_button_clicked(self, action: str) -> None:
+    def on_acction_button_clicked(self, action: str) -> None:
         """Execute the given action by sending a message to the appropriate topic.
 
         TODO: Here assuming we are going to use pubsub or equivalent to send messages
@@ -141,10 +141,14 @@ class OPUSControl(QGroupBox):
         Args:
             action: Action to be executed.
         """
-        logging.info(f"Action '{self.url(action)}' executed!")
+        logging.info(f"OPUS action '{self.url(action)}' executed!")
 
     def display_status(self) -> None:
-        """Retrieves and displays the new status."""
+        """Retrieves and displays the new status.
+
+        TODO: I'm not sure who should populate the error log in the GUI. Probably the
+        ones handling the individual actions above. These are all placeholders, for now.
+        """
         logging.info("Getting OPUS status!")
         self.status.load(QUrl(self.url("status")))
         self.status.show()
@@ -160,14 +164,21 @@ class OPUSControl(QGroupBox):
 
 
 class OPUSLogHandler(logging.Handler):
-    """Logger for the errors related to OPUS."""
+    """Specific logger for the errors related to OPUS.
+
+    Only log messages using the OPUS logger will be recorded here. Typically, they will
+    be error messages, but it can be any information worth to be logged.
+    """
 
     @classmethod
     def set_handler(cls, log_area: QTextBrowser):
-        """Creates the handler and adds it to the logger."""
+        """Creates the handler and adds it to the logger.
+
+        Args:
+            log_area: The area where the log will be printed.
+        """
         ch = cls(weakref.ref(log_area))
 
-        # create and add formatter to handle
         formatter = logging.Formatter(
             fmt="%(asctime)s [%(levelname)s]: %(message)s", datefmt="%Y/%m/%d %H:%M:%S"
         )

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -1,23 +1,38 @@
 """Panel and widgets related to the control of the OPUS interferometer."""
 import logging
 from functools import partial
+from typing import Dict, Optional
 
 from PySide6.QtCore import QUrl
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QVBoxLayout
 
+COMMANDS = {
+    "status": "opusrs/stat.htm",
+    "connect": "opusrs/cmd.htm?opusrsconnect",
+    "start": "opusrs/cmd.htm?opusrsstart",
+    "stop": "opusrs/cmd.htm?opusrsstop",
+    "cancel": "opusrs/cmd.htm?opusrscancel",
+    "opus": "TBC",
+}
+
 
 class OPUSControl(QGroupBox):
     """Class that monitors and control the OPUS interferometer."""
 
-    _btn_actions = ("Status", "Cancel", "Start", "Stop", "Connect", "OPUS")
-    _status_info = ("Status code", "Description", "Error code", "Error description")
+    def __init__(self, ip: str, commands: Optional[Dict[str, str]] = None) -> None:
+        """Creates the widgets to monitor and control the OPUS interferometer.
 
-    def __init__(self) -> None:
-        """Creates the widgets to monitor and control the OPUS interferometer."""
+        Args:
+            ip: IP for connecting to the OPUS system
+            commands: Commands to use to construct the action urls
+        """
         super().__init__("OPUS client view")
 
+        self.ip = ip
+        self.commands = commands if commands is not None else COMMANDS
         self.status: QWebEngineView
+
         layout = self._create_controls()
         self.setLayout(layout)
 
@@ -39,13 +54,24 @@ class OPUSControl(QGroupBox):
             QHBoxLayout: The layout with the buttons.
         """
         btn_layout = QVBoxLayout()
-        for action in self._btn_actions:
 
-            button = QPushButton(action)
-            button.released.connect(  # type: ignore
-                partial(self.on_button_clicked, action=action)
+        button = QPushButton("Status")
+        button.clicked.connect(self.display_status)  # type: ignore
+        btn_layout.addWidget(button)
+
+        for name in set(self.commands.keys()) - {"status", "opus"}:
+
+            button = QPushButton(name.capitalize())
+            button.clicked.connect(  # type: ignore
+                partial(self.on_button_clicked, action=name.lower())
             )
             btn_layout.addWidget(button)
+
+        button = QPushButton("OPUS")
+        button.clicked.connect(self.open_opus)  # type: ignore
+        btn_layout.addWidget(button)
+
+        btn_layout.addStretch()
 
         return btn_layout
 
@@ -66,6 +92,17 @@ class OPUSControl(QGroupBox):
         layout.addWidget(status_page)
         return layout
 
+    def url(self, action: str) -> str:
+        """Builds an URL out of the ip and the action.
+
+        Args:
+            action (str): The action to use.
+
+        Returns:
+            str: The constructed URL
+        """
+        return f"http://{self.ip}/{self.commands[action]}"
+
     def on_button_clicked(self, action: str) -> None:
         """Execute the given action by sending a message to the appropriate topic.
 
@@ -75,16 +112,20 @@ class OPUSControl(QGroupBox):
         Args:
             action: Action to be executed.
         """
-        logging.info(f"Action '{action}' executed!")
+        logging.info(f"Action '{self.url(action)}' executed!")
 
-    def display_status(self, url: str) -> None:
-        """Displays the new status provided by the url.
-
-        Args:
-            url: Where information with the new status is contained.
-        """
-        self.status.load(QUrl(url))
+    def display_status(self) -> None:
+        """Retrieves and displays the new status."""
+        logging.info("Getting OPUS status!")
+        self.status.load(QUrl(self.url("status")))
         self.status.show()
+
+    def open_opus(self) -> None:
+        """Opens OPUS front end somewhere else.
+
+        TODO: No idea what this is supposed to do.
+        """
+        logging.info("Going to OPUS!")
 
 
 if __name__ == "__main__":
@@ -95,7 +136,7 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
 
     window = QMainWindow()
-    opus = OPUSControl()
+    opus = OPUSControl("127.0.0.1", commands=COMMANDS)
     window.setCentralWidget(opus)
     window.show()
     app.exec()

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -69,7 +69,9 @@ class OPUSControl(QGroupBox):
         button.clicked.connect(self.display_status)  # type: ignore
         btn_layout.addWidget(button)
 
-        for name in set(self.commands.keys()) - {"status", "opus"}:
+        for name in self.commands.keys():
+            if name in ("status", "opus"):
+                continue
 
             button = QPushButton(name.capitalize())
             button.clicked.connect(  # type: ignore

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -3,7 +3,7 @@ import logging
 from functools import partial
 from typing import Dict, Optional
 
-from PySide6.QtCore import QUrl
+from PySide6.QtCore import QSize, QUrl
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QVBoxLayout
 
@@ -83,6 +83,7 @@ class OPUSControl(QGroupBox):
         """
         status_page = QGroupBox("Status")
         self.status = QWebEngineView()
+        self.status.setMinimumSize(QSize(200, 200))
 
         _layout = QVBoxLayout()
         _layout.addWidget(self.status)

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -1,0 +1,63 @@
+"""Panel and widgets related to the control of the OPUS interferometer."""
+import logging
+from functools import partial
+
+from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QVBoxLayout
+
+
+class OPUSControl(QGroupBox):
+    """Class that monitors and control the OPUS interferometer."""
+
+    _btn_actions = ("Status", "Cancel", "Start", "Stop", "Connect", "OPUS")
+
+    def __init__(self) -> None:
+        """Creates the widgets to monitor and control the OPUS interferometer."""
+        super().__init__("OPUS client view")
+
+        layout = self._create_controls()
+        self.setLayout(layout)
+
+    def _create_controls(self) -> QHBoxLayout:
+        """Creates the controls for the ports of the devices.
+
+        Returns:
+            QHBoxLayout: The layout with the widgets.
+        """
+        layout = QVBoxLayout()
+        for action in self._btn_actions:
+
+            button = QPushButton(action)
+            button.released.connect(  # type: ignore
+                partial(self.on_button_clicked, action=action)
+            )
+            layout.addWidget(button)
+
+        main_layout = QHBoxLayout()
+        main_layout.addLayout(layout)
+
+        return main_layout
+
+    def on_button_clicked(self, action: str) -> None:
+        """Execute the given action by sending a message to the appropriate topic.
+
+        TODO: Here assuming we are going to use pubsub or equivalent to send messages
+        around and communicate between backend and front end.
+
+        Args:
+            action: Action to be executed.
+        """
+        logging.info(f"Action '{action}' executed!")
+
+
+if __name__ == "__main__":
+    import sys
+
+    from PySide6.QtWidgets import QApplication, QMainWindow
+
+    app = QApplication(sys.argv)
+
+    window = QMainWindow()
+    opus = OPUSControl()
+    window.setCentralWidget(opus)
+    window.show()
+    app.exec()

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -29,7 +29,7 @@ class OPUSControl(QGroupBox):
     """Class that monitors and control the OPUS interferometer."""
 
     def __init__(self, ip: str, commands: Optional[Dict[str, str]] = None) -> None:
-        """Creates the widgets to monitor and control the OPUS interferometer.
+        """Create the widgets to monitor and control the OPUS interferometer.
 
         Args:
             ip: IP for connecting to the OPUS system
@@ -75,7 +75,7 @@ class OPUSControl(QGroupBox):
 
             button = QPushButton(name.capitalize())
             button.clicked.connect(  # type: ignore
-                partial(self.on_acction_button_clicked, action=name.lower())
+                partial(self.on_action_button_clicked, action=name.lower())
             )
             btn_layout.addWidget(button)
 
@@ -134,7 +134,7 @@ class OPUSControl(QGroupBox):
         """
         return f"http://{self.ip}/{self.commands[action]}"
 
-    def on_acction_button_clicked(self, action: str) -> None:
+    def on_action_button_clicked(self, action: str) -> None:
         """Execute the given action by sending a message to the appropriate topic.
 
         TODO: Here assuming we are going to use pubsub or equivalent to send messages
@@ -146,7 +146,7 @@ class OPUSControl(QGroupBox):
         logging.info(f"OPUS action '{self.url(action)}' executed!")
 
     def display_status(self) -> None:
-        """Retrieves and displays the new status.
+        """Retrieve and display the new status.
 
         TODO: I'm not sure who should populate the error log in the GUI. Probably the
         ones handling the individual actions above. These are all placeholders, for now.
@@ -194,7 +194,7 @@ class OPUSLogHandler(logging.Handler):
         Args:
             log_area: A weak reference to the log area.
         """
-        super(OPUSLogHandler, self).__init__()
+        super().__init__()
         self.log_area = log_area
 
     def emit(self, record):
@@ -203,13 +203,15 @@ class OPUSLogHandler(logging.Handler):
         If the log area has been destroyed before the logger, it will raise an
         AttributeError. This can only happen during tests and can be safely ignored.
         """
-        try:
-            self.log_area().append(self.format(record))
-            cursor = self.log_area().textCursor()
-            cursor.movePosition(QTextCursor.End)
-            self.log_area().setTextCursor(cursor)
-        except AttributeError:
-            pass
+        log_area = self.log_area()
+        if not log_area:
+            # log_area no longer exists
+            return
+
+        log_area.append(self.format(record))
+        cursor = log_area.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        log_area.setTextCursor(cursor)
 
 
 if __name__ == "__main__":

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -143,7 +143,7 @@ class OPUSControl(QGroupBox):
         Args:
             action: Action to be executed.
         """
-        logging.info(f"OPUS action '{self.url(action)}' executed!")
+        logging.info(f"OPUS action '{self.get_action_url(action)}' executed!")
 
     def display_status(self) -> None:
         """Retrieve and display the new status.
@@ -152,7 +152,7 @@ class OPUSControl(QGroupBox):
         ones handling the individual actions above. These are all placeholders, for now.
         """
         logging.info("Getting OPUS status!")
-        self.status.load(QUrl(self.url("status")))
+        self.status.load(QUrl(self.get_action_url("status")))
         self.status.show()
 
         logging.getLogger("OPUS").error("Oh, no! Something bad happened!")

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -123,7 +123,7 @@ class OPUSControl(QGroupBox):
         layout.addWidget(status_page)
         return layout
 
-    def url(self, action: str) -> str:
+    def get_action_url(self, action: str) -> str:
         """Builds an URL out of the ip and the action.
 
         Args:

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import QComboBox, QGridLayout, QGroupBox, QLabel, QPushBu
 
 
 class SerialPortControl(QGroupBox):
-    """Widgets to control the communication with a single serial port."""
+    """Widgets to control the communication with serial ports."""
 
     def __init__(
         self,
@@ -17,8 +17,6 @@ class SerialPortControl(QGroupBox):
         avail_baud_rates: Sequence[str],
     ) -> None:
         """Creates a sequence of widgets to control a serial connection to a device.
-
-        The devices
 
         Args:
             devices (Dict[str, Dict[str, str]]): Dictionary has a keys the names of the


### PR DESCRIPTION
Implements the view to control and monitor the connection to the interferometer. It follows the same layout than the original application, which does not mean it is the best option.

At the moment, there's no much in terms of backend relationship and - potentially - some of this information (the connection URLs) should be moved to the backend model - when there's a backend module. But it should work, for now. 

I've modified the main window to accommodate this view.

<img width="673" alt="image" src="https://user-images.githubusercontent.com/6095790/203526217-74899a7b-4c82-4002-a593-95a6cbb492e0.png">

Close #34 