### PR TITLE
Add code for handling uncaught exceptions

### DIFF
--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QGridLayout, QGroupBox, QMainWindow, QWidget
 
 from .opus_view import OPUSControl
 from .serial_view import SerialPortControl
+from .uncaught_exceptions import set_uncaught_exception_handler
 
 
 class MainWindow(QMainWindow):
@@ -12,6 +13,8 @@ class MainWindow(QMainWindow):
         """Create a new MainWindow."""
         super().__init__()
         self.setWindowTitle("FINESSE")
+
+        set_uncaught_exception_handler(self)
 
         layout = QGridLayout()
 

--- a/finesse/gui/uncaught_exceptions.py
+++ b/finesse/gui/uncaught_exceptions.py
@@ -1,0 +1,80 @@
+"""Code for handling uncaught exceptions."""
+import logging
+import sys
+import traceback
+from functools import partial
+from typing import Any, Type
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QPlainTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def set_uncaught_exception_handler(parent: QWidget) -> None:
+    """Catches uncaught exceptions so we can log them and display a dialog.
+
+    Details of the exception, including the stack trace, will be written to the program
+    log and displayed to the user in a pop-up dialog. Note that this won't happen if
+    you're running the program in a debugger that intercepts these exceptions first!
+
+    The purpose is to make it easier for end-users to communicate with the developers
+    when a bug occurs.
+    """
+    sys.excepthook = partial(_handle_exception, parent)
+
+
+def _handle_exception(
+    parent: QWidget,
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: Any,
+) -> None:
+    """Handle an uncaught exception."""
+    # Don't do anything special if user has just pressed Ctrl+C
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    traceback_str = "".join(
+        traceback.format_exception(exc_type, exc_value, exc_traceback)
+    )
+
+    # Write to program log
+    logging.error(f"Unhandled error:\n{traceback_str}")
+
+    try:
+        # Also show a message box for the user
+        _show_uncaught_exception_dialog(parent, exc_value, traceback_str)
+    except Exception:
+        # Something may go wrong with displaying the dialog, e.g. if the QApplication is
+        # shutting down, but we don't care at this point as it has been logged anyway
+        pass
+
+
+def _show_uncaught_exception_dialog(
+    parent: QWidget, exc_value: BaseException, traceback_str: str
+) -> None:
+    """Show a dialog containing information about an exception."""
+    dialog = QDialog(parent)
+    dialog.setWindowTitle("Uncaught exception")
+    dialog.resize(700, 500)
+
+    label = QLabel(f"An unhandled error has occurred: {repr(exc_value)}")
+    textEdit = QPlainTextEdit(traceback_str)
+    textEdit.setReadOnly(True)
+    buttonBox = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+    buttonBox.setCenterButtons(True)
+    buttonBox.accepted.connect(dialog.accept)  # type: ignore
+
+    layout = QVBoxLayout()
+    layout.addWidget(label)
+    layout.addWidget(textEdit)
+    layout.addWidget(buttonBox)
+
+    dialog.setLayout(layout)
+    dialog.exec()


### PR DESCRIPTION
This should make it easier for end-users to communicate with us about bugs. Closes #55.

The code is based on something similar I did for iPANACEA. It could potentially use an error icon, but I don't think that's a priority.

On my machine it looks like this:
![image](https://user-images.githubusercontent.com/23149834/204856940-80a39de3-4e1c-45b0-ad72-e652589d9cd9.png)
