### PR TITLE
Auto-deploy compiled Windows binaries to GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,15 @@ jobs:
       run: |
         poetry run mkdocs build -s
 
+    - name: Build package
+      if: matrix.os == 'windows-latest'
+      run: poetry run pyinstaller FINESSE.spec
+
+    - uses: actions/upload-artifact@v2
+      if: success() && matrix.os == 'windows-latest'
+      with:
+        name: FINESSE
+        path: dist/FINESSE.exe
 
   docs:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This is based on @dalonsoa's work for iPANACEA.

At the moment, I've set the CI to deploy a Windows binary on every push, which allows us to test code on PRs before merging them, but in future we may want to restrict this job to just run on `main` or for new releases.

Closes #12.