### PR TITLE
Add interface to OPUS EM27 software

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: "v0.991"
     hooks:
       - id: mypy
-        additional_dependencies: [types-PyYAML, types-requests]
+        additional_dependencies: [types-beautifulsoup4, types-PyYAML, types-requests]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.33.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: "v0.991"
     hooks:
       - id: mypy
-        additional_dependencies: [types-PyYAML]
+        additional_dependencies: [types-PyYAML, types-requests]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.33.0
     hooks:

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -11,3 +11,6 @@ ANGLE_PRESETS = ("zenith", "nadir", "hot_bb", "cold_bb", "home")
 
 BAUDRATES = (4800, 9600, 19200, 38400, 57600, 115200)
 """The valid baud rates for use by the GUI."""
+
+OPUS_IP = "10.10.0.2"
+"""The IP address of the machine running the OPUS software."""

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -1,4 +1,6 @@
 """Code for FINESSE's main GUI window."""
+from pubsub import pub
+from PySide6.QtGui import QHideEvent, QShowEvent
 from PySide6.QtWidgets import (
     QGridLayout,
     QGroupBox,
@@ -70,3 +72,11 @@ class MainWindow(QMainWindow):
         central.setLayout(layout)
 
         self.setCentralWidget(central)
+
+    def showEvent(self, event: QShowEvent) -> None:
+        """Send window.opened message."""
+        pub.sendMessage("window.opened")
+
+    def hideEvent(self, event: QHideEvent) -> None:
+        """Send window.closed message."""
+        pub.sendMessage("window.closed")

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -45,7 +45,7 @@ class MainWindow(QMainWindow):
         layout_left.addWidget(serial_port)
 
         layout_right = QGridLayout()
-        opus: QGroupBox = OPUSControl("127.0.0.1")
+        opus: QGroupBox = OPUSControl()
         layout_right.addWidget(opus, 0, 0, 1, 2)
 
         bb_monitor: QGroupBox = BBMonitor()

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -40,7 +40,7 @@ class OPUSControl(QGroupBox):
         self.ip = ip
         self.commands = commands if commands is not None else COMMANDS
         self.status: QWebEngineView
-        self.log_handler: OPUSLogHandler
+        self.logger = logging.getLogger("OPUS")
 
         layout = self._create_controls()
         self.setLayout(layout)
@@ -95,7 +95,7 @@ class OPUSControl(QGroupBox):
         """
         log_box = QGroupBox("Error log")
         log_area = QTextBrowser()
-        self.log_handler = OPUSLogHandler.set_handler(log_area)
+        OPUSLogHandler.set_handler(self.logger, log_area)
 
         _layout = QVBoxLayout()
         _layout.addWidget(log_area)
@@ -155,7 +155,7 @@ class OPUSControl(QGroupBox):
         self.status.load(QUrl(self.get_action_url("status")))
         self.status.show()
 
-        logging.getLogger("OPUS").error("Oh, no! Something bad happened!")
+        self.logger.error("Oh, no! Something bad happened!")
 
     def open_opus(self) -> None:
         """Opens OPUS front end somewhere else.
@@ -169,14 +169,15 @@ class OPUSLogHandler(logging.Handler):
     """Specific logger for the errors related to OPUS.
 
     Only log messages using the OPUS logger will be recorded here. Typically, they will
-    be error messages, but it can be any information worth to be logged.
+    be error messages, but it can be any information worth logging.
     """
 
     @classmethod
-    def set_handler(cls, log_area: QTextBrowser):
+    def set_handler(cls, logger: logging.Logger, log_area: QTextBrowser):
         """Creates the handler and adds it to the logger.
 
         Args:
+            logger: The logger to set the formatter for
             log_area: The area where the log will be printed.
         """
         ch = cls(weakref.ref(log_area))
@@ -186,7 +187,7 @@ class OPUSLogHandler(logging.Handler):
         )
         ch.setFormatter(formatter)
 
-        logging.getLogger("OPUS").addHandler(ch)
+        logger.addHandler(ch)
 
     def __init__(self, log_area: weakref.ref):
         """Constructor of the Handler.

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -41,6 +41,7 @@ class OPUSControl(QGroupBox):
         pub.subscribe(self._log_response, "opus.command.response")
         pub.subscribe(self._log_response, "opus.status.response")
         pub.subscribe(self._display_status, "opus.status.response")
+        pub.subscribe(self._log_error, "opus.error")
 
     def _create_controls(self) -> QHBoxLayout:
         """Creates the controls for communicating with the interferometer.
@@ -127,6 +128,9 @@ class OPUSControl(QGroupBox):
         self.logger.info(f"Response ({status}): {text}")
         if error:
             self.logger.error(f"Error ({error[0]}): {error[1]}")
+
+    def _log_error(self, message: str) -> None:
+        self.logger.error(f"Error during request: {message}")
 
     def on_command_button_clicked(self, command: str) -> None:
         """Execute the given command by sending a message to the appropriate topic.

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -40,13 +40,13 @@ class OPUSControl(QGroupBox):
         self.ip = ip
         self.commands = commands if commands is not None else COMMANDS
         self.status: QWebEngineView
-        self.log_hanlder: OPUSLogHandler
+        self.log_handler: OPUSLogHandler
 
         layout = self._create_controls()
         self.setLayout(layout)
 
     def _create_controls(self) -> QHBoxLayout:
-        """Creates the controls for comunicating with the interferometer.
+        """Creates the controls for communicating with the interferometer.
 
         Returns:
             QHBoxLayout: The layout with the buttons.
@@ -95,7 +95,7 @@ class OPUSControl(QGroupBox):
         """
         log_box = QGroupBox("Error log")
         log_area = QTextBrowser()
-        self.log_hanlder = OPUSLogHandler.set_handler(log_area)
+        self.log_handler = OPUSLogHandler.set_handler(log_area)
 
         _layout = QVBoxLayout()
         _layout.addWidget(log_area)

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -21,7 +21,7 @@ COMMANDS = ["cancel", "stop", "start", "connect"]
 
 
 class OPUSControl(QGroupBox):
-    """Class that monitors and control the OPUS interferometer."""
+    """Class that monitors and controls the OPUS interferometer."""
 
     def __init__(self, commands: Optional[list[str]] = None) -> None:
         """Create the widgets to monitor and control the OPUS interferometer.

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -1,6 +1,25 @@
 """This module contains code for interfacing with different hardware devices."""
-from . import em27_opus  # noqa
-from .dummy_stepper_motor import DummyStepperMotor
+from pubsub import pub
 
-# TODO: Replace with a real stepper motor device
-stepper = DummyStepperMotor(3600)
+from .dummy_stepper_motor import DummyStepperMotor
+from .em27_opus import OPUSInterface
+
+stepper: DummyStepperMotor
+opus: OPUSInterface
+
+
+def _init_hardware():
+    global stepper, opus
+    # TODO: Replace with a real stepper motor device
+    stepper = DummyStepperMotor(3600)
+
+    opus = OPUSInterface()
+
+
+def _stop_hardware():
+    global opus
+    del opus
+
+
+pub.subscribe(_init_hardware, "window.opened")
+pub.subscribe(_stop_hardware, "window.closed")

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -1,4 +1,5 @@
 """This module contains code for interfacing with different hardware devices."""
+from . import em27_opus  # noqa
 from .dummy_stepper_motor import DummyStepperMotor
 
 # TODO: Replace with a real stepper motor device

--- a/finesse/hardware/em27_opus.py
+++ b/finesse/hardware/em27_opus.py
@@ -10,6 +10,7 @@ from typing import Optional, cast
 import requests
 from bs4 import BeautifulSoup
 from pubsub import pub
+from PySide6.QtCore import QObject, QThread, Signal, Slot
 
 from ..config import OPUS_IP
 
@@ -17,53 +18,98 @@ STATUS_FILENAME = "stat.htm"
 COMMAND_FILENAME = "cmd.htm"
 
 
-def make_request(filename: str, topic: str):
-    """Make a request to the OPUS program.
+class OPUSRequester(QObject):
+    """Object which makes HTTP requests.
 
-    Args:
-        filename: The final part of the path on the HTTP server
-        topic: The topic on which to publish the response
+    The reason this has to be done as a class is because we need to inherit from QObject
+    so that this task can be assigned to a background thread.
     """
-    url = f"http://{OPUS_IP}/opusrs/{filename}"
-    response = requests.get(url)
-    assert response.status_code == 200
 
-    status: Optional[int] = None
-    text = ""
-    errcode: Optional[int] = None
-    errtext = ""
-    soup = BeautifulSoup(response.content, "html.parser")
-    for td in soup.find_all("td"):
-        if "id" not in td.attrs:
-            continue
+    request_complete = Signal(requests.Request, str)
 
-        id = td.attrs["id"]
-        data = td.contents[0]
-        if id == "STATUS":
-            status = int(data)
-        elif id == "TEXT":
-            text = data
-        elif id == "ERRCODE":
-            errcode = int(data)
-        elif id == "ERRTEXT":
-            errtext = data
+    @Slot()
+    def make_request(self, filename: str, topic: str):
+        """Make a request to the OPUS program.
 
-    if status is None or not text:
-        raise ValueError("Required tags not found")
-    error = None if errcode is None else (errcode, errtext)
-
-    pub.sendMessage(topic, url=url, status=cast(int, status), text=text, error=error)
+        Args:
+            filename: The final part of the path on the HTTP server
+            topic: The topic on which to publish the response
+        """
+        url = f"http://{OPUS_IP}/opusrs/{filename}"
+        response = requests.get(url)
+        self.request_complete.emit(response, topic)
 
 
-def request_status() -> None:
-    """Request an update on the device's status."""
-    make_request(STATUS_FILENAME, "opus.status.response")
+class OPUSInterface(QObject):
+    """Interface for communicating with the OPUS program.
 
+    HTTP requests are handled on a background thread.
+    """
 
-def request_command(command: str) -> None:
-    """Request that OPUS run the specified command."""
-    make_request(f"{COMMAND_FILENAME}?opusrs{command}", "opus.command.response")
+    submit_request = Signal(str, str)
 
+    def __init__(self) -> None:
+        """Create a new OPUSInterface."""
+        super().__init__()
 
-pub.subscribe(request_status, "opus.status.request")
-pub.subscribe(request_command, "opus.command.request")
+        # Make a new QThread to run HTTP requests in background
+        self.request_thread = QThread(self)
+        self.requester = OPUSRequester()
+        self.requester.moveToThread(self.request_thread)
+        self.requester.request_complete.connect(self._parse_response)
+
+        # Set up a signal for communicating between threads
+        self.submit_request.connect(self.requester.make_request)
+
+        # Subscribe to requests coming from the GUI
+        pub.subscribe(self.request_status, "opus.status.request")
+        pub.subscribe(self.request_command, "opus.command.request")
+
+        # Start processing requests
+        self.request_thread.start()
+
+    def __del__(self) -> None:
+        """Stop the background request thread."""
+        self.request_thread.quit()
+        self.request_thread.wait()
+
+    def _parse_response(self, response: requests.Response, topic: str) -> None:
+        assert response.status_code == 200
+
+        status: Optional[int] = None
+        text = ""
+        errcode: Optional[int] = None
+        errtext = ""
+        soup = BeautifulSoup(response.content, "html.parser")
+        for td in soup.find_all("td"):
+            if "id" not in td.attrs:
+                continue
+
+            id = td.attrs["id"]
+            data = td.contents[0]
+            if id == "STATUS":
+                status = int(data)
+            elif id == "TEXT":
+                text = data
+            elif id == "ERRCODE":
+                errcode = int(data)
+            elif id == "ERRTEXT":
+                errtext = data
+
+        if status is None or not text:
+            raise ValueError("Required tags not found")
+        error = None if errcode is None else (errcode, errtext)
+
+        pub.sendMessage(
+            topic, url=response.url, status=cast(int, status), text=text, error=error
+        )
+
+    def request_status(self) -> None:
+        """Request an update on the device's status."""
+        self.submit_request.emit(STATUS_FILENAME, "opus.status.response")
+
+    def request_command(self, command: str) -> None:
+        """Request that OPUS run the specified command."""
+        self.submit_request.emit(
+            f"{COMMAND_FILENAME}?opusrs{command}", "opus.command.response"
+        )

--- a/finesse/hardware/em27_opus.py
+++ b/finesse/hardware/em27_opus.py
@@ -5,6 +5,8 @@ Communication is based on a protocol using HTTP and HTML.
 The OPUS program must be running on the computer at OPUS_IP for the commands to work.
 Note that this is a separate machine from the EM27!
 """
+import logging
+import traceback
 from typing import Optional, cast
 
 import requests
@@ -18,14 +20,20 @@ STATUS_FILENAME = "stat.htm"
 COMMAND_FILENAME = "cmd.htm"
 
 
+class OPUSError(Exception):
+    """Indicates that an error occurred while communicating with the OPUS program."""
+
+
 class OPUSRequester(QThread):
     """Interface for making HTTP requests on a background thread."""
 
     request_complete = Signal(requests.Request, str)
+    request_error = Signal(BaseException)
 
-    def __init__(self) -> None:
+    def __init__(self, timeout: float) -> None:
         """Create a new OPUSRequester."""
         super().__init__()
+        self.timeout = timeout
         self.moveToThread(self)
 
     @Slot()
@@ -36,9 +44,12 @@ class OPUSRequester(QThread):
             filename: The final part of the path on the HTTP server
             topic: The topic on which to publish the response
         """
-        url = f"http://{OPUS_IP}/opusrs/{filename}"
-        response = requests.get(url)
-        self.request_complete.emit(response, topic)
+        try:
+            url = f"http://{OPUS_IP}/opusrs/{filename}"
+            response = requests.get(url, timeout=self.timeout)
+            self.request_complete.emit(response, topic)
+        except Exception as e:
+            self.request_error.emit(e)
 
 
 class OPUSInterface(QObject):
@@ -50,13 +61,18 @@ class OPUSInterface(QObject):
     submit_request = Signal(str, str)
     """Signal indicating that an HTTP request should be made."""
 
-    def __init__(self) -> None:
-        """Create a new OPUSInterface."""
+    def __init__(self, timeout: float = 3.0) -> None:
+        """Create a new OPUSInterface.
+
+        Args:
+            timeout: Amount of time before request times out (seconds)
+        """
         super().__init__()
 
-        self.requester = OPUSRequester()
+        self.requester = OPUSRequester(timeout)
         """For running HTTP requests in the background."""
         self.requester.request_complete.connect(self._parse_response)
+        self.requester.request_error.connect(self._error_occurred)
 
         # Set up a signal for communicating between threads
         self.submit_request.connect(self.requester.make_request)
@@ -74,35 +90,51 @@ class OPUSInterface(QObject):
         self.requester.wait()
 
     def _parse_response(self, response: requests.Response, topic: str) -> None:
-        assert response.status_code == 200
+        try:
+            if response.status_code != 200:
+                raise OPUSError(f"HTTP status code {response.status_code}")
 
-        status: Optional[int] = None
-        text = ""
-        errcode: Optional[int] = None
-        errtext = ""
-        soup = BeautifulSoup(response.content, "html.parser")
-        for td in soup.find_all("td"):
-            if "id" not in td.attrs:
-                continue
+            status: Optional[int] = None
+            text = ""
+            errcode: Optional[int] = None
+            errtext = ""
+            soup = BeautifulSoup(response.content, "html.parser")
+            for td in soup.find_all("td"):
+                if "id" not in td.attrs:
+                    continue
 
-            id = td.attrs["id"]
-            data = td.contents[0]
-            if id == "STATUS":
-                status = int(data)
-            elif id == "TEXT":
-                text = data
-            elif id == "ERRCODE":
-                errcode = int(data)
-            elif id == "ERRTEXT":
-                errtext = data
+                id = td.attrs["id"]
+                data = td.contents[0]
+                if id == "STATUS":
+                    status = int(data)
+                elif id == "TEXT":
+                    text = data
+                elif id == "ERRCODE":
+                    errcode = int(data)
+                elif id == "ERRTEXT":
+                    errtext = data
+                else:
+                    logging.warning(f"Received unknown ID: {id}")
 
-        if status is None or not text:
-            raise ValueError("Required tags not found")
-        error = None if errcode is None else (errcode, errtext)
+            if status is None or not text:
+                raise OPUSError("Required tags not found")
+            error = None if errcode is None else (errcode, errtext)
+        except Exception as e:
+            self._error_occurred(e)
+            return
 
         pub.sendMessage(
             topic, url=response.url, status=cast(int, status), text=text, error=error
         )
+
+    def _error_occurred(self, exception: BaseException) -> None:
+        traceback_str = "".join(traceback.format_tb(exception.__traceback__))
+
+        # Write details including stack trace to program log
+        logging.error(f"Error during OPUS request: {traceback_str}")
+
+        # Notify listeners
+        pub.sendMessage("opus.error", message=str(exception))
 
     def request_status(self) -> None:
         """Request an update on the device's status."""

--- a/finesse/hardware/em27_opus.py
+++ b/finesse/hardware/em27_opus.py
@@ -1,0 +1,69 @@
+"""Module containing code for sending commands to the OPUS program for the EM27.
+
+Communication is based on a protocol using HTTP and HTML.
+
+The OPUS program must be running on the computer at OPUS_IP for the commands to work.
+Note that this is a separate machine from the EM27!
+"""
+from typing import Optional, cast
+
+import requests
+from bs4 import BeautifulSoup
+from pubsub import pub
+
+from ..config import OPUS_IP
+
+STATUS_FILENAME = "stat.htm"
+COMMAND_FILENAME = "cmd.htm"
+
+
+def make_request(filename: str, topic: str):
+    """Make a request to the OPUS program.
+
+    Args:
+        filename: The final part of the path on the HTTP server
+        topic: The topic on which to publish the response
+    """
+    url = f"http://{OPUS_IP}/opusrs/{filename}"
+    response = requests.get(url)
+    assert response.status_code == 200
+
+    status: Optional[int] = None
+    text = ""
+    errcode: Optional[int] = None
+    errtext = ""
+    soup = BeautifulSoup(response.content, "html.parser")
+    for td in soup.find_all("td"):
+        if "id" not in td.attrs:
+            continue
+
+        id = td.attrs["id"]
+        data = td.contents[0]
+        if id == "STATUS":
+            status = int(data)
+        elif id == "TEXT":
+            text = data
+        elif id == "ERRCODE":
+            errcode = int(data)
+        elif id == "ERRTEXT":
+            errtext = data
+
+    if status is None or not text:
+        raise ValueError("Required tags not found")
+    error = None if errcode is None else (errcode, errtext)
+
+    pub.sendMessage(topic, url=url, status=cast(int, status), text=text, error=error)
+
+
+def request_status() -> None:
+    """Request an update on the device's status."""
+    make_request(STATUS_FILENAME, "opus.status.response")
+
+
+def request_command(command: str) -> None:
+    """Request that OPUS run the specified command."""
+    make_request(f"{COMMAND_FILENAME}?opusrs{command}", "opus.command.response")
+
+
+pub.subscribe(request_status, "opus.status.request")
+pub.subscribe(request_command, "opus.command.request")

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,25 @@ tests = ["attrs[tests-no-zope]", "zope.interface"]
 tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "22.12.0"
 description = "The uncompromising code formatter."
@@ -1850,6 +1869,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1859,6 +1890,33 @@ python-versions = ">=3.7"
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "types-beautifulsoup4"
+version = "4.11.6.4"
+description = "Typing stubs for beautifulsoup4"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-beautifulsoup4-4.11.6.4.tar.gz", hash = "sha256:53236c05d035449cc2021ad5d252db8b1ff23dbe280af060f177e6cdb4fcd468"},
+    {file = "types_beautifulsoup4-4.11.6.4-py3-none-any.whl", hash = "sha256:25067e323d8757ebcf6b5177513b8242b9fa2610781e306541279454e536d24b"},
+]
+
+[package.dependencies]
+types-html5lib = "*"
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.11"
+description = "Typing stubs for html5lib"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-html5lib-1.1.11.11.tar.gz", hash = "sha256:8cf7fb57dcaf3e612806e9bc25ae366ff7ca71a3418ae829f5b1a9c52cbb4960"},
+    {file = "types_html5lib-1.1.11.11-py3-none-any.whl", hash = "sha256:7456a07a4d162bb8c42c2a088c60cca7c63d06cf2c409a8de39536a6cdbbccc2"},
 ]
 
 [[package]]
@@ -2010,4 +2068,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "ca3f7ba6ada8e1a5d40a9f9246fb0992336cee2dcaaadf50cd155246f688f7cb"
+content-hash = "db37361a0c74b7a428e119aef12f6214c3ea7061e2130781616a682136c83a53"

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -95,7 +95,7 @@ files = [
 name = "charset-normalizer"
 version = "3.0.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 files = [
@@ -515,14 +515,14 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "0.25.3"
+version = "0.25.4"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "griffe-0.25.3-py3-none-any.whl", hash = "sha256:c98e8471a4fc7675a7989f45563a9f7ccbfdfb1713725526d69dec1bbdcda74a"},
-    {file = "griffe-0.25.3.tar.gz", hash = "sha256:a71f156851649b3f0bdad6eb6bf7d7ac70e720a30da9f2d5a60e042480e92c03"},
+    {file = "griffe-0.25.4-py3-none-any.whl", hash = "sha256:919f935a358b31074d16e324e26b041883c60a8cf10504655e394afc3a7caad8"},
+    {file = "griffe-0.25.4.tar.gz", hash = "sha256:f190edf8ef58d43c856d2d6761ec324a043ff60deb8c14359263571e8b91fe68"},
 ]
 
 [package.dependencies]
@@ -533,14 +533,14 @@ async = ["aiofiles (>=0.7,<1.0)"]
 
 [[package]]
 name = "identify"
-version = "2.5.13"
+version = "2.5.15"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.13-py2.py3-none-any.whl", hash = "sha256:8aa48ce56e38c28b6faa9f261075dea0a942dfbb42b341b4e711896cbb40f3f7"},
-    {file = "identify-2.5.13.tar.gz", hash = "sha256:abb546bca6f470228785338a01b539de8a85bbf46491250ae03363956d8ebb10"},
+    {file = "identify-2.5.15-py2.py3-none-any.whl", hash = "sha256:1f4b36c5f50f3f950864b2a047308743f064eaa6f6645da5e5c780d1c7125487"},
+    {file = "identify-2.5.15.tar.gz", hash = "sha256:c22aa206f47cc40486ecf585d27ad5f40adbfc494a3fa41dc3ed0499a23b123f"},
 ]
 
 [package.extras]
@@ -550,7 +550,7 @@ license = ["ukkonen"]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -739,52 +739,62 @@ testing = ["coverage", "pyyaml"]
 
 [[package]]
 name = "markupsafe"
-version = "2.1.1"
+version = "2.1.2"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
-    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
-    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
-    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
-    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
-    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:665a36ae6f8f20a4676b53224e33d456a6f5a72657d9c83c2aa00765072f31f7"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:340bea174e9761308703ae988e982005aedf427de816d1afe98147668cc03036"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22152d00bf4a9c7c83960521fc558f55a1adbc0631fbb00a9471e097b19d72e1"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28057e985dace2f478e042eaa15606c7efccb700797660629da387eb289b9323"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca244fa73f50a800cf8c3ebf7fd93149ec37f5cb9596aa8873ae2c1d23498601"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d9d971ec1e79906046aa3ca266de79eac42f1dbf3612a05dc9368125952bd1a1"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7e007132af78ea9df29495dbf7b5824cb71648d7133cf7848a2a5dd00d36f9ff"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7313ce6a199651c4ed9d7e4cfb4aa56fe923b1adf9af3b420ee14e6d9a73df65"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-win32.whl", hash = "sha256:c4a549890a45f57f1ebf99c067a4ad0cb423a05544accaf2b065246827ed9603"},
+    {file = "MarkupSafe-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:835fb5e38fd89328e9c81067fd642b3593c33e1e17e2fdbf77f5676abb14a156"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2ec4f2d48ae59bbb9d1f9d7efb9236ab81429a764dedca114f5fdabbc3788013"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:608e7073dfa9e38a85d38474c082d4281f4ce276ac0010224eaba11e929dd53a"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65608c35bfb8a76763f37036547f7adfd09270fbdbf96608be2bead319728fcd"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2bfb563d0211ce16b63c7cb9395d2c682a23187f54c3d79bfec33e6705473c6"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da25303d91526aac3672ee6d49a2f3db2d9502a4a60b55519feb1a4c7714e07d"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9cad97ab29dfc3f0249b483412c85c8ef4766d96cdf9dcf5a1e3caa3f3661cf1"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:085fd3201e7b12809f9e6e9bc1e5c96a368c8523fad5afb02afe3c051ae4afcc"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1bea30e9bf331f3fef67e0a3877b2288593c98a21ccb2cf29b74c581a4eb3af0"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-win32.whl", hash = "sha256:7df70907e00c970c60b9ef2938d894a9381f38e6b9db73c5be35e59d92e06625"},
+    {file = "MarkupSafe-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:e55e40ff0cc8cc5c07996915ad367fa47da6b3fc091fdadca7f5403239c5fec3"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a6e40afa7f45939ca356f348c8e23048e02cb109ced1eb8420961b2f40fb373a"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf877ab4ed6e302ec1d04952ca358b381a882fbd9d1b07cccbfd61783561f98a"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63ba06c9941e46fa389d389644e2d8225e0e3e5ebcc4ff1ea8506dce646f8c8a"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1cd098434e83e656abf198f103a8207a8187c0fc110306691a2e94a78d0abb2"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:55f44b440d491028addb3b88f72207d71eeebfb7b5dbf0643f7c023ae1fba619"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:a6f2fcca746e8d5910e18782f976489939d54a91f9411c32051b4aab2bd7c513"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0b462104ba25f1ac006fdab8b6a01ebbfbce9ed37fd37fd4acd70c67c973e460"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-win32.whl", hash = "sha256:7668b52e102d0ed87cb082380a7e2e1e78737ddecdde129acadb0eccc5423859"},
+    {file = "MarkupSafe-2.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6d6607f98fcf17e534162f0709aaad3ab7a96032723d8ac8750ffe17ae5a0666"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a806db027852538d2ad7555b203300173dd1b77ba116de92da9afbc3a3be3eed"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a4abaec6ca3ad8660690236d11bfe28dfd707778e2442b45addd2f086d6ef094"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f03a532d7dee1bed20bc4884194a16160a2de9ffc6354b3878ec9682bb623c54"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cf06cdc1dda95223e9d2d3c58d3b178aa5dacb35ee7e3bbac10e4e1faacb419"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22731d79ed2eb25059ae3df1dfc9cb1546691cc41f4e3130fe6bfbc3ecbbecfa"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f8ffb705ffcf5ddd0e80b65ddf7bed7ee4f5a441ea7d3419e861a12eaf41af58"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8db032bf0ce9022a8e41a22598eefc802314e81b879ae093f36ce9ddf39ab1ba"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2298c859cfc5463f1b64bd55cb3e602528db6fa0f3cfd568d3605c50678f8f03"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-win32.whl", hash = "sha256:50c42830a633fa0cf9e7d27664637532791bfc31c731a87b202d2d8ac40c3ea2"},
+    {file = "MarkupSafe-2.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:bb06feb762bade6bf3c8b844462274db0c76acc95c52abe8dbed28ae3d44a147"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:99625a92da8229df6d44335e6fcc558a5037dd0a760e11d84be2260e6f37002f"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8bca7e26c1dd751236cfb0c6c72d4ad61d986e9a41bbf76cb445f69488b2a2bd"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40627dcf047dadb22cd25ea7ecfe9cbf3bbbad0482ee5920b582f3809c97654f"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40dfd3fefbef579ee058f139733ac336312663c6706d1163b82b3003fb1925c4"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:090376d812fb6ac5f171e5938e82e7f2d7adc2b629101cec0db8b267815c85e2"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2e7821bffe00aa6bd07a23913b7f4e01328c3d5cc0b40b36c0bd81d362faeb65"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c0a33bc9f02c2b17c3ea382f91b4db0e6cde90b63b296422a939886a7a80de1c"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b8526c6d437855442cdd3d87eede9c425c4445ea011ca38d937db299382e6fa3"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-win32.whl", hash = "sha256:137678c63c977754abe9086a3ec011e8fd985ab90631145dfb9294ad09c102a7"},
+    {file = "MarkupSafe-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed"},
+    {file = "MarkupSafe-2.1.2.tar.gz", hash = "sha256:abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"},
 ]
 
 [[package]]
@@ -1347,14 +1357,14 @@ files = [
 
 [[package]]
 name = "pydocstyle"
-version = "6.2.3"
+version = "6.3.0"
 description = "Python docstring style checker"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pydocstyle-6.2.3-py3-none-any.whl", hash = "sha256:a04ed1e6fe0be0970eddbb1681a7ab59b11eb92729fdb4b9b24f0eb11a25629e"},
-    {file = "pydocstyle-6.2.3.tar.gz", hash = "sha256:d867acad25e48471f2ad8a40ef9813125e954ad675202245ca836cb6e28b2297"},
+    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
+    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
 ]
 
 [package.dependencies]
@@ -1438,14 +1448,14 @@ files = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "9.9.1"
+version = "9.9.2"
 description = "Extension pack for Python Markdown."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pymdown_extensions-9.9.1-py3-none-any.whl", hash = "sha256:8a8973933ab45b6fe8f5f8da1de25766356b1f91dee107bf4a34efd158dc340b"},
-    {file = "pymdown_extensions-9.9.1.tar.gz", hash = "sha256:abed29926960bbb3b40f5ed5fa6375e29724d4e3cb86ced7c2bbd37ead1afeea"},
+    {file = "pymdown_extensions-9.9.2-py3-none-any.whl", hash = "sha256:c3d804eb4a42b85bafb5f36436342a5ad38df03878bb24db8855a4aa8b08b765"},
+    {file = "pymdown_extensions-9.9.2.tar.gz", hash = "sha256:ebb33069bafcb64d5f5988043331d4ea4929325dc678a6bcf247ddfcf96499f8"},
 ]
 
 [package.dependencies]
@@ -1749,7 +1759,7 @@ pyyaml = "*"
 name = "requests"
 version = "2.28.2"
 description = "Python HTTP for Humans."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7, <4"
 files = [
@@ -1784,14 +1794,14 @@ contextlib2 = ">=0.5.5"
 
 [[package]]
 name = "setuptools"
-version = "66.0.0"
+version = "66.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-66.0.0-py3-none-any.whl", hash = "sha256:a78d01d1e2c175c474884671dde039962c9d74c7223db7369771fcf6e29ceeab"},
-    {file = "setuptools-66.0.0.tar.gz", hash = "sha256:bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6"},
+    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
+    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
 ]
 
 [package.extras]
@@ -1864,6 +1874,33 @@ files = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.28.11.8"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-requests-2.28.11.8.tar.gz", hash = "sha256:e67424525f84adfbeab7268a159d3c633862dafae15c5b19547ce1b55954f0a3"},
+    {file = "types_requests-2.28.11.8-py3-none-any.whl", hash = "sha256:61960554baca0008ae7e2db2bd3b322ca9a144d3e80ce270f5fb640817e40994"},
+]
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.4"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.4.tar.gz", hash = "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"},
+    {file = "types_urllib3-1.26.25.4-py3-none-any.whl", hash = "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1879,7 +1916,7 @@ files = [
 name = "urllib3"
 version = "1.26.14"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
@@ -1973,4 +2010,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "bfa214a3e6c358f64703dd45a0f546e8569e792dc0581cbd56ddb89047640e9c"
+content-hash = "ca3f7ba6ada8e1a5d40a9f9246fb0992336cee2dcaaadf50cd155246f688f7cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pypubsub = "^4.0.3"
 pyyaml = "^6.0"
 schema = "^0.7.5"
 pyserial = "^3.5"
+requests = "^2.28.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
@@ -31,6 +32,7 @@ flake8 = "^4.0.1"
 flake8-docstrings = "^1.6.0"
 pyinstaller = "^5.6.2"
 types-pyyaml = "^6.0.12.3"
+types-requests = "^2.28.11.7"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pyyaml = "^6.0"
 schema = "^0.7.5"
 pyserial = "^3.5"
 requests = "^2.28.2"
+beautifulsoup4 = "^4.11.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
@@ -33,6 +34,7 @@ flake8-docstrings = "^1.6.0"
 pyinstaller = "^5.6.2"
 types-pyyaml = "^6.0.12.3"
 types-requests = "^2.28.11.7"
+types-beautifulsoup4 = "^4.11.6.2"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.2"

--- a/tests/test_em27_opus.py
+++ b/tests/test_em27_opus.py
@@ -1,0 +1,66 @@
+"""Tests for the interface to the EM27's OPUS control program."""
+from unittest.mock import patch
+
+import pytest
+
+from finesse.config import OPUS_IP
+from finesse.hardware.em27_opus import OPUSInterface, OPUSRequester
+
+
+@pytest.fixture
+@patch("finesse.hardware.em27_opus.QThread.start")
+def opus(mock) -> OPUSInterface:
+    """Fixture for OPUSInterface."""
+    return OPUSInterface()
+
+
+def test_request_status(opus: OPUSInterface) -> None:
+    """Test OPUSInterface's request_status() method."""
+    with patch.object(opus, "submit_request") as request_mock:
+        opus.request_status()
+        request_mock.emit.assert_called_once_with("stat.htm", "opus.status.response")
+
+
+def test_request_command(opus: OPUSInterface) -> None:
+    """Test OPUSInterface's request_command() method."""
+    with patch.object(opus, "submit_request") as request_mock:
+        opus.request_command("hello")
+        request_mock.emit.assert_called_once_with(
+            "cmd.htm?opusrshello", "opus.command.response"
+        )
+
+
+@patch("finesse.hardware.em27_opus.requests")
+def test_make_request_success(requests_mock) -> None:
+    """Test OPUSRequester's make_request() method with a successful request."""
+    requester = OPUSRequester(5.0)
+
+    with patch.object(requester, "request_complete") as request_complete_mock:
+        filename = "filename"
+        topic = "topic"
+        requests_mock.get.return_value = "MAGIC"
+        requester.make_request(filename, topic)
+        requests_mock.get.assert_called_once_with(
+            f"http://{OPUS_IP}/opusrs/{filename}", timeout=5.0
+        )
+
+        request_complete_mock.emit.assert_called_once_with("MAGIC", topic)
+
+
+@patch("finesse.hardware.em27_opus.requests")
+def test_make_request_error(requests_mock) -> None:
+    """Test OPUSRequester's make_request() method with failed request."""
+    requester = OPUSRequester(5.0)
+    error = RuntimeError("Request failed")
+    requests_mock.get.side_effect = error
+
+    with patch.object(requester, "request_error") as request_error_mock:
+        filename = "filename"
+        topic = "topic"
+        requests_mock.get.return_value = "MAGIC"
+        requester.make_request(filename, topic)
+        requests_mock.get.assert_called_once_with(
+            f"http://{OPUS_IP}/opusrs/{filename}", timeout=5.0
+        )
+
+        request_error_mock.emit.assert_called_once_with(error)


### PR DESCRIPTION
Closes #78.

This completes the integration with the OPUS software, which is used to control the Bruker EM27 spectrometer. Scans can be started and stopped and the status can be queried by connecting to this software via an HTTP-based protocol. The software is proprietary and there is currently only a licence to run it on a single machine.

Commit summary:

- Move the OPUS backend out of `finesse.gui` into `finesse.hardware`
- Parse the returned HTML-formatted information returned by OPUS in response to requests to get error status etc.
- Handle HTTP requests on a background `QThread` so they don't hang the GUI
- Also log errors during requests in the GUI

Limitations:

- The IP address of the machine running OPUS is hardcoded. Not really a problem (it's a single-machine setup) but it isn't very clean
- Currently when you check the status, the status page is loaded once for parsing and once again to render it. @jonemurray is in favour of removing the web panel in future though, so I think it's fine as a stopgap
- It uses the `beautifulsoup4` library for parsing HTML, which may be overkill
- To stop the request `QThread` on exit, we wait for a message that the main window is closing and explicitly delete the `OPUSInterface`, which a) feels like a hack and b) sometimes temporarily hangs the GUI if the thread is busy doing things
- I haven't implemented automatic enabling/disabling of buttons based on actions that are available (e.g. starting/stopping etc.)
- The "OPUS" button still doesn't do anything