### PR TITLE
Add initial support for ST10 stepper motor controller

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -6,7 +6,7 @@ APP_NAME = "FINESSE"
 APP_AUTHOR = "Imperial College London"
 """The name of the app's author (used for program data path)."""
 
-ANGLE_PRESETS = ("zenith", "nadir", "hot_bb", "cold_bb", "home")
+ANGLE_PRESETS = ("zenith", "nadir", "hot_bb", "cold_bb", "home", "park")
 """Names of preset angles that the mirror can rotate to."""
 
 BAUDRATES = (4800, 9600, 19200, 38400, 57600, 115200)

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -6,8 +6,15 @@ APP_NAME = "FINESSE"
 APP_AUTHOR = "Imperial College London"
 """The name of the app's author (used for program data path)."""
 
-ANGLE_PRESETS = ("zenith", "nadir", "hot_bb", "cold_bb", "home", "park")
-"""Names of preset angles that the mirror can rotate to."""
+ANGLE_PRESETS = {
+    "zenith": 180.0,
+    "nadir": 0.0,
+    "hot_bb": 270.0,
+    "cold_bb": 225.0,
+    "home": 0.0,
+    "park": 90.0,
+}
+"""Preset angles that the mirror can rotate to."""
 
 BAUDRATES = (4800, 9600, 19200, 38400, 57600, 115200)
 """The valid baud rates for use by the GUI."""

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -47,9 +47,9 @@ class DummyStepperMotor:
         if isinstance(target, str):
             target = DummyStepperMotor.get_preset_angle(target)
 
+        if target < 0.0 or target > 270.0:
+            raise ValueError("Angle must be between 0° and 270°")
         step = round(self.steps_per_rotation * target / 360.0)
-        if step < 0 or step >= self.steps_per_rotation:
-            raise ValueError("step number is out of range")
         self.current_step = step
 
         logging.info(f"Moving stepper motor to step {self.current_step} (={target}°)")

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -18,16 +18,23 @@ class DummyStepperMotor(StepperMotorBase):
         if steps_per_rotation < 1:
             raise ValueError("steps_per_rotation must be at least one")
 
-        self.steps_per_rotation = steps_per_rotation
-        self.current_step = 0
+        self._steps_per_rotation = steps_per_rotation
+        self._step = 0
 
         pub.subscribe(self.move_to, "stepper.move")
 
-    def get_steps_per_rotation(self) -> int:
-        """Get the number of steps that correspond to a full rotation."""
-        return self.steps_per_rotation
+    @property
+    def steps_per_rotation(self) -> int:
+        """The number of steps that correspond to a full rotation."""
+        return self._steps_per_rotation
 
-    def move_to_step(self, step: int) -> None:
+    @property
+    def step(self) -> int:
+        """The number of steps that correspond to a full rotation."""
+        return self._step
+
+    @step.setter
+    def step(self, step: int) -> None:
         """Move the stepper motor to the specified absolute position."""
-        self.current_step = step
+        self._step = step
         logging.info(f"Moving stepper motor to step {step}")

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -1,13 +1,12 @@
 """Code for a fake stepper motor device."""
 import logging
-from typing import Union
 
 from pubsub import pub
 
-from ..config import ANGLE_PRESETS
+from .stepper_motor_base import StepperMotorBase
 
 
-class DummyStepperMotor:
+class DummyStepperMotor(StepperMotorBase):
     """A fake stepper motor device used for unit tests etc."""
 
     def __init__(self, steps_per_rotation: int) -> None:
@@ -24,32 +23,11 @@ class DummyStepperMotor:
 
         pub.subscribe(self.move_to, "stepper.move")
 
-    @staticmethod
-    def get_preset_angle(name: str) -> float:
-        """Get the angle for one of the preset positions.
+    def get_steps_per_rotation(self) -> int:
+        """Get the number of steps that correspond to a full rotation."""
+        return self.steps_per_rotation
 
-        Args:
-            name: Name of preset angle
-        Returns:
-            The angle in degrees
-        """
-        try:
-            return ANGLE_PRESETS[name]
-        except KeyError as e:
-            raise ValueError(f"{name} is not a valid preset") from e
-
-    def move_to(self, target: Union[float, str]) -> None:
-        """Move the motor to a specified rotation.
-
-        Args:
-            target: The target angle (in degrees) or the name of a preset
-        """
-        if isinstance(target, str):
-            target = DummyStepperMotor.get_preset_angle(target)
-
-        if target < 0.0 or target > 270.0:
-            raise ValueError("Angle must be between 0° and 270°")
-        step = round(self.steps_per_rotation * target / 360.0)
+    def move_to_step(self, step: int) -> None:
+        """Move the stepper motor to the specified absolute position."""
         self.current_step = step
-
-        logging.info(f"Moving stepper motor to step {self.current_step} (={target}°)")
+        logging.info(f"Moving stepper motor to step {step}")

--- a/finesse/hardware/st10_controller.py
+++ b/finesse/hardware/st10_controller.py
@@ -1,0 +1,293 @@
+"""Code for interfacing with the ST10-Q-NN stepper motor controller.
+
+Applied Motions have their own bespoke programming language ("Q") for interfacing with
+their devices, of which we're only using a small portion here.
+
+The specification is available online:
+    https://appliedmotion.s3.amazonaws.com/Host-Command-Reference_920-0002W_0.pdf
+"""
+
+import logging
+from typing import Any, Optional
+
+from serial import Serial, SerialException, SerialTimeoutException
+
+from .stepper_motor_base import StepperMotorBase
+
+
+class ST10ControllerError(SerialException):
+    """Indicates that an error has occurred with the ST10 controller."""
+
+
+class ST10Controller(StepperMotorBase):
+    """An interface for the ST10-Q-NN stepper motor controller.
+
+    This class allows for moving the mirror to arbitrary positions and retrieving its
+    current position.
+    """
+
+    STEPS_PER_ROTATION = 50800
+    """The total number of steps in one full rotation of the mirror."""
+
+    def __init__(self, serial: Serial) -> None:
+        """Create a new ST10Controller.
+
+        Args:
+            serial: The serial device to communicate with the ST10 controller
+        """
+        self.serial = serial
+
+        # Check that we are connecting to an ST10
+        self._check_device_id()
+
+        # Move mirror to home position
+        self.home()
+
+    @staticmethod
+    def create(
+        port: str,
+        baudrate: int = 9600,
+        timeout: float = 1.0,
+        *serial_args: Any,
+        **serial_kwargs: Any,
+    ):
+        """Create a new ST10Controller with the specified serial device properties.
+
+        Args:
+            port: Serial port name
+            baudrate: Serial port baudrate
+            timeout: How long to wait for read operations (seconds)
+            serial_args: Extra arguments to Serial constructor
+            serial_kwargs: Extra keyword arguments to Serial constructor
+        """
+        if "write_timeout" not in serial_kwargs:
+            serial_kwargs["write_timeout"] = timeout
+
+        serial = Serial(port, baudrate, *serial_args, timeout=timeout, **serial_kwargs)
+        return ST10Controller(serial)
+
+    def __del__(self) -> None:
+        """Leave mirror facing downwards when finished.
+
+        This prevents dust accumulating.
+        """
+        try:
+            self.move_to("nadir")
+        except Exception as e:
+            logging.error(f"Failed to reset mirror to downward position: {e}")
+
+    def _check_device_id(self) -> None:
+        """Check that the ID is the correct one for an ST10."""
+        self._write("MV")
+        assert self._read() == "107F024"
+
+    def _get_input_status(self, index: int) -> bool:
+        """Read the value of the device's input status.
+
+        The input status is a boolean array represented as zeros and ones. I don't know
+        what it actually corresponds to on the device, but it is used in a couple of
+        places in the old program.
+        """
+        input_status = self._request_value("IS")
+        return input_status[index] == "1"
+
+    @property
+    def steps_per_rotation(self) -> int:
+        """Get the number of steps that correspond to a full rotation."""
+        return self.STEPS_PER_ROTATION
+
+    def home(self) -> None:
+        """Return the stepper motor to its home position.
+
+        The device's internal counter is also reset to zero.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+        """
+        # If the third (boolean) value of the input status array is set, then move the
+        # motor first. I don't know what the input status actually means, but this is
+        # how it was done in the old program, so I'm copying it here.
+        if self._get_input_status(3):
+            self.relative_move(-5000)
+
+        # Send home command; leaves mirror facing upwards
+        self._write_check("SH6H")
+
+        # Turn mirror so it's facing down
+        self.relative_move(-30130)
+
+        # Tell the controller that this is step 0
+        self._write_check("SP0")
+
+    def relative_move(self, step: int) -> None:
+        """Move the stepper motor to the specified relative position.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+        """
+        self._write_check(f"FL{step}")
+
+    @property
+    def step(self) -> int:
+        """The current state of the device's step counter.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+        """
+        step = self._request_value("SP")
+        try:
+            return int(step)
+        except ValueError:
+            raise ST10ControllerError(f"Invalid value for step received: {step}")
+
+    @step.setter
+    def step(self, step: int) -> None:
+        """Move the stepper motor to the specified absolute position.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+        """
+        self._write_check(f"FP{step}")
+
+    def _send_string(self, string: str) -> None:
+        """Request that the device sends string when operations have completed."""
+        self._write_check(f"SS{string}")
+
+    def _read(self) -> str:
+        """Read the next message from the device.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+        """
+        raw = self.serial.read_until(b"\r")
+
+        # Check that it hasn't timed out
+        if not raw:
+            raise SerialTimeoutException()
+
+        logging.debug(f"(ST10) <<< {repr(raw)}")
+
+        try:
+            return raw[:-1].decode("ascii")
+        except UnicodeDecodeError:
+            raise ST10ControllerError(f"Invalid message received: {repr(raw)}")
+
+    def _write(self, message: str) -> None:
+        """Send the specified message to the device.
+
+        Raises:
+            SerialException: Error communicating with device
+            UnicodeEncodeError: Malformed message
+        """
+        data = f"{message}\r".encode("ascii")
+        logging.debug(f"(ST10)>>> {repr(data)}")
+        self.serial.write(data)
+
+    def _write_check(self, message: str) -> None:
+        """Send the specified message and check whether the device returns an error.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+            UnicodeEncodeError: Message to be sent is malformed
+        """
+        self._write(message)
+        self._check_response()
+
+    def _check_response(self) -> None:
+        """Check whether the device has returned an error.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+        """
+        response = self._read()
+
+        # These values are referred to as "ack" and "qack" in the old program (nack is
+        # "?"). I don't know what qack is. Could it mean clockwise/anticlockwise
+        # movement?
+        if response == "%" or response == "*":
+            return
+
+        # An error occurred
+        if response[0] == "?":
+            raise ST10ControllerError(
+                f"Device returned an error (code: {response[1:]})"
+            )
+
+        raise ST10ControllerError(f"Unexpected response from device: {response}")
+
+    def _request_value(self, name: str) -> str:
+        """Request a named value from the device.
+
+        You can request the values of various variables, which all seem to have
+        two-letter names.
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for response from device
+            ST10ControllerError: Malformed message received from device
+            UnicodeEncodeError: Message to be sent is malformed
+        """
+        self._write(name)
+        response = self._read()
+        if not response.startswith(f"{name}="):
+            raise ST10ControllerError(f"Unexpected response when querying value {name}")
+
+        return response[len(name) + 1 :]
+
+    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+        """Wait until the motor has stopped moving.
+
+        Args:
+            timeout: Time to wait for motor to finish moving (None == forever)
+
+        Raises:
+            SerialException: Error communicating with device
+            SerialTimeoutException: Timed out waiting for motor to finish moving
+            ST10ControllerError: Malformed message received from device
+        """
+        # Tell device to send "X" when current operations are complete
+        self._send_string("X")
+
+        # Set temporary timeout
+        old_timeout, self.serial.timeout = self.serial.timeout, timeout
+        try:
+            if self._read() != "X":
+                raise ST10ControllerError(
+                    "Invalid response received when waiting for X"
+                )
+        finally:
+            # Restore previous timeout setting
+            self.serial.timeout = old_timeout
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(f"Connecting to device {sys.argv[1]}...")
+    dev = ST10Controller.create(sys.argv[1])
+    print("Done. Homing...")
+
+    dev.wait_until_stopped()
+    print("Homing complete")
+    print(f"Current angle: {dev.angle}°")
+
+    angles = (0.0, 90.0, 180.0, "hot_bb")
+    for ang in angles:
+        print(f"Moving to {ang}")
+        dev.move_to(ang)
+        dev.wait_until_stopped()
+        print(f"Current angle: {dev.angle}°")

--- a/finesse/hardware/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor_base.py
@@ -22,6 +22,14 @@ class StepperMotorBase(ABC):
         except KeyError as e:
             raise ValueError(f"{name} is not a valid preset") from e
 
+    def home(self) -> None:
+        """Return the stepper motor to its home position.
+
+        This default implementation just uses the preset angle for home, but it may be a
+        special operation for some devices.
+        """
+        self.move_to(self.preset_angle("home"))
+
     @abstractmethod
     def get_steps_per_rotation(self) -> int:
         """Get the number of steps that correspond to a full rotation."""
@@ -37,6 +45,11 @@ class StepperMotorBase(ABC):
             target: The target angle (in degrees) or the name of a preset
         """
         if isinstance(target, str):
+            # Homing may be a special operation
+            if target == "home":
+                self.home()
+                return
+
             target = self.preset_angle(target)
 
         if target < 0.0 or target > 270.0:

--- a/finesse/hardware/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor_base.py
@@ -1,0 +1,46 @@
+"""Provides the base class for stepper motor implementations."""
+from abc import ABC, abstractmethod
+from typing import Union
+
+from ..config import ANGLE_PRESETS
+
+
+class StepperMotorBase(ABC):
+    """A base class for stepper motor implementations."""
+
+    @staticmethod
+    def preset_angle(name: str) -> float:
+        """Get the angle for one of the preset positions.
+
+        Args:
+            name: Name of preset angle
+        Returns:
+            The angle in degrees
+        """
+        try:
+            return ANGLE_PRESETS[name]
+        except KeyError as e:
+            raise ValueError(f"{name} is not a valid preset") from e
+
+    @abstractmethod
+    def get_steps_per_rotation(self) -> int:
+        """Get the number of steps that correspond to a full rotation."""
+
+    @abstractmethod
+    def move_to_step(self, step: int) -> None:
+        """Move the stepper motor to the specified absolute position."""
+
+    def move_to(self, target: Union[float, str]) -> None:
+        """Move the motor to a specified rotation.
+
+        Args:
+            target: The target angle (in degrees) or the name of a preset
+        """
+        if isinstance(target, str):
+            target = self.preset_angle(target)
+
+        if target < 0.0 or target > 270.0:
+            raise ValueError("Angle must be between 0° and 270°")
+
+        step = round(self.get_steps_per_rotation() * target / 360.0)
+        self.move_to_step(step)

--- a/finesse/hardware/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor_base.py
@@ -30,13 +30,25 @@ class StepperMotorBase(ABC):
         """
         self.move_to(self.preset_angle("home"))
 
+    @property
     @abstractmethod
-    def get_steps_per_rotation(self) -> int:
-        """Get the number of steps that correspond to a full rotation."""
+    def steps_per_rotation(self) -> int:
+        """The number of steps that correspond to a full rotation."""
 
+    @property
     @abstractmethod
-    def move_to_step(self, step: int) -> None:
-        """Move the stepper motor to the specified absolute position."""
+    def step(self) -> int:
+        """The current state of the device's step counter."""
+
+    @step.setter
+    @abstractmethod
+    def step(self, step: int) -> None:
+        pass
+
+    @property
+    def angle(self) -> float:
+        """The current angle of the motor in degrees."""
+        return self.step * 360.0 / self.steps_per_rotation
 
     def move_to(self, target: Union[float, str]) -> None:
         """Move the motor to a specified rotation.
@@ -55,5 +67,4 @@ class StepperMotorBase(ABC):
         if target < 0.0 or target > 270.0:
             raise ValueError("Angle must be between 0° and 270°")
 
-        step = round(self.get_steps_per_rotation() * target / 360.0)
-        self.move_to_step(step)
+        self.step = round(self.steps_per_rotation * target / 360.0)

--- a/tests/test_st10_controller.py
+++ b/tests/test_st10_controller.py
@@ -1,0 +1,136 @@
+"""Tests for the ST10Controller class."""
+from contextlib import nullcontext as does_not_raise
+from itertools import chain
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from serial import SerialTimeoutException
+
+from finesse.hardware.st10_controller import ST10Controller, ST10ControllerError
+
+
+@pytest.fixture
+def dev() -> ST10Controller:
+    """A fixture providing an ST10Controller with a patched Serial object."""
+    serial = MagicMock()
+
+    # check_device_id() and home() should both be called by ST10Controller.__init__(),
+    # but patch them for now as we'll test their inner workings elsewhere
+    with patch.object(ST10Controller, "_check_device_id") as check_mock:
+        with patch.object(ST10Controller, "home") as home_mock:
+            st10 = ST10Controller(serial)
+            check_mock.assert_called_once()
+            home_mock.assert_called_once()
+            return st10
+
+
+def read_mock(dev: ST10Controller, return_value: str):
+    """Patch the _read() method of dev."""
+    return patch.object(dev, "_read", return_value=return_value)
+
+
+def test_write(dev: ST10Controller) -> None:
+    """Test the _write() method."""
+    dev._write("hello")
+    dev.serial.write.assert_called_once_with(b"hello\r")
+
+
+def test_read(dev: ST10Controller) -> None:
+    """Test the _read() method."""
+    # Check a normal read
+    dev.serial.read_until.return_value = b"hello\r"
+    ret = dev._read()
+    dev.serial.read_until.assert_called_with(b"\r")
+    assert ret == "hello"
+
+    # Check a timed-out read
+    dev.serial.read_until.return_value = b""
+    with pytest.raises(SerialTimeoutException):
+        dev._read()
+
+    # Check a non-ASCII return value
+    dev.serial.read_until.return_value = b"\xff\r"
+    with pytest.raises(ST10ControllerError):
+        dev._read()
+
+
+@pytest.mark.parametrize(
+    "response,raises",
+    [
+        (
+            response,
+            does_not_raise()
+            if response == "%" or response == "*"
+            else pytest.raises(ST10ControllerError),
+        )
+        for response in ["%", "*", "?error", "something else"]
+    ],
+)
+def test_check_response(response: str, raises: Any, dev: ST10Controller) -> None:
+    """Test the _check_response() method."""
+    with read_mock(dev, response):
+        with raises:
+            dev._check_response()
+
+
+def test_write_check(dev: ST10Controller) -> None:
+    """Test the _write_check() method."""
+    with patch.object(dev, "_write") as write_mock:
+        with patch.object(dev, "_check_response") as check_mock:
+            dev._write_check("hello")
+            write_mock.assert_called_once_with("hello")
+            check_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "name,value,response,raises",
+    [
+        (
+            name,
+            value,
+            response,
+            does_not_raise()
+            if response.startswith(f"{name}=")
+            else pytest.raises(ST10ControllerError),
+        )
+        for name in ["hello", "IS", "SP"]
+        for value in ["", "value", "123"]
+        for response in [f"{name}={value}", value, "%", "*", "?4"]
+    ],
+)
+def test_request_value(
+    name: str, value: str, response: str, raises: Any, dev: ST10Controller
+) -> None:
+    """Test the _request_value() method."""
+    with patch.object(dev, "_write") as write_mock:
+        with read_mock(dev, response):
+            with raises:
+                assert dev._request_value(name) == value
+            write_mock.assert_called_once_with(name)
+
+
+def test_check_device_id(dev: ST10Controller) -> None:
+    """Test the _check_device_id() method."""
+    # Check with the correct ID
+    with read_mock(dev, "107F024"):
+        dev._check_device_id()
+
+    # Check with an invalid ID
+    with read_mock(dev, "hello"):
+        with pytest.raises(ST10ControllerError):
+            dev._check_device_id()
+
+
+@pytest.mark.parametrize(
+    "step,response,raises",
+    chain(
+        [(step, f"SP={step}", does_not_raise()) for step in range(0, 250, 50)],
+        [(4, "SP=hello", pytest.raises(ST10ControllerError))],
+    ),
+)
+def test_get_step(step: int, response: str, raises: Any, dev: ST10Controller) -> None:
+    """Test getting the step property."""
+    with read_mock(dev, response):
+        with raises:
+            assert dev.step == step

--- a/tests/test_stepper_motor.py
+++ b/tests/test_stepper_motor.py
@@ -4,6 +4,7 @@ from itertools import chain
 from typing import Any
 
 import pytest
+from pytest_mock import MockerFixture
 
 from finesse.config import ANGLE_PRESETS
 from finesse.hardware.dummy_stepper_motor import DummyStepperMotor
@@ -45,6 +46,14 @@ def test_move_to_number(target: int, raises: Any) -> None:
     with raises:
         stepper.move_to(10.0 * float(target))
         assert stepper.current_step == target
+
+
+def test_home_is_special(mocker: MockerFixture) -> None:
+    """Test whether the home() method is invoked when moving to "home" preset."""
+    home = mocker.patch("finesse.hardware.stepper_motor_base.StepperMotorBase.home")
+    stepper = DummyStepperMotor(36)
+    stepper.move_to("home")
+    home.assert_called_once()
 
 
 # Invalid names for presets. Note that case matters.

--- a/tests/test_stepper_motor.py
+++ b/tests/test_stepper_motor.py
@@ -31,7 +31,7 @@ def test_constructor(steps: int, raises: Any) -> None:
         [
             target,
             pytest.raises(ValueError)
-            if target < 0 or target >= 36
+            if target < 0 or target > 27
             else does_not_raise(),
         ]
         for target in range(-36, 2 * 36)

--- a/tests/test_stepper_motor.py
+++ b/tests/test_stepper_motor.py
@@ -41,11 +41,11 @@ def test_constructor(steps: int, raises: Any) -> None:
 def test_move_to_number(target: int, raises: Any) -> None:
     """Check move_to, when an angle is given."""
     stepper = DummyStepperMotor(36)
-    assert stepper.current_step == 0
+    assert stepper.step == 0
 
     with raises:
         stepper.move_to(10.0 * float(target))
-        assert stepper.current_step == target
+        assert stepper.step == target
 
 
 def test_home_is_special(mocker: MockerFixture) -> None:

--- a/tests/test_stepper_motor.py
+++ b/tests/test_stepper_motor.py
@@ -14,11 +14,9 @@ from finesse.hardware.dummy_stepper_motor import DummyStepperMotor
     [
         [
             steps,
-            pytest.raises(ValueError)
-            if steps < len(ANGLE_PRESETS)
-            else does_not_raise(),
+            pytest.raises(ValueError) if steps <= 0 else does_not_raise(),
         ]
-        for steps in range(-5, len(ANGLE_PRESETS) + 5)
+        for steps in range(-5, 5)
     ],
 )
 def test_constructor(steps: int, raises: Any) -> None:
@@ -59,10 +57,10 @@ BAD_PRESETS = ("", "ZENITH", "kevin", "badger")
         [
             name,
             pytest.raises(ValueError)
-            if name not in ANGLE_PRESETS
+            if name not in ANGLE_PRESETS.keys()
             else does_not_raise(),
         ]
-        for name in chain(ANGLE_PRESETS, BAD_PRESETS)
+        for name in chain(ANGLE_PRESETS.keys(), BAD_PRESETS)
     ],
 )
 def test_move_to_preset(name: str, raises: Any) -> None:


### PR DESCRIPTION
This PR adds a class (`ST10Controller`) for communicating with the stepper motor controller over a USB serial connection, though this support isn't integrated with the GUI yet.

Summary:

- Make a `StepperMotorBase` class as a parent for `ST10Controller` and `DummyStepperMotor`
- Add support for getting and setting the angle of the ST10, including moving it to preset positions

Limitations:

- As with the TC4820, there is no integration with the GUI yet and errors in the backend will only be displayed by the logger