### PR TITLE
Add LED icon class

### DIFF
--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -29,8 +29,8 @@ class LEDIcon(QLabel):
             is_on (bool): On/off status of LED.
         """
         super().__init__()
-        self._on_img = QImage(on_img)
-        self._off_img = QImage(off_img)
+        self._on_img = on_img
+        self._off_img = off_img
         if is_on:
             self._turn_on()
         else:

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -1,4 +1,6 @@
 """Class for LED Icons."""
+from __future__ import annotations
+
 from importlib import resources
 
 from PySide6.QtCore import QTimer
@@ -38,15 +40,15 @@ class LEDIcon(QLabel):
         self._timer = QTimer()
         self._timer.timeout.connect(self._turn_off)  # type: ignore
 
-    @staticmethod
-    def create_poll_icon() -> "LEDIcon":
+    @classmethod
+    def create_poll_icon(cls) -> LEDIcon:
         """Creates the LED icon for polling the server."""
-        return LEDIcon(on_img=_poll_on_img, off_img=_poll_off_img)
+        return cls(on_img=_poll_on_img, off_img=_poll_off_img)
 
-    @staticmethod
-    def create_alarm_icon() -> "LEDIcon":
+    @classmethod
+    def create_alarm_icon(cls) -> LEDIcon:
         """Creates the LED icon to indicate alarm status."""
-        return LEDIcon(on_img=_alarm_on_img, off_img=_alarm_off_img)
+        return cls(on_img=_alarm_on_img, off_img=_alarm_off_img)
 
     def _turn_on(self) -> None:
         """Turns the LED on."""

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -1,6 +1,7 @@
 """Class for LED Icons."""
 from importlib import resources
 
+from PySide6.QtCore import QTimer
 from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import QLabel
 
@@ -25,6 +26,8 @@ class LEDIcon(QLabel):
         self._status = status
         self._on_img = QImage()
         self._off_img = QImage()
+        self._timer = QTimer()
+        self._timer.timeout.connect(self._turn_off)
 
     def _turn_on(self):
         """Turns the LED on."""
@@ -36,15 +39,14 @@ class LEDIcon(QLabel):
         self._status = 0
         self.setPixmap(QPixmap(self._off_img))
 
-    def _flash(self, duration: int):
+    def _flash(self, duration: int = 1000):
         """Turns the LED on for a specified duration.
 
         Args:
             duration (int): Number of milliseconds to keep LED lit for
         """
         self._turn_on()
-        # wait for <duration> ms
-        self._turn_off()
+        self._timer.singleShot(duration, self._turn_off)
 
 
 class PollIcon(LEDIcon):

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -20,16 +20,21 @@ _alarm_off_img = QImage.fromData(_alarm_off_img_data)
 class LEDIcon(QLabel):
     """QLabel object to represent an LED with on/off status."""
 
-    def __init__(self, is_on: bool = False) -> None:
+    def __init__(self, on_img: QImage, off_img: QImage, is_on: bool = False) -> None:
         """Creates the LED icon, sets its status and stores corresponding image data.
 
         Args:
+            on_img (QImage): QImage for LED on state.
+            off_img (QImage): QImage for LED off state.
             is_on (bool): On/off status of LED.
         """
         super().__init__()
-        self._is_on = is_on
-        self._on_img = QImage()
-        self._off_img = QImage()
+        self._on_img = QImage(on_img)
+        self._off_img = QImage(off_img)
+        if is_on:
+            self._turn_on()
+        else:
+            self._turn_off()
         self._timer = QTimer()
         self._timer.timeout.connect(self._turn_off)  # type: ignore
 
@@ -56,34 +61,30 @@ class LEDIcon(QLabel):
 class PollIcon(LEDIcon):
     """QLabel object to represent an LED for polling server."""
 
-    def __init__(self, is_on: bool = False) -> None:
+    def __init__(
+        self, on_img=_poll_on_img, off_img=_poll_off_img, is_on: bool = False
+    ) -> None:
         """Creates the LED icon, sets its status and stores corresponding image data.
 
         Args:
+            on_img (QImage): QImage for LED on state.
+            off_img (QImage): QImage for LED off state.
             is_on (bool): On/off status of LED.
         """
-        super().__init__(is_on=is_on)
-        self._on_img = _poll_on_img
-        self._off_img = _poll_off_img
-        if is_on:
-            self._turn_on()
-        else:
-            self._turn_off()
+        super().__init__(on_img=on_img, off_img=off_img, is_on=is_on)
 
 
 class AlarmIcon(LEDIcon):
     """QLabel object to represent an LED to indicate alarm status."""
 
-    def __init__(self, is_on: bool = False) -> None:
+    def __init__(
+        self, on_img=_alarm_on_img, off_img=_alarm_off_img, is_on: bool = False
+    ) -> None:
         """Creates the LED icon, sets its status and stores corresponding image data.
 
         Args:
+            on_img (QImage): QImage for LED on state.
+            off_img (QImage): QImage for LED off state.
             is_on (bool): On/off status of LED.
         """
-        super().__init__(is_on=is_on)
-        self._on_img = _alarm_on_img
-        self._off_img = _alarm_off_img
-        if is_on:
-            self._turn_on()
-        else:
-            self._turn_off()
+        super().__init__(on_img=on_img, off_img=off_img, is_on=is_on)

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -45,10 +45,10 @@ class LEDIcon(QLabel):
 
     def _turn_off(self):
         """Turns the LED off."""
-        self._is_on = 0
+        self._is_on = False
         self.setPixmap(QPixmap(self._off_img))
 
-    def _flash(self, duration: int = 1000):
+    def _flash(self, duration: int = 250):
         """Turns the LED on for a specified duration.
 
         Args:

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -38,17 +38,27 @@ class LEDIcon(QLabel):
         self._timer = QTimer()
         self._timer.timeout.connect(self._turn_off)  # type: ignore
 
-    def _turn_on(self):
+    @staticmethod
+    def create_poll_icon() -> "LEDIcon":
+        """Creates the LED icon for polling the server."""
+        return LEDIcon(on_img=_poll_on_img, off_img=_poll_off_img)
+
+    @staticmethod
+    def create_alarm_icon() -> "LEDIcon":
+        """Creates the LED icon to indicate alarm status."""
+        return LEDIcon(on_img=_alarm_on_img, off_img=_alarm_off_img)
+
+    def _turn_on(self) -> None:
         """Turns the LED on."""
         self._is_on = True
         self.setPixmap(QPixmap(self._on_img))
 
-    def _turn_off(self):
+    def _turn_off(self) -> None:
         """Turns the LED off."""
         self._is_on = False
         self.setPixmap(QPixmap(self._off_img))
 
-    def _flash(self, duration: int = 250):
+    def _flash(self, duration: int = 250) -> None:
         """Turns the LED on for a specified duration.
 
         Args:
@@ -56,35 +66,3 @@ class LEDIcon(QLabel):
         """
         self._turn_on()
         self._timer.singleShot(duration, self._turn_off)
-
-
-class PollIcon(LEDIcon):
-    """QLabel object to represent an LED for polling server."""
-
-    def __init__(
-        self, on_img=_poll_on_img, off_img=_poll_off_img, is_on: bool = False
-    ) -> None:
-        """Creates the LED icon, sets its status and stores corresponding image data.
-
-        Args:
-            on_img (QImage): QImage for LED on state.
-            off_img (QImage): QImage for LED off state.
-            is_on (bool): On/off status of LED.
-        """
-        super().__init__(on_img=on_img, off_img=off_img, is_on=is_on)
-
-
-class AlarmIcon(LEDIcon):
-    """QLabel object to represent an LED to indicate alarm status."""
-
-    def __init__(
-        self, on_img=_alarm_on_img, off_img=_alarm_off_img, is_on: bool = False
-    ) -> None:
-        """Creates the LED icon, sets its status and stores corresponding image data.
-
-        Args:
-            on_img (QImage): QImage for LED on state.
-            off_img (QImage): QImage for LED off state.
-            is_on (bool): On/off status of LED.
-        """
-        super().__init__(on_img=on_img, off_img=off_img, is_on=is_on)

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -5,25 +5,29 @@ from PySide6.QtCore import QTimer
 from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import QLabel
 
-img_files = resources.files("finesse.gui.images")
-poll_on_img_data = img_files.joinpath("poll_on.png").read_bytes()
-poll_off_img_data = img_files.joinpath("poll_off.png").read_bytes()
-alarm_on_img_data = img_files.joinpath("alarm_on.png").read_bytes()
-alarm_off_img_data = img_files.joinpath("alarm_off.png").read_bytes()
+_img_files = resources.files("finesse.gui.images")
+_poll_on_img_data = _img_files.joinpath("poll_on.png").read_bytes()
+_poll_off_img_data = _img_files.joinpath("poll_off.png").read_bytes()
+_alarm_on_img_data = _img_files.joinpath("alarm_on.png").read_bytes()
+_alarm_off_img_data = _img_files.joinpath("alarm_off.png").read_bytes()
 
-poll_on_img = QImage.fromData(poll_on_img_data)
-poll_off_img = QImage.fromData(poll_off_img_data)
-alarm_on_img = QImage.fromData(alarm_on_img_data)
-alarm_off_img = QImage.fromData(alarm_off_img_data)
+_poll_on_img = QImage.fromData(_poll_on_img_data)
+_poll_off_img = QImage.fromData(_poll_off_img_data)
+_alarm_on_img = QImage.fromData(_alarm_on_img_data)
+_alarm_off_img = QImage.fromData(_alarm_off_img_data)
 
 
 class LEDIcon(QLabel):
     """QLabel object to represent an LED with on/off status."""
 
-    def __init__(self, status: int) -> None:
-        """Creates the LED icon, sets its status and stores corresponding image data."""
+    def __init__(self, is_on: bool = False) -> None:
+        """Creates the LED icon, sets its status and stores corresponding image data.
+
+        Args:
+            is_on (bool): On/off status of LED.
+        """
         super().__init__()
-        self._status = status
+        self._is_on = is_on
         self._on_img = QImage()
         self._off_img = QImage()
         self._timer = QTimer()
@@ -31,12 +35,12 @@ class LEDIcon(QLabel):
 
     def _turn_on(self):
         """Turns the LED on."""
-        self._status = 1
+        self._is_on = True
         self.setPixmap(QPixmap(self._on_img))
 
     def _turn_off(self):
         """Turns the LED off."""
-        self._status = 0
+        self._is_on = 0
         self.setPixmap(QPixmap(self._off_img))
 
     def _flash(self, duration: int = 1000):
@@ -52,16 +56,16 @@ class LEDIcon(QLabel):
 class PollIcon(LEDIcon):
     """QLabel object to represent an LED for polling server."""
 
-    def __init__(self, status: int) -> None:
+    def __init__(self, is_on: bool = False) -> None:
         """Creates the LED icon, sets its status and stores corresponding image data.
 
         Args:
-            status (int): On/off status of LED. 0 = off, !0 = on
+            is_on (bool): On/off status of LED.
         """
-        super().__init__(status=status)
-        self._on_img = poll_on_img
-        self._off_img = poll_off_img
-        if status:
+        super().__init__(is_on=is_on)
+        self._on_img = _poll_on_img
+        self._off_img = _poll_off_img
+        if is_on:
             self._turn_on()
         else:
             self._turn_off()
@@ -70,16 +74,16 @@ class PollIcon(LEDIcon):
 class AlarmIcon(LEDIcon):
     """QLabel object to represent an LED to indicate alarm status."""
 
-    def __init__(self, status: int) -> None:
+    def __init__(self, is_on: bool = False) -> None:
         """Creates the LED icon, sets its status and stores corresponding image data.
 
         Args:
-            status (int): On/off status of LED. 0 = off, !0 = on
+            is_on (bool): On/off status of LED.
         """
-        super().__init__(status=status)
-        self._on_img = alarm_on_img
-        self._off_img = alarm_off_img
-        if status:
+        super().__init__(is_on=is_on)
+        self._on_img = _alarm_on_img
+        self._off_img = _alarm_off_img
+        if is_on:
             self._turn_on()
         else:
             self._turn_off()

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -27,7 +27,7 @@ class LEDIcon(QLabel):
         self._on_img = QImage()
         self._off_img = QImage()
         self._timer = QTimer()
-        self._timer.timeout.connect(self._turn_off)
+        self._timer.timeout.connect(self._turn_off)  # type: ignore
 
     def _turn_on(self):
         """Turns the LED on."""

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -1,0 +1,83 @@
+"""Class for LED Icons."""
+from importlib import resources
+
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import QLabel
+
+img_files = resources.files("finesse.gui.images")
+poll_on_img_data = img_files.joinpath("poll_on.png").read_bytes()
+poll_off_img_data = img_files.joinpath("poll_off.png").read_bytes()
+alarm_on_img_data = img_files.joinpath("alarm_on.png").read_bytes()
+alarm_off_img_data = img_files.joinpath("alarm_off.png").read_bytes()
+
+poll_on_img = QImage.fromData(poll_on_img_data)
+poll_off_img = QImage.fromData(poll_off_img_data)
+alarm_on_img = QImage.fromData(alarm_on_img_data)
+alarm_off_img = QImage.fromData(alarm_off_img_data)
+
+
+class LEDIcon(QLabel):
+    """QLabel object to represent an LED with on/off status."""
+
+    def __init__(self, status: int) -> None:
+        """Creates the LED icon, sets its status and stores corresponding image data."""
+        super().__init__()
+        self._status = status
+        self._on_img = QImage()
+        self._off_img = QImage()
+
+    def _turn_on(self):
+        """Turns the LED on."""
+        self._status = 1
+        self.setPixmap(QPixmap(self._on_img))
+
+    def _turn_off(self):
+        """Turns the LED off."""
+        self._status = 0
+        self.setPixmap(QPixmap(self._off_img))
+
+    def _flash(self, duration: int):
+        """Turns the LED on for a specified duration.
+
+        Args:
+            duration (int): Number of milliseconds to keep LED lit for
+        """
+        self._turn_on()
+        # wait for <duration> ms
+        self._turn_off()
+
+
+class PollIcon(LEDIcon):
+    """QLabel object to represent an LED for polling server."""
+
+    def __init__(self, status: int) -> None:
+        """Creates the LED icon, sets its status and stores corresponding image data.
+
+        Args:
+            status (int): On/off status of LED. 0 = off, !0 = on
+        """
+        super().__init__(status=status)
+        self._on_img = poll_on_img
+        self._off_img = poll_off_img
+        if status:
+            self._turn_on()
+        else:
+            self._turn_off()
+
+
+class AlarmIcon(LEDIcon):
+    """QLabel object to represent an LED to indicate alarm status."""
+
+    def __init__(self, status: int) -> None:
+        """Creates the LED icon, sets its status and stores corresponding image data.
+
+        Args:
+            status (int): On/off status of LED. 0 = off, !0 = on
+        """
+        super().__init__(status=status)
+        self._on_img = alarm_on_img
+        self._off_img = alarm_off_img
+        if status:
+            self._turn_on()
+        else:
+            self._turn_off()

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -187,7 +187,7 @@ class DP9800(QGroupBox):
         )
         layout.addWidget(poll_label, 0, 9, 2, 1)
 
-        self._poll_light = PollIcon(status=0)
+        self._poll_light = PollIcon()
         layout.addWidget(self._poll_light, 0, 10, 2, 1)
 
         return layout
@@ -257,8 +257,8 @@ class TC4820(QGroupBox):
         layout.addWidget(self._power_bar, 1, 1, 1, 3)
         layout.addWidget(QLineEdit("40"), 1, 4)
 
-        self._poll_light = PollIcon(status=0)
-        self._alarm_light = AlarmIcon(status=0)
+        self._poll_light = PollIcon()
+        self._alarm_light = AlarmIcon()
         layout.addWidget(self._poll_light, 0, 5)
         layout.addWidget(self._alarm_light, 2, 5)
 

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -1,13 +1,11 @@
 """Panel and widgets related to temperature monitoring."""
 from datetime import datetime
 from functools import partial
-from importlib import resources
 from typing import Tuple
 
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
     QGridLayout,
     QGroupBox,
@@ -19,15 +17,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-img_files = resources.files("finesse.gui.images")
-poll_on_img_data = img_files.joinpath("poll_on.png").read_bytes()
-poll_off_img_data = img_files.joinpath("poll_off.png").read_bytes()
-alarm_on_img_data = img_files.joinpath("alarm_on.png").read_bytes()
-alarm_off_img_data = img_files.joinpath("alarm_off.png").read_bytes()
-poll_on_img = QImage.fromData(poll_on_img_data)
-poll_off_img = QImage.fromData(poll_off_img_data)
-alarm_on_img = QImage.fromData(alarm_on_img_data)
-alarm_off_img = QImage.fromData(alarm_off_img_data)
+from .led_icons import AlarmIcon, PollIcon
 
 
 def get_temperature_data() -> Tuple[float, float, float]:
@@ -197,8 +187,7 @@ class DP9800(QGroupBox):
         )
         layout.addWidget(poll_label, 0, 9, 2, 1)
 
-        self._poll_light = QLabel()
-        self._poll_light.setPixmap(QPixmap(poll_off_img))
+        self._poll_light = PollIcon(status=0)
         layout.addWidget(self._poll_light, 0, 10, 2, 1)
 
         return layout
@@ -268,10 +257,8 @@ class TC4820(QGroupBox):
         layout.addWidget(self._power_bar, 1, 1, 1, 3)
         layout.addWidget(QLineEdit("40"), 1, 4)
 
-        self._poll_light = QLabel()
-        self._poll_light.setPixmap(QPixmap(poll_off_img))
-        self._alarm_light = QLabel()
-        self._alarm_light.setPixmap(QPixmap(alarm_off_img))
+        self._poll_light = PollIcon(status=0)
+        self._alarm_light = AlarmIcon(status=0)
         layout.addWidget(self._poll_light, 0, 5)
         layout.addWidget(self._alarm_light, 2, 5)
 

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from .led_icons import AlarmIcon, PollIcon
+from .led_icons import LEDIcon
 
 
 def get_temperature_data() -> Tuple[float, float, float]:
@@ -187,7 +187,7 @@ class DP9800(QGroupBox):
         )
         layout.addWidget(poll_label, 0, 9, 2, 1)
 
-        self._poll_light = PollIcon()
+        self._poll_light = LEDIcon.create_poll_icon()
         layout.addWidget(self._poll_light, 0, 10, 2, 1)
 
         return layout
@@ -257,8 +257,8 @@ class TC4820(QGroupBox):
         layout.addWidget(self._power_bar, 1, 1, 1, 3)
         layout.addWidget(QLineEdit("40"), 1, 4)
 
-        self._poll_light = PollIcon()
-        self._alarm_light = AlarmIcon()
+        self._poll_light = LEDIcon.create_poll_icon()
+        self._alarm_light = LEDIcon.create_alarm_icon()
         layout.addWidget(self._poll_light, 0, 5)
         layout.addWidget(self._alarm_light, 2, 5)
 


### PR DESCRIPTION
This PR adds a new class for handling LED indicators on the GUI. The main advantage is that the image data are loaded only once, rather than for each separate GUI component that requires them. I have also provided some additional functionality, allowing the LED icons to flash on for a specified duration, once some process triggers them (e.g. polling the server).