### PR TITLE
Add async support to stepper motor controller code

### DIFF
--- a/finesse/gui/measure_script/parse.py
+++ b/finesse/gui/measure_script/parse.py
@@ -31,7 +31,7 @@ class Measurement:
     def run(self) -> None:
         """A placeholder function for recording multiple measurements."""
         # Move the mirror to the correct location
-        pub.sendMessage("stepper.move", target=self.angle)
+        pub.sendMessage("stepper.move.begin", target=self.angle)
 
         # Take the recordings
         logging.info(f"Recording {self.measurements} measurements")

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -55,4 +55,4 @@ class StepperMotorControl(QGroupBox):
     def _preset_clicked(self, btn: QPushButton) -> None:
         """Move the stepper motor to preset position."""
         target = float(self.angle.value()) if btn is self.goto else btn.text().lower()
-        pub.sendMessage("stepper.move", target=target)
+        pub.sendMessage("stepper.move.begin", target=target)

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -54,5 +54,8 @@ class StepperMotorControl(QGroupBox):
 
     def _preset_clicked(self, btn: QPushButton) -> None:
         """Move the stepper motor to preset position."""
+        # If the motor is already moving, stop it now
+        pub.sendMessage("stepper.stop")
+
         target = float(self.angle.value()) if btn is self.goto else btn.text().lower()
         pub.sendMessage("stepper.move.begin", target=target)

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Optional
 
+from pubsub import pub
+
 from .stepper_motor_base import StepperMotorBase
 
 
@@ -46,7 +48,7 @@ class DummyStepperMotor(StepperMotorBase):
         """Immediately stop moving the motor."""
         logging.info("Stopping motor")
 
-    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped_sync(self, timeout: Optional[float] = None) -> None:
         """Wait until the motor has stopped moving.
 
         For this dummy class, this is a no-op.
@@ -54,3 +56,12 @@ class DummyStepperMotor(StepperMotorBase):
         Args:
             timeout: Time to wait for motor to finish moving (None == forever)
         """
+
+    def wait_until_stopped_async(self) -> None:
+        """Wait until the motor has stopped moving and send a message when done.
+
+        The message is stepper.move.end.
+
+        As this is a dummy class, this completes immediately.
+        """
+        pub.sendMessage("stepper.move.end")

--- a/finesse/hardware/dummy_stepper_motor.py
+++ b/finesse/hardware/dummy_stepper_motor.py
@@ -48,7 +48,7 @@ class DummyStepperMotor(StepperMotorBase):
         """Immediately stop moving the motor."""
         logging.info("Stopping motor")
 
-    def wait_until_stopped_sync(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
         """Wait until the motor has stopped moving.
 
         For this dummy class, this is a no-op.
@@ -57,7 +57,7 @@ class DummyStepperMotor(StepperMotorBase):
             timeout: Time to wait for motor to finish moving (None == forever)
         """
 
-    def wait_until_stopped_async(self) -> None:
+    def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done.
 
         The message is stepper.move.end.

--- a/finesse/hardware/st10_controller.py
+++ b/finesse/hardware/st10_controller.py
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     dev = ST10Controller.create(sys.argv[1])
     print("Done. Homing...")
 
-    dev.wait_until_stopped_sync()
+    dev.wait_until_stopped()
     print("Homing complete")
     print(f"Current angle: {dev.angle}°")
 
@@ -468,5 +468,5 @@ if __name__ == "__main__":
     for ang in angles:
         print(f"Moving to {ang}")
         dev.move_to(ang)
-        dev.wait_until_stopped_sync()
+        dev.wait_until_stopped()
         print(f"Current angle: {dev.angle}°")

--- a/finesse/hardware/st10_controller.py
+++ b/finesse/hardware/st10_controller.py
@@ -22,7 +22,11 @@ class ST10ControllerError(SerialException):
     """Indicates that an error has occurred with the ST10 controller."""
 
 
-_ASYNC_MAGIC = "Z"
+_SEND_STRING_MAGIC = "Z"
+"""The arbitrary magic string we are using for the send string command.
+
+See ST10Controller._send_string() for details of this command.
+"""
 
 
 class _SerialReader(QThread):
@@ -88,7 +92,7 @@ class _SerialReader(QThread):
 
     def _read_success(self, message: str) -> None:
         # The motor is signalling that it has finished moving
-        if message == _ASYNC_MAGIC:
+        if message == _SEND_STRING_MAGIC:
             self.async_read_completed.emit()
             return
 
@@ -319,6 +323,9 @@ class ST10Controller(StepperMotorBase):
     def _send_string(self, string: str) -> None:
         """Request that the device sends string when operations have completed.
 
+        The string is sent when the queue of move commands is empty and the motor has
+        stopped moving.
+
         Args:
             string: String to be returned by the device
         """
@@ -450,7 +457,7 @@ class ST10Controller(StepperMotorBase):
 
     def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done."""
-        self._send_string(_ASYNC_MAGIC)
+        self._send_string(_SEND_STRING_MAGIC)
 
 
 if __name__ == "__main__":

--- a/finesse/hardware/st10_controller.py
+++ b/finesse/hardware/st10_controller.py
@@ -423,7 +423,7 @@ class ST10Controller(StepperMotorBase):
         """Immediately stop moving the motor."""
         self._write_check("ST")
 
-    def wait_until_stopped_sync(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
         """Wait until the motor has stopped moving.
 
         Args:
@@ -448,7 +448,7 @@ class ST10Controller(StepperMotorBase):
             # Restore previous timeout setting
             self.serial.timeout = old_timeout
 
-    def wait_until_stopped_async(self) -> None:
+    def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done."""
         self._send_string(_ASYNC_MAGIC)
 

--- a/finesse/hardware/st10_controller.py
+++ b/finesse/hardware/st10_controller.py
@@ -211,6 +211,11 @@ class ST10Controller(StepperMotorBase):
         except Exception as e:
             logging.error(f"Failed to reset mirror to downward position: {e}")
 
+        # Set flag that indicates the thread should quit
+        self._reader.quit()
+
+        # If _reader is blocking on a read (which is likely), we could end up waiting
+        # forever, so close the socket so that the read operation will terminate
         self.serial.close()
 
     @Slot()

--- a/finesse/hardware/st10_controller.py
+++ b/finesse/hardware/st10_controller.py
@@ -30,7 +30,24 @@ See ST10Controller._send_string() for details of this command.
 
 
 class _SerialReader(QThread):
-    """For background reading of serial device."""
+    """For background reading from the serial device.
+
+    There are two types of messages that we receive from the device. The first are
+    immediately sent in response to a command sent to the controller, e.g. an ack
+    message ("%"). This is what happens with all but one of the commands we are using.
+    The one exception is the send string command ("SS"), which, in addition to eliciting
+    an immediate ack (or nack) response, also leads to another response being sent when
+    the motor has finished moving. Note that while the motor is moving, other commands
+    can be sent and even processed, e.g. you can request the motor's current position
+    while it is moving.
+
+    All of the reading we do from the device goes via this class, as conceivably the
+    magic send string response could be sent at any point after the send string command
+    is sent, so reading should be continuous.
+
+    When the magic send string response is received, the async_read_completed signal is
+    emitted. Synchronous reads are handled by putting received messages into a Queue.
+    """
 
     async_read_completed = Signal()
     """Indicates that an asynchronous read has finished."""

--- a/finesse/hardware/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor_base.py
@@ -17,6 +17,7 @@ class StepperMotorBase(ABC):
         """
         pub.subscribe(self.move_to, "stepper.move.begin")
         pub.subscribe(self.stop_moving, "stepper.stop")
+        pub.subscribe(self.notify_on_stopped, "stepper.notify_on_stopped")
 
     @staticmethod
     def preset_angle(name: str) -> float:
@@ -91,6 +92,3 @@ class StepperMotorBase(ABC):
             raise ValueError("Angle must be between 0° and 270°")
 
         self.step = round(self.steps_per_rotation * target / 360.0)
-
-        # Send a message when the motor has stopped moving
-        self.notify_on_stopped()

--- a/finesse/hardware/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor_base.py
@@ -57,7 +57,7 @@ class StepperMotorBase(ABC):
         """Immediately stop moving the motor."""
 
     @abstractmethod
-    def wait_until_stopped_sync(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
         """Wait until the motor has stopped moving.
 
         Args:
@@ -65,7 +65,7 @@ class StepperMotorBase(ABC):
         """
 
     @abstractmethod
-    def wait_until_stopped_async(self) -> None:
+    def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done.
 
         The message is stepper.move.end.
@@ -93,4 +93,4 @@ class StepperMotorBase(ABC):
         self.step = round(self.steps_per_rotation * target / 360.0)
 
         # Send a message when the motor has stopped moving
-        self.wait_until_stopped_async()
+        self.notify_on_stopped()

--- a/finesse/hardware/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor_base.py
@@ -16,6 +16,7 @@ class StepperMotorBase(ABC):
         Subscribe to stepper.move messages.
         """
         pub.subscribe(self.move_to, "stepper.move.begin")
+        pub.subscribe(self.stop_moving, "stepper.stop")
 
     @staticmethod
     def preset_angle(name: str) -> float:

--- a/tests/test_st10_controller.py
+++ b/tests/test_st10_controller.py
@@ -226,12 +226,12 @@ def test_get_step(step: int, response: str, raises: Any, dev: ST10Controller) ->
             assert dev.step == step
 
 
-def test_wait_until_stopped_async(dev: ST10Controller) -> None:
-    """Test the wait_until_stopped_async() method."""
+def test_notify_on_stopped(dev: ST10Controller) -> None:
+    """Test the notify_on_stopped() method."""
     dev.serial.read_until.return_value = b"Z\r"
 
     with patch.object(dev, "_send_string") as ss_mock:
-        dev.wait_until_stopped_async()
+        dev.notify_on_stopped()
         ss_mock.assert_called_once_with("Z")
 
     # As the _SerialReader is not actually running on a separate thread, we have to

--- a/tests/test_st10_controller.py
+++ b/tests/test_st10_controller.py
@@ -7,13 +7,31 @@ from unittest.mock import MagicMock, patch
 import pytest
 from serial import SerialException, SerialTimeoutException
 
-from finesse.hardware.st10_controller import ST10Controller, ST10ControllerError
+from finesse.hardware.st10_controller import (
+    ST10Controller,
+    ST10ControllerError,
+    _SerialReader,
+)
+
+
+class MockSerialReader(_SerialReader):
+    """A mock version of _SerialReader that runs on the main thread."""
+
+    def run(self) -> None:
+        """Override the run method to make the thread do nothing."""
+
+    def read_sync(self) -> str:
+        """Read synchronously (mocked)."""
+        self._process_read()
+        return super().read_sync()
 
 
 @pytest.fixture
+@patch("finesse.hardware.st10_controller._SerialReader", MockSerialReader)
 def dev() -> ST10Controller:
     """A fixture providing an ST10Controller with a patched Serial object."""
     serial = MagicMock()
+    serial.timeout = 5.0
 
     # These functions should all be called, but patch them for now as we test this
     # elsewhere
@@ -23,9 +41,11 @@ def dev() -> ST10Controller:
                 return ST10Controller(serial)
 
 
+@patch("finesse.hardware.st10_controller._SerialReader", MockSerialReader)
 def test_init() -> None:
     """Test __init__()."""
     serial = MagicMock()
+    serial.timeout = 5.0
 
     with patch.object(ST10Controller, "_check_device_id") as check_mock:
         with patch.object(ST10Controller, "stop_moving") as stop_mock:
@@ -39,8 +59,8 @@ def test_init() -> None:
 
 
 def read_mock(dev: ST10Controller, return_value: str):
-    """Patch the _read() method of dev."""
-    return patch.object(dev, "_read", return_value=return_value)
+    """Patch the _read_sync() method of dev."""
+    return patch.object(dev, "_read_sync", return_value=return_value)
 
 
 def test_write(dev: ST10Controller) -> None:
@@ -52,7 +72,7 @@ def test_write(dev: ST10Controller) -> None:
 def test_read_normal(dev: ST10Controller) -> None:
     """Test the _read() method with a valid message."""
     dev.serial.read_until.return_value = b"hello\r"
-    ret = dev._read()
+    ret = dev._read_sync()
     dev.serial.read_until.assert_called_with(b"\r")
     assert ret == "hello"
 
@@ -63,7 +83,7 @@ def test_read_error(dev: ST10Controller) -> None:
     dev.serial.read_until.side_effect = SerialException()
 
     with pytest.raises(SerialException):
-        dev._read()
+        dev._read_sync()
         dev.serial.read_until.assert_called_with(b"\r")
 
 
@@ -71,14 +91,14 @@ def test_read_timed_out(dev: ST10Controller) -> None:
     """Test the _read() method with a timed-out response."""
     dev.serial.read_until.return_value = b""
     with pytest.raises(SerialTimeoutException):
-        dev._read()
+        dev._read_sync()
 
 
 def test_read_non_ascii(dev: ST10Controller) -> None:
     """Test the _read() method with a non-ASCII response."""
     dev.serial.read_until.return_value = b"\xff\r"
     with pytest.raises(ST10ControllerError):
-        dev._read()
+        dev._read_sync()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds the option to interact with the motor controller asynchronously, namely by sending a `pubsub` message when movement has stopped. This feature is needed so that we can run measure scripts, as we need to know that the motor has stopped moving before we issue the command to the EM27 to start recording.

The way the ST10 controller works is that whenever a move command is issued, it adds it to a queue. The controller runs through the commands one by one, waiting for each movement to finish before running the next. We don't actually care about this feature directly as we don't need to run sequences of movements. The `ST` command can be issued to stop the current movement and throw away the rest of the queue. I have used this in a few places to ensure that we don't have to wait for a previous operation to complete before moving.

There is a slightly strange command called "send string", which tells the controller to send the specified message when it has finished all of the movements in its queue. This can therefore be used to establish when the motor has stopped moving. Unlike the existing commands we are using, this message is sent from the controller without a request being issued from the PC. This presented a bit of a problem for the existing design, which relied on explicitly reading from the device when a response was expected, but the send string message can be received at any time once requested. I considered having a separate thread which exclusively waits for these send string messages, but the problem with this is that a) this thread could inadvertently read a response that another function was waiting for and b) some other function could read the send string message while waiting for something else. The solution is to have *all* the reading from the serial device happen in one place in the code which can then decide what to do with it (i.e. send the "motor has stopped" message or send the data to another waiting function). For the synchronous reading case, I implemented this using a `Queue` which is filled with all messages received from the device that don't correspond to the expected send string response.