### PR TITLE
Add codecov to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       env:
         QT_QPA_PLATFORM: offscreen
 
+    - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && success()
+        uses: codecov/codecov-action@v3
+
     - name: Check for documentation errors with MkDocs
       run: |
         poetry run mkdocs build -s

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "*/tests/*”


### PR DESCRIPTION
It would be useful to keep track of code coverage as some portions of the code are relatively untested atm.