### PR TITLE
Refactor OPUS code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "*/tests/*”
+  - "*/tests/*"

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-COMMANDS = ["cancel", "stop", "start", "connect"]
+COMMANDS = ["status", "cancel", "stop", "start", "connect"]
 """The default commands shown for interacting with OPUS."""
 
 
@@ -38,8 +38,7 @@ class OPUSControl(QGroupBox):
         layout = self._create_controls()
         self.setLayout(layout)
 
-        pub.subscribe(self._log_response, "opus.response.command")
-        pub.subscribe(self._log_response, "opus.response.status")
+        pub.subscribe(self._log_response, "opus.response")
         pub.subscribe(self._display_status, "opus.response.status")
         pub.subscribe(self._log_error, "opus.error")
 
@@ -62,10 +61,6 @@ class OPUSControl(QGroupBox):
             QHBoxLayout: The layout with the buttons.
         """
         btn_layout = QVBoxLayout()
-
-        button = QPushButton("Status")
-        button.clicked.connect(self._request_status)  # type: ignore
-        btn_layout.addWidget(button)
 
         for name in self.commands:
             button = QPushButton(name.capitalize())
@@ -139,11 +134,11 @@ class OPUSControl(QGroupBox):
             command: OPUS command to be executed
         """
         self.logger.info(f'Executing command "{command}"')
-        pub.sendMessage("opus.request.command", command=command)
+        pub.sendMessage("opus.request", command=command)
 
     def _request_status(self) -> None:
         self.logger.info("Requesting status")
-        pub.sendMessage("opus.request.status")
+        pub.sendMessage("opus.request", command="status")
 
     def _display_status(
         self, status: int, text: str, error: Optional[tuple[int, str]], url: str

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -38,9 +38,9 @@ class OPUSControl(QGroupBox):
         layout = self._create_controls()
         self.setLayout(layout)
 
-        pub.subscribe(self._log_response, "opus.command.response")
-        pub.subscribe(self._log_response, "opus.status.response")
-        pub.subscribe(self._display_status, "opus.status.response")
+        pub.subscribe(self._log_response, "opus.response.command")
+        pub.subscribe(self._log_response, "opus.response.status")
+        pub.subscribe(self._display_status, "opus.response.status")
         pub.subscribe(self._log_error, "opus.error")
 
     def _create_controls(self) -> QHBoxLayout:
@@ -139,18 +139,18 @@ class OPUSControl(QGroupBox):
             command: OPUS command to be executed
         """
         self.logger.info(f'Executing command "{command}"')
-        pub.sendMessage("opus.command.request", command=command)
+        pub.sendMessage("opus.request.command", command=command)
 
     def _request_status(self) -> None:
         self.logger.info("Requesting status")
-        pub.sendMessage("opus.status.request")
+        pub.sendMessage("opus.request.status")
 
     def _display_status(
         self, status: int, text: str, error: Optional[tuple[int, str]], url: str
     ) -> None:
         """Display the status in the GUI's browser pane.
 
-        This method is a handler for the opus.status.response message, which means that
+        This method is a handler for the opus.response.status message, which means that
         we only reload the page displayed in self.status once the status has already
         been requested! However, the self.status widget is not really necessary (the
         user doesn't need to know how the returned HTML looks), so hopefully we can

--- a/finesse/hardware/dummy_opus.py
+++ b/finesse/hardware/dummy_opus.py
@@ -141,7 +141,7 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         state = self.state_machine.current_state
 
         pub.sendMessage(
-            f"opus.{type}.response",
+            f"opus.response.{type}",
             url="https://example.com",
             status=state.value,
             text=state.name,

--- a/finesse/hardware/dummy_opus.py
+++ b/finesse/hardware/dummy_opus.py
@@ -132,29 +132,6 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         )
         """An object representing the internal state of the device."""
 
-    def _send_response(self, type: str) -> None:
-        """Send a message signalling that a response was received.
-
-        Args:
-            type: Either "status" or "command", indicating what message to send
-        """
-        state = self.state_machine.current_state
-
-        pub.sendMessage(
-            f"opus.response.{type}",
-            url="https://example.com",
-            status=state.value,
-            text=state.name,
-            error=self.last_error.to_tuple(),
-        )
-
-    def request_status(self) -> None:
-        """Request the device's current status."""
-        if self.state_machine.current_state == OPUSStateMachine.idle:
-            self.last_error = OPUSError.NOT_CONNECTED
-
-        self._send_response("status")
-
     def _run_command(self, command: str) -> None:
         """Try to run the specified command.
 
@@ -165,6 +142,7 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         """
         fun = getattr(self.state_machine, command)
 
+        self.last_error = OPUSError.NO_ERROR
         try:
             fun()
         except TransitionNotAllowed:
@@ -173,17 +151,29 @@ class DummyOPUSInterface(OPUSInterfaceBase):
     def request_command(self, command: str) -> None:
         """Execute the specified command on the device.
 
+        Note that we treat "status" as a command, even though it requires a different
+        URL to access.
+
         Args:
             command: The command to run
         """
-        self.last_error = OPUSError.NO_ERROR
-
-        if command in self._COMMAND_ERRORS:
+        if command == "status":
+            if self.state_machine.current_state == OPUSStateMachine.idle:
+                self.last_error = OPUSError.NOT_CONNECTED
+        elif command in self._COMMAND_ERRORS:
             self._run_command(command)
         else:
             self.last_error = OPUSError.UNKNOWN_COMMAND
 
-        self._send_response("command")
+        # Broadcast the response for the command
+        state = self.state_machine.current_state
+        pub.sendMessage(
+            f"opus.response.{command}",
+            url="https://example.com",
+            status=state.value,
+            text=state.name,
+            error=self.last_error.to_tuple(),
+        )
 
     def _measuring_finished(self) -> None:
         """Finish measurement successfully."""

--- a/finesse/hardware/em27_opus.py
+++ b/finesse/hardware/em27_opus.py
@@ -91,16 +91,16 @@ class OPUSInterface(OPUSInterfaceBase):
                 raise OPUSError(f"HTTP status code {response.status_code}")
 
             status: Optional[int] = None
-            text = ""
+            text: Optional[str] = None
             errcode: Optional[int] = None
-            errtext = ""
+            errtext: Optional[str] = None
             soup = BeautifulSoup(response.content, "html.parser")
             for td in soup.find_all("td"):
                 if "id" not in td.attrs:
                     continue
 
                 id = td.attrs["id"]
-                data = td.contents[0]
+                data = td.contents[0] if td.contents else ""
                 if id == "STATUS":
                     status = int(data)
                 elif id == "TEXT":
@@ -112,7 +112,7 @@ class OPUSInterface(OPUSInterfaceBase):
                 else:
                     logging.warning(f"Received unknown ID: {id}")
 
-            if status is None or not text:
+            if status is None or text is None:
                 raise OPUSError("Required tags not found")
             error = None if errcode is None else (errcode, errtext)
         except Exception as e:

--- a/finesse/hardware/em27_opus.py
+++ b/finesse/hardware/em27_opus.py
@@ -125,10 +125,10 @@ class OPUSInterface(OPUSInterfaceBase):
 
     def request_status(self) -> None:
         """Request an update on the device's status."""
-        self.submit_request.emit(STATUS_FILENAME, "opus.status.response")
+        self.submit_request.emit(STATUS_FILENAME, "opus.response.status")
 
     def request_command(self, command: str) -> None:
         """Request that OPUS run the specified command."""
         self.submit_request.emit(
-            f"{COMMAND_FILENAME}?opusrs{command}", "opus.command.response"
+            f"{COMMAND_FILENAME}?opusrs{command}", "opus.response.command"
         )

--- a/finesse/hardware/em27_opus.py
+++ b/finesse/hardware/em27_opus.py
@@ -123,12 +123,18 @@ class OPUSInterface(OPUSInterfaceBase):
             topic, url=response.url, status=cast(int, status), text=text, error=error
         )
 
-    def request_status(self) -> None:
-        """Request an update on the device's status."""
-        self.submit_request.emit(STATUS_FILENAME, "opus.response.status")
-
     def request_command(self, command: str) -> None:
-        """Request that OPUS run the specified command."""
-        self.submit_request.emit(
-            f"{COMMAND_FILENAME}?opusrs{command}", "opus.response.command"
+        """Request that OPUS run the specified command.
+
+        Note that we treat "status" as a command, even though it requires a different
+        URL to access.
+
+        Args:
+            command: Name of command to run
+        """
+        filename = (
+            STATUS_FILENAME
+            if command == "status"
+            else f"{COMMAND_FILENAME}?opusrs{command}"
         )
+        self.submit_request.emit(filename, f"opus.response.{command}")

--- a/finesse/hardware/opus_interface_base.py
+++ b/finesse/hardware/opus_interface_base.py
@@ -12,8 +12,7 @@ class OPUSInterfaceBase(QObject):
     def __init__(self) -> None:
         """Create a new OPUSInterfaceBase."""
         super().__init__()
-        pub.subscribe(self.request_status, "opus.request.status")
-        pub.subscribe(self.request_command, "opus.request.command")
+        pub.subscribe(self.request_command, "opus.request")
 
     def error_occurred(self, exception: BaseException) -> None:
         """Signal that an error occurred."""
@@ -25,10 +24,13 @@ class OPUSInterfaceBase(QObject):
         # Notify listeners
         pub.sendMessage("opus.error", message=str(exception))
 
-    def request_status(self) -> None:
-        """Request an update on the device's status."""
-        raise NotImplementedError("request_status() must be overridden by subclass")
-
     def request_command(self, command: str) -> None:
-        """Request that OPUS run the specified command."""
+        """Request that OPUS run the specified command.
+
+        Note that we treat "status" as a command, even though it requires a different
+        URL to access.
+
+        Args:
+            command: Name of command to run
+        """
         raise NotImplementedError("request_command() must be overridden by subclass")

--- a/finesse/hardware/opus_interface_base.py
+++ b/finesse/hardware/opus_interface_base.py
@@ -12,8 +12,8 @@ class OPUSInterfaceBase(QObject):
     def __init__(self) -> None:
         """Create a new OPUSInterfaceBase."""
         super().__init__()
-        pub.subscribe(self.request_status, "opus.status.request")
-        pub.subscribe(self.request_command, "opus.command.request")
+        pub.subscribe(self.request_status, "opus.request.status")
+        pub.subscribe(self.request_command, "opus.request.command")
 
     def error_occurred(self, exception: BaseException) -> None:
         """Signal that an error occurred."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Configuration for pytest."""
+from unittest.mock import MagicMock
+
+import pytest
+from pubsub import pub
+
+
+@pytest.fixture
+def sendmsg_mock(monkeypatch) -> MagicMock:
+    """Fixture for pub.sendMessage."""
+    mock = MagicMock()
+    monkeypatch.setattr(pub, "sendMessage", mock)
+    return mock

--- a/tests/test_dummy_opus.py
+++ b/tests/test_dummy_opus.py
@@ -56,7 +56,7 @@ def test_request_status(
 
     dev.request_status()
     send_message_mock.assert_called_once_with(
-        "opus.status.response",
+        "opus.response.status",
         url="https://example.com",
         status=state.value,
         text=state.name,
@@ -113,7 +113,7 @@ def test_request_command(
         # Check that the right response message was sent
         state = dev.state_machine.current_state
         send_message_mock.assert_called_once_with(
-            "opus.command.response",
+            "opus.response.command",
             url="https://example.com",
             status=state.value,
             text=state.name,
@@ -129,7 +129,7 @@ def test_request_command_bad_command(
 
     state = dev.state_machine.current_state
     send_message_mock.assert_called_once_with(
-        "opus.command.response",
+        "opus.response.command",
         url="https://example.com",
         status=state.value,
         text=state.name,

--- a/tests/test_dummy_opus.py
+++ b/tests/test_dummy_opus.py
@@ -54,7 +54,7 @@ def test_request_status(
     dev.last_error = error
     dev.state_machine.current_state = state
 
-    dev.request_status()
+    dev.request_command("status")
     send_message_mock.assert_called_once_with(
         "opus.response.status",
         url="https://example.com",
@@ -113,7 +113,7 @@ def test_request_command(
         # Check that the right response message was sent
         state = dev.state_machine.current_state
         send_message_mock.assert_called_once_with(
-            "opus.response.command",
+            f"opus.response.{command}",
             url="https://example.com",
             status=state.value,
             text=state.name,
@@ -129,7 +129,7 @@ def test_request_command_bad_command(
 
     state = dev.state_machine.current_state
     send_message_mock.assert_called_once_with(
-        "opus.response.command",
+        "opus.response.non_existent_command",
         url="https://example.com",
         status=state.value,
         text=state.name,

--- a/tests/test_em27_opus.py
+++ b/tests/test_em27_opus.py
@@ -17,7 +17,7 @@ def opus(mock) -> OPUSInterface:
 def test_request_status(opus: OPUSInterface) -> None:
     """Test OPUSInterface's request_status() method."""
     with patch.object(opus, "submit_request") as request_mock:
-        opus.request_status()
+        opus.request_command("status")
         request_mock.emit.assert_called_once_with("stat.htm", "opus.response.status")
 
 
@@ -26,7 +26,7 @@ def test_request_command(opus: OPUSInterface) -> None:
     with patch.object(opus, "submit_request") as request_mock:
         opus.request_command("hello")
         request_mock.emit.assert_called_once_with(
-            "cmd.htm?opusrshello", "opus.response.command"
+            "cmd.htm?opusrshello", "opus.response.hello"
         )
 
 

--- a/tests/test_em27_opus.py
+++ b/tests/test_em27_opus.py
@@ -18,7 +18,7 @@ def test_request_status(opus: OPUSInterface) -> None:
     """Test OPUSInterface's request_status() method."""
     with patch.object(opus, "submit_request") as request_mock:
         opus.request_status()
-        request_mock.emit.assert_called_once_with("stat.htm", "opus.status.response")
+        request_mock.emit.assert_called_once_with("stat.htm", "opus.response.status")
 
 
 def test_request_command(opus: OPUSInterface) -> None:
@@ -26,7 +26,7 @@ def test_request_command(opus: OPUSInterface) -> None:
     with patch.object(opus, "submit_request") as request_mock:
         opus.request_command("hello")
         request_mock.emit.assert_called_once_with(
-            "cmd.htm?opusrshello", "opus.command.response"
+            "cmd.htm?opusrshello", "opus.response.command"
         )
 
 

--- a/tests/test_st10_controller.py
+++ b/tests/test_st10_controller.py
@@ -5,7 +5,6 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pubsub import pub
 from serial import SerialException, SerialTimeoutException
 
 from finesse.hardware.st10_controller import (
@@ -72,25 +71,17 @@ def test_init() -> None:
                 home_mock.assert_called_once()
 
 
-def test_send_move_end_message(dev: ST10Controller) -> None:
+def test_send_move_end_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
     """Test the _send_move_end_message() method."""
-    handler = MagicMock()
-    pub.subscribe(handler, "stepper.move.end")
     dev._send_move_end_message()
-    handler.assert_called_once()
+    sendmsg_mock.assert_called_once_with("stepper.move.end")
 
 
-def test_send_error_message(dev: ST10Controller) -> None:
+def test_send_error_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
     """Test the _send_error_message() method."""
-    has_run = False
-
-    def handler(error: BaseException):
-        nonlocal has_run
-        has_run = True
-
-    pub.subscribe(handler, "stepper.error")
-    dev._send_error_message(Exception())
-    assert has_run
+    error = Exception()
+    dev._send_error_message(error)
+    sendmsg_mock.assert_called_once_with("stepper.error", error=error)
 
 
 def read_mock(dev: ST10Controller, return_value: str):


### PR DESCRIPTION
I noticed a small issue with the current OPUS code (both the dummy version and the "real" one) after my last PR had been reviewed, but I thought it would be best to make a new PR for it as it involves a few small changes all over.

Currently, when the response to a command is received from OPUS, we send a `"opus.command.response"` message. The problem is that information about *which* command has been executed is not included, which makes it annoying to work with. I decided to use separate messages for each command of the form `f"opus.response.{command}`, which allows the users of the interface to subscribe to responses from specific commands if desired (or they can subscribe to `opus.response` to get all of them). In addition, I've turned `"status"` into a regular command like the others. In a sense it is special, as we have to request a separate URL from OPUS and it behaves slightly differently, but this isn't a distinction the frontend needs to care about.

I also added a test for the OPUS HTML parser and fixed some unrelated stepper motor tests which were giving spurious failures.