### PR TITLE
Set size policies of EM27 SOH Monitor columns to show full sensor values

### DIFF
--- a/finesse/gui/interferometer_monitor.py
+++ b/finesse/gui/interferometer_monitor.py
@@ -109,9 +109,15 @@ class EM27Monitor(QGroupBox):
         """
         if prop.name not in self._val_lineedits:
             prop_label = QLabel(prop.name)
+            prop_label.setSizePolicy(
+                QSizePolicy.Fixed, QSizePolicy.Fixed  # type: ignore
+            )
             val_lineedit = QLineEdit()
             val_lineedit.setReadOnly(True)
             val_lineedit.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            val_lineedit.setSizePolicy(
+                QSizePolicy.MinimumExpanding, QSizePolicy.Fixed  # type: ignore
+            )
 
             self._val_lineedits[prop.name] = val_lineedit
 


### PR DESCRIPTION
This PR contains a fix to set the column widths of the EM27 SOH Monitor panel, so that the full sensor values are shown, regardless of the window's size.

This is achieved by setting the `QSizePolicy` attributes of the `QLabel`s and `QLineEdits` in each row.

Closes #122.