### PR TITLE
Add `SerialManager` class for opening/closing devices on backend

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -23,5 +23,11 @@ BAUDRATES = (4800, 9600, 19200, 38400, 57600, 115200)
 DEFAULT_SCRIPT_PATH = Path.home()
 """The default path to search for script files in."""
 
+STEPPER_MOTOR_TOPIC = "stepper_motor"
+"""The topic name to use for stepper motor-related messages."""
+
+TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
+"""The topic name to user for temperature controller-related messages."""
+
 OPUS_IP = "10.10.0.2"
 """The IP address of the machine running the OPUS software."""

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -20,6 +20,9 @@ ANGLE_PRESETS = {
 BAUDRATES = (4800, 9600, 19200, 38400, 57600, 115200)
 """The valid baud rates for use by the GUI."""
 
+DUMMY_DEVICE_PORT = "Dummy"
+"""The port name to display for dummy serial devices."""
+
 DEFAULT_SCRIPT_PATH = Path.home()
 """The default path to search for script files in."""
 

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -12,7 +12,7 @@ from pubsub import pub
 from PySide6.QtWidgets import QWidget
 from schema import And, Or, Schema, SchemaError
 
-from ...config import ANGLE_PRESETS
+from ...config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 from ..error_message import show_error_message
 
 
@@ -33,7 +33,7 @@ class Measurement:
     def run(self) -> None:
         """A placeholder function for recording multiple measurements."""
         # Move the mirror to the correct location
-        pub.sendMessage("stepper.move.begin", target=self.angle)
+        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.move.begin", target=self.angle)
 
         # Take the recordings
         logging.info(f"Recording {self.measurements} measurements")

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
     QSpinBox,
 )
 
-from ..config import ANGLE_PRESETS
+from ..config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 
 
 class StepperMotorControl(QGroupBox):
@@ -55,7 +55,7 @@ class StepperMotorControl(QGroupBox):
     def _preset_clicked(self, btn: QPushButton) -> None:
         """Move the stepper motor to preset position."""
         # If the motor is already moving, stop it now
-        pub.sendMessage("stepper.stop")
+        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.stop")
 
         target = float(self.angle.value()) if btn is self.goto else btn.text().lower()
-        pub.sendMessage("stepper.move.begin", target=target)
+        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.move.begin", target=target)

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -8,16 +8,13 @@ if "--dummy-em27" in sys.argv:
 else:
     from .opus.em27 import OPUSInterface  # type: ignore
 
-from .stepper_motor.dummy import DummyStepperMotor
+from .stepper_motor import create_stepper_motor_serial_manager
 
-stepper: DummyStepperMotor
 opus: OPUSInterface
 
 
 def _init_hardware():
-    global stepper, opus
-    # TODO: Replace with a real stepper motor device
-    stepper = DummyStepperMotor(3600)
+    global opus
 
     opus = OPUSInterface()
 
@@ -29,3 +26,5 @@ def _stop_hardware():
 
 pub.subscribe(_init_hardware, "window.opened")
 pub.subscribe(_stop_hardware, "window.closed")
+
+create_stepper_motor_serial_manager()

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -9,6 +9,7 @@ else:
     from .opus.em27 import OPUSInterface  # type: ignore
 
 from .stepper_motor import create_stepper_motor_serial_manager
+from .temperature import create_temperature_controller_serial_managers
 
 opus: OPUSInterface
 
@@ -28,3 +29,4 @@ pub.subscribe(_init_hardware, "window.opened")
 pub.subscribe(_stop_hardware, "window.closed")
 
 create_stepper_motor_serial_manager()
+create_temperature_controller_serial_managers()

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -30,3 +30,6 @@ pub.subscribe(_stop_hardware, "window.closed")
 
 create_stepper_motor_serial_manager()
 create_temperature_controller_serial_managers()
+
+# HACK: Temporary workaround so that we can still use the dummy device for now
+pub.sendMessage("serial.stepper_motor.open", port="Dummy", baudrate=-1)

--- a/finesse/hardware/device_base.py
+++ b/finesse/hardware/device_base.py
@@ -1,0 +1,14 @@
+"""Provides a base class for all serial devices (and mock devices)."""
+from abc import ABC, abstractmethod
+
+
+class DeviceBase(ABC):
+    """A base class for all devices which mandates that they have a close() method."""
+
+    def __del__(self) -> None:
+        """Close the device on deletion."""
+        self.close()
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the connection to the device."""

--- a/finesse/hardware/serial_manager.py
+++ b/finesse/hardware/serial_manager.py
@@ -1,0 +1,78 @@
+"""Common functionality for opening and closing USB serial devices."""
+from collections.abc import Callable
+
+from pubsub import pub
+from serial import Serial
+
+from ..config import DUMMY_DEVICE_PORT
+from .device_base import DeviceBase
+
+
+class SerialManager:
+    """A class for managing the opening and closing of USB serial devices.
+
+    When the object receives the "serial.{name}.open" message, a new instance of the
+    device will be created, using the serial argument. If the argument is None, a dummy
+    device will be called instead. When the "serial.{name}.open" message is received,
+    the device will be closed.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        device_ctor: Callable[[Serial], DeviceBase],
+        dummy_device_ctor: Callable[[], DeviceBase],
+    ) -> None:
+        """Create a new SerialManager object.
+
+        Args:
+            name: A unique name for the device to be used in pubsub topic names
+            device_ctor: A constructor for the real device (accepting a Serial object)
+            dummy_device_ctor: A constructor for the dummy device
+        """
+        self.name = name
+        self.device: DeviceBase
+        self.device_ctor = device_ctor
+        self.dummy_device_ctor = dummy_device_ctor
+
+        # Listen for open events for this device
+        pub.subscribe(self._open, f"serial.{name}.open")
+
+    def _open(self, port: str, baudrate: int) -> None:
+        """Open the device.
+
+        If the port is "Dummy", then a dummy device will be created.
+
+        Args:
+            port: The serial port to use
+            baudrate: The baudrate to use
+        """
+        try:
+            if port == DUMMY_DEVICE_PORT:
+                self.device = self.dummy_device_ctor()
+            else:
+                serial = Serial(port, baudrate)
+                self.device = self.device_ctor(serial)
+        except Exception as error:
+            pub.sendMessage(f"serial.{self.name}.error", error=error)
+        else:
+            # Listen for close events for this device
+            pub.subscribe(self._close, f"serial.{self.name}.close")
+
+            # For now, assume all errors are fatal so close the port
+            pub.subscribe(self._send_close_message, f"serial.{self.name}.error")
+
+            # Signal that serial device is now open
+            pub.sendMessage(f"serial.{self.name}.opened")
+
+    def _send_close_message(self, error: BaseException) -> None:
+        pub.sendMessage(f"serial.{self.name}.close")
+
+    def _close(self) -> None:
+        """Close the device.
+
+        It is ensured that devices will only be closed once.
+        """
+        pub.unsubscribe(self._close, f"serial.{self.name}.close")
+        self.device.close()
+        del self.device

--- a/finesse/hardware/stepper_motor/__init__.py
+++ b/finesse/hardware/stepper_motor/__init__.py
@@ -1,1 +1,17 @@
 """Code for interfacing with stepper motors."""
+from functools import partial
+
+from ...config import STEPPER_MOTOR_TOPIC
+from ..serial_manager import SerialManager
+from .dummy import DummyStepperMotor
+from .st10_controller import ST10Controller
+
+_serial_manager: SerialManager
+
+
+def create_stepper_motor_serial_manager() -> None:
+    """Create a SerialManager for the stepper motor device."""
+    global _serial_manager
+    _serial_manager = SerialManager(
+        STEPPER_MOTOR_TOPIC, ST10Controller, partial(DummyStepperMotor, 3600)
+    )

--- a/finesse/hardware/stepper_motor/__init__.py
+++ b/finesse/hardware/stepper_motor/__init__.py
@@ -2,7 +2,7 @@
 from functools import partial
 
 from ...config import STEPPER_MOTOR_TOPIC
-from ..serial_manager import SerialManager
+from ..serial_manager import SerialManager, make_device_factory
 from .dummy import DummyStepperMotor
 from .st10_controller import ST10Controller
 
@@ -13,5 +13,6 @@ def create_stepper_motor_serial_manager() -> None:
     """Create a SerialManager for the stepper motor device."""
     global _serial_manager
     _serial_manager = SerialManager(
-        STEPPER_MOTOR_TOPIC, ST10Controller, partial(DummyStepperMotor, 3600)
+        STEPPER_MOTOR_TOPIC,
+        make_device_factory(ST10Controller, partial(DummyStepperMotor, 3600)),
     )

--- a/finesse/hardware/stepper_motor/dummy.py
+++ b/finesse/hardware/stepper_motor/dummy.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from pubsub import pub
 
+from ...config import STEPPER_MOTOR_TOPIC
 from .stepper_motor_base import StepperMotorBase
 
 
@@ -67,4 +68,4 @@ class DummyStepperMotor(StepperMotorBase):
 
         As this is a dummy class, this completes immediately.
         """
-        pub.sendMessage("stepper.move.end")
+        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.move.end")

--- a/finesse/hardware/stepper_motor/dummy.py
+++ b/finesse/hardware/stepper_motor/dummy.py
@@ -24,6 +24,9 @@ class DummyStepperMotor(StepperMotorBase):
 
         super().__init__()
 
+    def close(self) -> None:
+        """Shut down the device."""
+
     @property
     def steps_per_rotation(self) -> int:
         """The number of steps that correspond to a full rotation."""

--- a/finesse/hardware/stepper_motor/st10_controller.py
+++ b/finesse/hardware/stepper_motor/st10_controller.py
@@ -15,6 +15,7 @@ from pubsub import pub
 from PySide6.QtCore import QThread, Signal, Slot
 from serial import Serial, SerialException, SerialTimeoutException
 
+from ...config import STEPPER_MOTOR_TOPIC
 from .stepper_motor_base import StepperMotorBase
 
 
@@ -240,11 +241,11 @@ class ST10Controller(StepperMotorBase):
 
     @Slot()
     def _send_move_end_message(self) -> None:
-        pub.sendMessage("stepper.move.end")
+        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.move.end")
 
     @Slot()
     def _send_error_message(self, error: BaseException) -> None:
-        pub.sendMessage("stepper.error", error=error)
+        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.error", error=error)
 
     def _check_device_id(self) -> None:
         """Check that the ID is the correct one for an ST10.

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -1,13 +1,14 @@
 """Provides the base class for stepper motor implementations."""
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Optional, Union
 
 from pubsub import pub
 
 from ...config import ANGLE_PRESETS
+from ..device_base import DeviceBase
 
 
-class StepperMotorBase(ABC):
+class StepperMotorBase(DeviceBase):
     """A base class for stepper motor implementations."""
 
     def __init__(self) -> None:

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from pubsub import pub
 
-from ...config import ANGLE_PRESETS
+from ...config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 from ..device_base import DeviceBase
 
 
@@ -16,9 +16,11 @@ class StepperMotorBase(DeviceBase):
 
         Subscribe to stepper.move messages.
         """
-        pub.subscribe(self.move_to, "stepper.move.begin")
-        pub.subscribe(self.stop_moving, "stepper.stop")
-        pub.subscribe(self.notify_on_stopped, "stepper.notify_on_stopped")
+        pub.subscribe(self.move_to, f"serial.{STEPPER_MOTOR_TOPIC}.move.begin")
+        pub.subscribe(self.stop_moving, f"serial.{STEPPER_MOTOR_TOPIC}.stop")
+        pub.subscribe(
+            self.notify_on_stopped, f"serial.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"
+        )
 
     @staticmethod
     def preset_angle(name: str) -> float:

--- a/finesse/hardware/temperature/__init__.py
+++ b/finesse/hardware/temperature/__init__.py
@@ -1,1 +1,25 @@
 """This module contains interfaces for temperature-related hardware."""
+from functools import partial
+
+from ...config import TEMPERATURE_CONTROLLER_TOPIC
+from ..serial_manager import SerialManager
+from .dummy_temperature_controller import DummyTemperatureController
+from .tc4820 import TC4820
+
+_serial_manager_hot_bb: SerialManager
+_serial_manager_cold_bb: SerialManager
+
+
+def _create_serial_manager(name: str) -> SerialManager:
+    return SerialManager(
+        f"{TEMPERATURE_CONTROLLER_TOPIC}.{name}",
+        partial(TC4820, name),
+        partial(DummyTemperatureController, name),
+    )
+
+
+def create_temperature_controller_serial_managers() -> None:
+    """Create SerialManagers for the cold and hot black body temperature controllers."""
+    global _serial_manager_cold_bb, _serial_manager_hot_bb
+    _serial_manager_hot_bb = _create_serial_manager("hot_bb")
+    _serial_manager_cold_bb = _create_serial_manager("cold_bb")

--- a/finesse/hardware/temperature/__init__.py
+++ b/finesse/hardware/temperature/__init__.py
@@ -2,7 +2,7 @@
 from functools import partial
 
 from ...config import TEMPERATURE_CONTROLLER_TOPIC
-from ..serial_manager import SerialManager
+from ..serial_manager import SerialManager, make_device_factory
 from .dummy_temperature_controller import DummyTemperatureController
 from .tc4820 import TC4820
 
@@ -13,8 +13,9 @@ _serial_manager_cold_bb: SerialManager
 def _create_serial_manager(name: str) -> SerialManager:
     return SerialManager(
         f"{TEMPERATURE_CONTROLLER_TOPIC}.{name}",
-        partial(TC4820, name),
-        partial(DummyTemperatureController, name),
+        make_device_factory(
+            partial(TC4820, name), partial(DummyTemperatureController, name)
+        ),
     )
 
 

--- a/finesse/hardware/temperature/dummy_temperature_controller.py
+++ b/finesse/hardware/temperature/dummy_temperature_controller.py
@@ -47,6 +47,9 @@ class DummyTemperatureController(TemperatureControllerBase):
 
         super().__init__(name)
 
+    def close(self) -> None:
+        """Shut down the device."""
+
     @property
     def temperature(self) -> Decimal:
         """The current temperature reported by the device."""

--- a/finesse/hardware/temperature/tc4820.py
+++ b/finesse/hardware/temperature/tc4820.py
@@ -47,6 +47,10 @@ class TC4820(TemperatureControllerBase):
 
         super().__init__(name)
 
+    def close(self) -> None:
+        """Shut down the device."""
+        self.serial.close()
+
     @staticmethod
     def create(
         port: str,

--- a/finesse/hardware/temperature/temperature_controller_base.py
+++ b/finesse/hardware/temperature/temperature_controller_base.py
@@ -1,11 +1,13 @@
 """Provides a base class for temperature controller devices or mock devices."""
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from decimal import Decimal
 
 from pubsub import pub
 
+from ..device_base import DeviceBase
 
-class TemperatureControllerBase(ABC):
+
+class TemperatureControllerBase(DeviceBase):
     """The base class for temperature controller devices or mock devices."""
 
     def __init__(self, name: str) -> None:

--- a/finesse/hardware/temperature/temperature_controller_base.py
+++ b/finesse/hardware/temperature/temperature_controller_base.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from pubsub import pub
 
+from ...config import TEMPERATURE_CONTROLLER_TOPIC
 from ..device_base import DeviceBase
 
 
@@ -20,9 +21,13 @@ class TemperatureControllerBase(DeviceBase):
         """
         super().__init__()
         self.name = name
-        pub.subscribe(self.request_properties, f"temperature_controller.{name}.request")
         pub.subscribe(
-            self.change_set_point, f"temperature_controller.{name}.change_set_point"
+            self.request_properties,
+            f"serial.{TEMPERATURE_CONTROLLER_TOPIC}.{name}.request",
+        )
+        pub.subscribe(
+            self.change_set_point,
+            f"serial.{TEMPERATURE_CONTROLLER_TOPIC}.{name}.change_set_point",
         )
 
     def request_properties(self) -> None:
@@ -32,7 +37,8 @@ class TemperatureControllerBase(DeviceBase):
             properties[prop] = getattr(self, prop)
 
         pub.sendMessage(
-            f"temperature_controller.{self.name}.response", properties=properties
+            f"serial.{TEMPERATURE_CONTROLLER_TOPIC}.{self.name}.response",
+            properties=properties,
         )
 
     def change_set_point(self, temperature: Decimal) -> None:

--- a/tests/hardware/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/stepper_motor/test_st10_controller.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from serial import SerialException, SerialTimeoutException
 
+from finesse.config import STEPPER_MOTOR_TOPIC
 from finesse.hardware.stepper_motor.st10_controller import (
     ST10Controller,
     ST10ControllerError,
@@ -80,14 +81,16 @@ def test_close(dev: ST10Controller) -> None:
 def test_send_move_end_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
     """Test the _send_move_end_message() method."""
     dev._send_move_end_message()
-    sendmsg_mock.assert_called_once_with("stepper.move.end")
+    sendmsg_mock.assert_called_once_with(f"serial.{STEPPER_MOTOR_TOPIC}.move.end")
 
 
 def test_send_error_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
     """Test the _send_error_message() method."""
     error = Exception()
     dev._send_error_message(error)
-    sendmsg_mock.assert_called_once_with("stepper.error", error=error)
+    sendmsg_mock.assert_called_once_with(
+        f"serial.{STEPPER_MOTOR_TOPIC}.error", error=error
+    )
 
 
 def read_mock(dev: ST10Controller, return_value: str):

--- a/tests/hardware/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/stepper_motor/test_st10_controller.py
@@ -71,6 +71,12 @@ def test_init() -> None:
                 home_mock.assert_called_once()
 
 
+def test_close(dev: ST10Controller) -> None:
+    """Test the close() method."""
+    dev.close()
+    dev.serial.close.assert_called_once_with()
+
+
 def test_send_move_end_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
     """Test the _send_move_end_message() method."""
     dev._send_move_end_message()

--- a/tests/hardware/temperature/test_tc4820.py
+++ b/tests/hardware/temperature/test_tc4820.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_mock import MockerFixture
 from serial import SerialException
 
+from finesse.config import TEMPERATURE_CONTROLLER_TOPIC
 from finesse.hardware.temperature.tc4820 import TC4820, MalformedMessageError
 
 
@@ -25,10 +26,11 @@ def test_init(name: str, subscribe_mock: MagicMock) -> None:
     dev = TC4820(name, MagicMock())
     assert dev.max_attempts == 3
     subscribe_mock.assert_any_call(
-        dev.request_properties, f"temperature_controller.{name}.request"
+        dev.request_properties, f"serial.{TEMPERATURE_CONTROLLER_TOPIC}.{name}.request"
     )
     subscribe_mock.assert_any_call(
-        dev.change_set_point, f"temperature_controller.{name}.change_set_point"
+        dev.change_set_point,
+        f"serial.{TEMPERATURE_CONTROLLER_TOPIC}.{name}.change_set_point",
     )
 
 
@@ -45,7 +47,8 @@ def test_request_properties(dev: TC4820, sendmsg_mock: MagicMock) -> None:
         mock_int.return_value = 0
         dev.request_properties()
         sendmsg_mock.assert_called_once_with(
-            "temperature_controller.device.response", properties=expected
+            f"serial.{TEMPERATURE_CONTROLLER_TOPIC}.device.response",
+            properties=expected,
         )
 
 

--- a/tests/hardware/test_serial_manager.py
+++ b/tests/hardware/test_serial_manager.py
@@ -6,7 +6,7 @@ from pubsub import pub
 from serial import SerialException
 
 from finesse.config import DUMMY_DEVICE_PORT
-from finesse.hardware.serial_manager import SerialManager
+from finesse.hardware.serial_manager import SerialManager, make_device_factory
 
 
 @pytest.fixture
@@ -17,24 +17,43 @@ def unsubscribe_mock(monkeypatch) -> MagicMock:
     return mock
 
 
-def test_init(subscribe_mock: MagicMock) -> None:
-    """Test SerialManager's constructor."""
-    manager = SerialManager("my_device", MagicMock(), MagicMock())
-    subscribe_mock.assert_any_call(manager._open, "serial.my_device.open")
-
-
 @patch("finesse.hardware.serial_manager.Serial")
-def test_open_real_success(
-    serial_mock: Mock, sendmsg_mock: MagicMock, subscribe_mock: MagicMock
-) -> None:
-    """Test the _open() method with a real serial device that opens successfully."""
+def test_make_device_factory_real(serial_mock: Mock) -> None:
+    """Test the make_device_factory() function when constructing a real device."""
     serial = MagicMock()
     serial_mock.return_value = serial
 
-    device_ctor = MagicMock()
-    manager = SerialManager("my_device", device_ctor, MagicMock())
+    device_factory = MagicMock()
+    device_factory.return_value = "MAGIC"
+    create_device = make_device_factory(device_factory, MagicMock())
+    assert create_device("COM1", 1234) == "MAGIC"
+    serial_mock.assert_called_once_with("COM1", 1234)
+    device_factory.assert_called_once_with(serial)
+
+
+def test_make_device_factory_dummy() -> None:
+    """Test the make_device_factory() function when constructing a dummy device."""
+    dummy_device_factory = MagicMock()
+    dummy_device_factory.return_value = "MAGIC"
+    create_device = make_device_factory(MagicMock(), dummy_device_factory)
+    assert create_device(DUMMY_DEVICE_PORT, 1234) == "MAGIC"
+    dummy_device_factory.assert_called_once_with()
+
+
+def test_init(subscribe_mock: MagicMock) -> None:
+    """Test SerialManager's constructor."""
+    device_factory = MagicMock()
+    manager = SerialManager("my_device", device_factory)
+    assert manager.device_factory == device_factory
+    subscribe_mock.assert_any_call(manager._open, "serial.my_device.open")
+
+
+def test_open_real_success(sendmsg_mock: MagicMock, subscribe_mock: MagicMock) -> None:
+    """Test the _open() method with a device that opens successfully."""
+    device_factory = MagicMock()
+    manager = SerialManager("my_device", device_factory)
     manager._open("COM1", 1234)
-    device_ctor.assert_called_once_with(serial)
+    device_factory.assert_called_once_with("COM1", 1234)
     subscribe_mock.assert_any_call(manager._close, "serial.my_device.close")
     subscribe_mock.assert_any_call(
         manager._send_close_message, "serial.my_device.error"
@@ -42,41 +61,28 @@ def test_open_real_success(
     sendmsg_mock.assert_any_call("serial.my_device.opened")
 
 
-@patch("finesse.hardware.serial_manager.Serial")
-def test_open_real_fail(serial_mock: Mock, sendmsg_mock: MagicMock) -> None:
-    """Test the _open() method with a real serial device that fails to open."""
+def test_open_real_fail(sendmsg_mock: MagicMock) -> None:
+    """Test the _open() method with a device that fails to open."""
+    device_factory = MagicMock()
     error = SerialException()
-    serial_mock.side_effect = error
+    device_factory.side_effect = error
 
-    manager = SerialManager("my_device", MagicMock(), MagicMock())
+    manager = SerialManager("my_device", device_factory)
     manager._open("COM1", 1234)
     sendmsg_mock.assert_called_once_with("serial.my_device.error", error=error)
 
 
-def test_open_dummy(sendmsg_mock: MagicMock, subscribe_mock: MagicMock) -> None:
-    """Test the _open() method with a dummy serial device."""
-    dummy_device_ctor = MagicMock()
-    manager = SerialManager("my_device", MagicMock(), dummy_device_ctor)
-    manager._open(DUMMY_DEVICE_PORT, 1234)
-    dummy_device_ctor.assert_called_once_with()
-    subscribe_mock.assert_any_call(manager._close, "serial.my_device.close")
-    subscribe_mock.assert_any_call(
-        manager._send_close_message, "serial.my_device.error"
-    )
-    sendmsg_mock.assert_any_call("serial.my_device.opened")
-
-
 def test_close(unsubscribe_mock: MagicMock) -> None:
     """Test the _close() method."""
-    dummy_device_ctor = MagicMock()
-    device_mock = MagicMock()
-    dummy_device_ctor.return_value = device_mock
-    manager = SerialManager("my_device", MagicMock(), dummy_device_ctor)
+    device_factory = MagicMock()
+    device = MagicMock()
+    device_factory.return_value = device
+    manager = SerialManager("my_device", device_factory)
     manager._open(DUMMY_DEVICE_PORT, 1234)
     manager._close()
 
     # Check the device was closed
-    device_mock.close.assert_called_once_with()
+    device.close.assert_called_once_with()
 
     # Check manager has unsubscribed from future close events
     unsubscribe_mock.assert_any_call(manager._close, "serial.my_device.close")

--- a/tests/hardware/test_serial_manager.py
+++ b/tests/hardware/test_serial_manager.py
@@ -1,0 +1,82 @@
+"""Tests for SerialManager."""
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from pubsub import pub
+from serial import SerialException
+
+from finesse.config import DUMMY_DEVICE_PORT
+from finesse.hardware.serial_manager import SerialManager
+
+
+@pytest.fixture
+def unsubscribe_mock(monkeypatch) -> MagicMock:
+    """Fixture for pub.subscribe."""
+    mock = MagicMock()
+    monkeypatch.setattr(pub, "unsubscribe", mock)
+    return mock
+
+
+def test_init(subscribe_mock: MagicMock) -> None:
+    """Test SerialManager's constructor."""
+    manager = SerialManager("my_device", MagicMock(), MagicMock())
+    subscribe_mock.assert_any_call(manager._open, "serial.my_device.open")
+
+
+@patch("finesse.hardware.serial_manager.Serial")
+def test_open_real_success(
+    serial_mock: Mock, sendmsg_mock: MagicMock, subscribe_mock: MagicMock
+) -> None:
+    """Test the _open() method with a real serial device that opens successfully."""
+    serial = MagicMock()
+    serial_mock.return_value = serial
+
+    device_ctor = MagicMock()
+    manager = SerialManager("my_device", device_ctor, MagicMock())
+    manager._open("COM1", 1234)
+    device_ctor.assert_called_once_with(serial)
+    subscribe_mock.assert_any_call(manager._close, "serial.my_device.close")
+    subscribe_mock.assert_any_call(
+        manager._send_close_message, "serial.my_device.error"
+    )
+    sendmsg_mock.assert_any_call("serial.my_device.opened")
+
+
+@patch("finesse.hardware.serial_manager.Serial")
+def test_open_real_fail(serial_mock: Mock, sendmsg_mock: MagicMock) -> None:
+    """Test the _open() method with a real serial device that fails to open."""
+    error = SerialException()
+    serial_mock.side_effect = error
+
+    manager = SerialManager("my_device", MagicMock(), MagicMock())
+    manager._open("COM1", 1234)
+    sendmsg_mock.assert_called_once_with("serial.my_device.error", error=error)
+
+
+def test_open_dummy(sendmsg_mock: MagicMock, subscribe_mock: MagicMock) -> None:
+    """Test the _open() method with a dummy serial device."""
+    dummy_device_ctor = MagicMock()
+    manager = SerialManager("my_device", MagicMock(), dummy_device_ctor)
+    manager._open(DUMMY_DEVICE_PORT, 1234)
+    dummy_device_ctor.assert_called_once_with()
+    subscribe_mock.assert_any_call(manager._close, "serial.my_device.close")
+    subscribe_mock.assert_any_call(
+        manager._send_close_message, "serial.my_device.error"
+    )
+    sendmsg_mock.assert_any_call("serial.my_device.opened")
+
+
+def test_close(unsubscribe_mock: MagicMock) -> None:
+    """Test the _close() method."""
+    dummy_device_ctor = MagicMock()
+    device_mock = MagicMock()
+    dummy_device_ctor.return_value = device_mock
+    manager = SerialManager("my_device", MagicMock(), dummy_device_ctor)
+    manager._open(DUMMY_DEVICE_PORT, 1234)
+    manager._close()
+
+    # Check the device was closed
+    device_mock.close.assert_called_once_with()
+
+    # Check manager has unsubscribed from future close events
+    unsubscribe_mock.assert_any_call(manager._close, "serial.my_device.close")

--- a/tests/hardware/test_serial_manager_creation.py
+++ b/tests/hardware/test_serial_manager_creation.py
@@ -28,3 +28,38 @@ def test_stepper_motor(
     _serial_manager._open("COM1", 1234)
     serial_mock.assert_called_once_with("COM1", 1234)
     st10_mock.assert_called_once_with(serial)
+
+
+@patch("finesse.hardware.temperature.DummyTemperatureController")
+@patch("finesse.hardware.temperature.TC4820")
+@patch("finesse.hardware.serial_manager.Serial")
+def test_tc4820(
+    serial_mock: Mock, tc4820_mock: Mock, dummy_mock: Mock, subscribe_mock: Mock
+) -> None:
+    """Test for the two TC4820 SerialManagers."""
+    serial = MagicMock()
+    serial_mock.return_value = serial
+
+    from finesse.hardware.temperature import (
+        create_temperature_controller_serial_managers,
+    )
+
+    create_temperature_controller_serial_managers()
+    from finesse.hardware.temperature import (
+        _serial_manager_cold_bb,
+        _serial_manager_hot_bb,
+    )
+
+    # Check the dummy devices are created
+    _serial_manager_cold_bb._open(DUMMY_DEVICE_PORT, 1234)
+    dummy_mock.assert_called_once()
+    dummy_mock.reset_mock()
+    _serial_manager_hot_bb._open(DUMMY_DEVICE_PORT, 1234)
+    dummy_mock.assert_called_once()
+
+    # Check the real devices are created
+    _serial_manager_cold_bb._open("COM1", 1234)
+    tc4820_mock.assert_called_once()
+    tc4820_mock.reset_mock()
+    _serial_manager_hot_bb._open("COM1", 1234)
+    tc4820_mock.assert_called_once()

--- a/tests/hardware/test_serial_manager_creation.py
+++ b/tests/hardware/test_serial_manager_creation.py
@@ -1,0 +1,30 @@
+"""Test that SerialManagers for the different devices are set up correctly."""
+from unittest.mock import MagicMock, Mock, patch
+
+from finesse.config import DUMMY_DEVICE_PORT, STEPPER_MOTOR_TOPIC
+
+
+@patch("finesse.hardware.stepper_motor.DummyStepperMotor")
+@patch("finesse.hardware.stepper_motor.ST10Controller")
+@patch("finesse.hardware.serial_manager.Serial")
+def test_stepper_motor(
+    serial_mock: Mock, st10_mock: Mock, dummy_mock: Mock, subscribe_mock: Mock
+) -> None:
+    """Test for the stepper motor SerialManager."""
+    from finesse.hardware.stepper_motor import create_stepper_motor_serial_manager
+
+    create_stepper_motor_serial_manager()
+    from finesse.hardware.stepper_motor import _serial_manager
+
+    assert _serial_manager.name == STEPPER_MOTOR_TOPIC
+
+    # Check the dummy device is created
+    _serial_manager._open(DUMMY_DEVICE_PORT, 1234)
+    dummy_mock.assert_called_once()
+
+    # Check the real device is created
+    serial = MagicMock()
+    serial_mock.return_value = serial
+    _serial_manager._open("COM1", 1234)
+    serial_mock.assert_called_once_with("COM1", 1234)
+    st10_mock.assert_called_once_with(serial)


### PR DESCRIPTION
This is part of the work that I've been doing on issue #31 (i.e. making the open/close buttons on the `SerialControl` work). I realised that the changes needed to the backend are substantial enough that they probably deserve their own PR, so here it is.

Aside from adding the new class, there were some other preparatory changes I made for it:

1. Use constants for the hardware-related topic names (I had been making mistakes, so I thought this would be safer)
2. Add a base class for serial devices, which requires that all its subclasses have a `close()` method (used by `SerialManager`)