### PR TITLE
codecov: Don't fail CI if coverage drops

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
-ignore:
-  - "*/tests/*"
+coverage:
+  status:
+    project:
+      default:
+        # Don't fail CI if coverage drops
+        informational: true


### PR DESCRIPTION
Currently the CI is failing on `main`, because the codecov GitHub Action fails if the coverage drops. We only want codecov to advise us rather than fail the CI, so change the settings to reflect this.