### PR TITLE
Connect up `SerialControl` to backend

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -29,8 +29,14 @@ DEFAULT_SCRIPT_PATH = Path.home()
 STEPPER_MOTOR_TOPIC = "stepper_motor"
 """The topic name to use for stepper motor-related messages."""
 
+DEFAULT_ST10_BAUDRATE = 9600
+"""The default baudrate to use for the ST10 controller."""
+
 TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
 """The topic name to user for temperature controller-related messages."""
+
+DEFAULT_TC4820_BAUDRATE = 115200
+"""The default baudrate to use for TC4820 temperature controllers."""
 
 OPUS_IP = "10.10.0.2"
 """The IP address of the machine running the OPUS software."""

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -34,3 +34,6 @@ TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
 
 OPUS_IP = "10.10.0.2"
 """The IP address of the machine running the OPUS software."""
+
+ALLOW_DUMMY_DEVICES = True
+"""Whether to allow the user to choose dummy serial devices."""

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -32,14 +32,7 @@ class MainWindow(QMainWindow):
         measure_script = ScriptControl()
 
         # Setup for serial port control
-        devices = {
-            "ST10": {"port": "COM5", "baud_rate": "9600"},
-            "DP9800": {"port": "COM1", "baud_rate": "9600"},
-        }
-        serial_port: QGroupBox = SerialPortControl(
-            devices,
-            ("COM1", "COM5", "COM7"),
-        )
+        serial_port: QGroupBox = SerialPortControl()
 
         # Setup for interferometer monitor
         em27_monitor = EM27Monitor()

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -1,12 +1,132 @@
 """Panel and widgets related to the control of the serial ports."""
 import logging
-from copy import deepcopy
-from functools import partial
-from typing import Dict, Sequence
+from typing import Sequence
 
-from PySide6.QtWidgets import QComboBox, QGridLayout, QGroupBox, QLabel, QPushButton
+from pubsub import pub
+from PySide6.QtWidgets import (
+    QComboBox,
+    QGridLayout,
+    QGroupBox,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+)
+from serial.tools.list_ports import comports
 
-from ..config import BAUDRATES
+from ..config import (
+    ALLOW_DUMMY_DEVICES,
+    BAUDRATES,
+    DUMMY_DEVICE_PORT,
+    STEPPER_MOTOR_TOPIC,
+    TEMPERATURE_CONTROLLER_TOPIC,
+)
+
+
+def get_usb_serial_ports() -> list[str]:
+    """Get the ports for connected USB serial devices."""
+    # Vendor ID is a USB-specific field, so we can use this to check whether the device
+    # is USB or not
+    return sorted(port.device for port in comports() if port.vid is not None)
+
+
+def get_default_ports() -> list[str]:
+    """Get the default serial ports."""
+    ports = get_usb_serial_ports()
+    if ALLOW_DUMMY_DEVICES:
+        ports.append(DUMMY_DEVICE_PORT)
+    return ports
+
+
+class DeviceControls:
+    """A set of controls for opening/closing a connection to a single serial device."""
+
+    def __init__(
+        self,
+        layout: QGridLayout,
+        row: int,
+        name: str,
+        label: str,
+        avail_ports: Sequence[str],
+        avail_baudrates: Sequence[int],
+    ) -> None:
+        """Create a new DeviceControls.
+
+        The controls are added as a new row to a QGridLayout.
+
+        Args:
+            layout: The QGridLayout to add the controls to
+            row: The row of the QGridLayout to add the controls to
+            name: The name of the device to use in pubsub messages
+            label: A human-readable name for the device
+            avail_ports: Possible serial ports to choose from
+            avail_baudrates: Possible baudrates to choose from
+        """
+        self.name = name
+        self.label = label
+
+        # Add a label showing the device name
+        layout.addWidget(QLabel(label), row, 0)
+
+        self.ports = QComboBox()
+        """The available serial ports for the device."""
+        self.ports.addItems(avail_ports)
+        # TODO: Remember which port was used last time
+        layout.addWidget(self.ports, row, 1)
+
+        self.baudrates = QComboBox()
+        """The available baudrates for the device."""
+        self.baudrates.addItems([str(br) for br in avail_baudrates])
+        # TODO: Remember which baudrate was used last time
+        layout.addWidget(self.baudrates, row, 2)
+
+        self.open_close_btn = QPushButton("Open")
+        """A button for opening and closing the port manually."""
+        self.open_close_btn.setCheckable(True)
+        self.open_close_btn.clicked.connect(self._on_open_close_clicked)  # type: ignore
+        layout.addWidget(self.open_close_btn, row, 3)
+        self.open_close_btn.setChecked(False)
+
+        pub.subscribe(self._set_button_to_close, f"serial.{name}.opened")
+        pub.subscribe(self._set_button_to_open, f"serial.{name}.close")
+        pub.subscribe(self._show_error_message, f"serial.{name}.error")
+
+    def _set_button_to_open(self):
+        """Change the button to say Open."""
+        self.open_close_btn.setText("Open")
+        self.open_close_btn.setChecked(False)
+
+    def _set_button_to_close(self):
+        """Change the button to say Close."""
+        self.open_close_btn.setText("Close")
+        self.open_close_btn.setChecked(True)
+
+    def _show_error_message(self, error: BaseException) -> None:
+        """Show an error message when something has gone wrong with the device."""
+        QMessageBox(
+            QMessageBox.Icon.Critical,
+            "A device error has occurred",
+            f"A fatal error has occurred with the {self.label} device.",
+        ).exec()
+
+    def _open_device(self) -> None:
+        """Open the specified serial device."""
+        logging.info(f"Opening device {self.name}...")
+
+        port = self.ports.currentText()
+        baudrate = int(self.baudrates.currentText())
+        pub.sendMessage(f"serial.{self.name}.open", port=port, baudrate=baudrate)
+
+    def _close_device(self) -> None:
+        """Close the specified serial device."""
+        pub.sendMessage(f"serial.{self.name}.close")
+        logging.info(f"Port for device {self.name} is closed")
+
+    def _on_open_close_clicked(self) -> None:
+        """Open/close the connection of the chosen device when the button is pushed."""
+        if self.open_close_btn.text() == "Open":
+            self._open_device()
+        else:
+            self._close_device()
 
 
 class SerialPortControl(QGroupBox):
@@ -14,125 +134,32 @@ class SerialPortControl(QGroupBox):
 
     def __init__(
         self,
-        devices: Dict[str, Dict[str, str]],
-        avail_ports: Sequence[str],
-        avail_baud_rates: Sequence[int] = BAUDRATES,
+        devices: Sequence[str] = (
+            STEPPER_MOTOR_TOPIC,
+            f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+            f"{TEMPERATURE_CONTROLLER_TOPIC}.cold_bb",
+        ),
+        device_labels: Sequence[str] = ("ST10", "TC4820 Hot", "TC4820 Cold"),
+        avail_ports: Sequence[str] = get_default_ports(),
+        avail_baudrates: Sequence[int] = BAUDRATES,
     ) -> None:
         """Creates a sequence of widgets to control a serial connection to a device.
 
         Args:
-            devices (Dict[str, Dict[str, str]]): Dictionary has a keys the names of the
-                devices to control and as values a dictionary with the port and baud
-                rate chosen for that device.
-            avail_ports: Sequence of possible serial ports.
-            avail_baud_rates: Sequence of possible baud rates.
+            devices: The names of devices to list (for pubsub messages)
+            device_labels: Human-readable names for the devices
+            avail_ports: Sequence of available USB serial ports
+            avail_baudrates: Sequence of possible baudrates
         """
         super().__init__("Serial port control")
 
-        self._devices = deepcopy(devices)
-        self._is_open = {d: False for d in devices.keys()}
-        layout = self._create_controls(avail_ports, avail_baud_rates)
-        self.setLayout(layout)
-
-    def _create_controls(
-        self, avail_ports: Sequence[str], avail_baud_rates: Sequence[int]
-    ) -> QGridLayout:
-        """Creates the controls for the ports of the devices.
-
-        Args:
-            avail_ports: Sequence of possible serial ports.
-            avail_baud_rates: Sequence of possible baud rates.
-
-        Returns:
-            QGridLayout: The layout with the widgets.
-        """
         layout = QGridLayout()
-        for i, (name, details) in enumerate(self._devices.items()):
-            # Adding the device name
-            layout.addWidget(QLabel(name), i, 0)
+        self._devices = [
+            DeviceControls(layout, i, device, label, avail_ports, avail_baudrates)
+            for i, (device, label) in enumerate(zip(devices, device_labels))
+        ]
 
-            # Its port
-            _port = QComboBox()
-            _port.addItems(list(avail_ports))
-            _port.setCurrentText(details["port"])
-            _port.currentTextChanged.connect(  # type: ignore
-                partial(self.on_port_changed, device_name=name)
-            )
-            layout.addWidget(_port, i, 1)
-
-            # Its baud rate
-            _brate = QComboBox()
-            _brate.addItems([str(br) for br in avail_baud_rates])
-            _brate.setCurrentText(details["baud_rate"])
-            _brate.currentTextChanged.connect(  # type: ignore
-                partial(self.on_baud_rate_changed, device_name=name)
-            )
-            layout.addWidget(_brate, i, 2)
-
-            # And a manual way to open/close it
-            _open_close_btn = QPushButton("Open")
-            _open_close_btn.setCheckable(True)
-            _open_close_btn.released.connect(  # type: ignore
-                partial(
-                    self.on_open_close_clicked, device_name=name, button=_open_close_btn
-                )
-            )
-            _open_close_btn.setChecked(False)
-            layout.addWidget(_open_close_btn, i, 3)
-
-        return layout
-
-    def on_port_changed(self, new_port: str, device_name: str) -> None:
-        """Callback to deal with a change of port for the given device.
-
-        Args:
-            new_port: The new port selected.
-            device_name: Name of the device affected.
-        """
-        logging.info(
-            f"{device_name} - old port: {self._devices[device_name]['port']} "
-            f"- new port: {new_port}"
-        )
-        self._devices[device_name]["port"] = new_port
-
-    def on_baud_rate_changed(self, new_baud_rate: str, device_name: str) -> None:
-        """Callback to deal with a change of baud rate for the given device.
-
-        Args:
-            new_baud_rate: The new port selected.
-            device_name: Name of the device affected.
-        """
-        logging.info(
-            f"{device_name} - old baud_rate: {self._devices[device_name]['baud_rate']} "
-            f"- new baud_rate: {new_baud_rate}"
-        )
-        self._devices[device_name]["port"] = new_baud_rate
-
-    def on_open_close_clicked(self, device_name: str, button: QPushButton) -> None:
-        """Open/Close the connection of the chosen device when the button is pushed.
-
-        This method tries to open/close the device and, if successful, change the label
-        on the button. Otherwise, it reverts back to the previous state.
-
-        TODO: Do we need this? Not doing anything for now, obviously.
-
-        Args:
-            device_name: Name of the device affected.
-            button: The button that sent the signal.
-        """
-        is_open = button.isChecked()
-        try:
-            # Try to open/close things
-            pass
-        except Exception:
-            # and if they dont work...
-            is_open = not is_open
-
-        self._is_open[device_name] = is_open
-        button.setChecked(is_open)
-        button.setText("Close" if is_open else "Open")
-
-        logging.info(f"Port for device {device_name} is open: {is_open}")
+        self.setLayout(layout)
 
 
 if __name__ == "__main__":
@@ -143,14 +170,7 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
 
     window = QMainWindow()
-    devices = {
-        "ST10": {"port": "COM5", "baud_rate": "9600"},
-        "DP9800": {"port": "COM1", "baud_rate": "9600"},
-    }
-    serial_port = SerialPortControl(
-        devices,
-        ("COM1", "COM5", "COM7"),
-    )
+    serial_port = SerialPortControl()
     window.setCentralWidget(serial_port)
     window.show()
     app.exec()

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -1,5 +1,4 @@
 """Panel and widgets related to the control of the serial ports."""
-import logging
 from dataclasses import dataclass
 from typing import Sequence, cast
 
@@ -143,8 +142,6 @@ class DeviceControls:
 
     def _open_device(self) -> None:
         """Open the specified serial device."""
-        logging.info(f"Opening device {self.name}...")
-
         port = self.ports.currentText()
         baudrate = int(self.baudrates.currentText())
 
@@ -158,7 +155,6 @@ class DeviceControls:
     def _close_device(self) -> None:
         """Close the specified serial device."""
         pub.sendMessage(f"serial.{self.name}.close")
-        logging.info(f"Port for device {self.name} is closed")
 
     def _on_open_close_clicked(self) -> None:
         """Open/close the connection of the chosen device when the button is pushed."""

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -24,9 +24,6 @@ from ..config import (
 )
 from ..settings import settings
 
-_KEY_PREFIX = "serial"
-"""Prefix to use for settings keys."""
-
 
 def get_usb_serial_ports() -> list[str]:
     """Get the ports for connected USB serial devices."""
@@ -94,10 +91,7 @@ class DeviceControls:
         # Try to load the port from settings
         if avail_ports:
             saved_port = cast(
-                str,
-                settings.value(
-                    f"{_KEY_PREFIX}/{self.device.name}/port", avail_ports[0]
-                ),
+                str, settings.value(f"serial/{self.device.name}/port", avail_ports[0])
             )
             self.ports.setCurrentText(saved_port)
 
@@ -111,8 +105,7 @@ class DeviceControls:
             saved_baudrate = cast(
                 int,
                 settings.value(
-                    f"{_KEY_PREFIX}/{self.device.name}/baudrate",
-                    device.default_baudrate,
+                    f"serial/{self.device.name}/baudrate", device.default_baudrate
                 ),
             )
             self.baudrates.setCurrentText(str(saved_baudrate))
@@ -149,8 +142,8 @@ class DeviceControls:
         baudrate = int(self.baudrates.currentText())
 
         # Remember these settings for the next time program is run
-        settings.setValue(f"{_KEY_PREFIX}/{self.device.name}/port", port)
-        settings.setValue(f"{_KEY_PREFIX}/{self.device.name}/baudrate", baudrate)
+        settings.setValue(f"serial/{self.device.name}/port", port)
+        settings.setValue(f"serial/{self.device.name}/baudrate", baudrate)
 
         # Tell backend to open serial device
         pub.sendMessage(f"serial.{self.device.name}.open", port=port, baudrate=baudrate)

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -120,7 +120,6 @@ class DeviceControls:
         self.open_close_btn.setCheckable(True)
         self.open_close_btn.clicked.connect(self._on_open_close_clicked)  # type: ignore
         layout.addWidget(self.open_close_btn, row, 3)
-        self.open_close_btn.setChecked(False)
 
         pub.subscribe(self._set_button_to_close, f"serial.{self.name}.opened")
         pub.subscribe(self._set_button_to_open, f"serial.{self.name}.close")
@@ -129,12 +128,10 @@ class DeviceControls:
     def _set_button_to_open(self):
         """Change the button to say Open."""
         self.open_close_btn.setText("Open")
-        self.open_close_btn.setChecked(False)
 
     def _set_button_to_close(self):
         """Change the button to say Close."""
         self.open_close_btn.setText("Close")
-        self.open_close_btn.setChecked(True)
 
     def _show_error_message(self, error: BaseException) -> None:
         """Show an error message when something has gone wrong with the device."""

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -17,6 +17,8 @@ from serial.tools.list_ports import comports
 from ..config import (
     ALLOW_DUMMY_DEVICES,
     BAUDRATES,
+    DEFAULT_ST10_BAUDRATE,
+    DEFAULT_TC4820_BAUDRATE,
     DUMMY_DEVICE_PORT,
     STEPPER_MOTOR_TOPIC,
     TEMPERATURE_CONTROLLER_TOPIC,
@@ -46,6 +48,8 @@ class Device:
     """A human-readable label for the device"""
     name: str
     """The name of the device as used in pubsub topic"""
+    default_baudrate: int
+    """The default baudrate to select for the device"""
 
 
 class DeviceControls:
@@ -87,6 +91,10 @@ class DeviceControls:
         self.baudrates.addItems([str(br) for br in avail_baudrates])
         # TODO: Remember which baudrate was used last time
         layout.addWidget(self.baudrates, row, 2)
+
+        if device.default_baudrate not in avail_baudrates:
+            raise ValueError("Invalid default baudrate supplied")
+        self.baudrates.setCurrentText(str(device.default_baudrate))
 
         self.open_close_btn = QPushButton("Open")
         """A button for opening and closing the port manually."""
@@ -144,9 +152,17 @@ class SerialPortControl(QGroupBox):
     def __init__(
         self,
         devices: Sequence[Device] = (
-            Device("ST10", STEPPER_MOTOR_TOPIC),
-            Device("TC4820 Hot", f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb"),
-            Device("TC4820 Cold", f"{TEMPERATURE_CONTROLLER_TOPIC}.cold_bb"),
+            Device("ST10", STEPPER_MOTOR_TOPIC, DEFAULT_ST10_BAUDRATE),
+            Device(
+                "TC4820 Hot",
+                f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+                DEFAULT_TC4820_BAUDRATE,
+            ),
+            Device(
+                "TC4820 Cold",
+                f"{TEMPERATURE_CONTROLLER_TOPIC}.cold_bb",
+                DEFAULT_TC4820_BAUDRATE,
+            ),
         ),
         avail_ports: Sequence[str] = get_default_ports(),
         avail_baudrates: Sequence[int] = BAUDRATES,

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -30,6 +30,3 @@ pub.subscribe(_stop_hardware, "window.closed")
 
 create_stepper_motor_serial_manager()
 create_temperature_controller_serial_managers()
-
-# HACK: Temporary workaround so that we can still use the dummy device for now
-pub.sendMessage("serial.stepper_motor.open", port="Dummy", baudrate=-1)

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -31,7 +31,5 @@ pub.subscribe(_stop_hardware, "window.closed")
 create_stepper_motor_serial_manager()
 create_temperature_controller_serial_managers()
 
-# HACK: Temporary workaround so that we can use dummy devices for now
+# HACK: Temporary workaround so that we can still use the dummy device for now
 pub.sendMessage("serial.stepper_motor.open", port="Dummy", baudrate=-1)
-pub.sendMessage("serial.temperature_controller.hot_bb.open", port="Dummy", baudrate=-1)
-pub.sendMessage("serial.temperature_controller.cold_bb.open", port="Dummy", baudrate=-1)

--- a/finesse/settings.py
+++ b/finesse/settings.py
@@ -1,0 +1,7 @@
+"""A module with a single settings object for the program settings."""
+from PySide6.QtCore import QSettings
+
+from .config import APP_AUTHOR, APP_NAME
+
+settings = QSettings(APP_AUTHOR, APP_NAME)
+"""Contains the program settings for FINESSE."""

--- a/tests/gui/test_serial_view.py
+++ b/tests/gui/test_serial_view.py
@@ -9,6 +9,7 @@ from pytestqt.qtbot import QtBot
 
 from finesse.gui.serial_view import (
     DUMMY_DEVICE_PORT,
+    Device,
     DeviceControls,
     SerialPortControl,
     get_default_ports,
@@ -24,7 +25,9 @@ def device_controls(qtbot: QtBot) -> DeviceControls:
     """A fixture providing a DeviceControls object."""
     ports = ("COM0",)
     baudrates = range(3)
-    return DeviceControls(QGridLayout(), 0, DEVICE_NAME, "My device", ports, baudrates)
+    return DeviceControls(
+        QGridLayout(), 0, Device("My device", DEVICE_NAME), ports, baudrates
+    )
 
 
 MockPortInfo = namedtuple("MockPortInfo", "device vid")
@@ -98,7 +101,7 @@ def test_device_controls_init(
     baudrates = range(3)
 
     controls = DeviceControls(
-        MagicMock(), 0, DEVICE_NAME, "My device", ports, baudrates
+        MagicMock(), 0, Device("My device", DEVICE_NAME), ports, baudrates
     )
     assert items_equal(controls.ports, ports)
     assert items_equal(controls.baudrates, baudrates)
@@ -199,14 +202,11 @@ def test_serial_port_control_init(
     layout = QGridLayout()
     grid_mock.return_value = layout
 
-    devices = ("device1", "device2")
-    labels = ("DEVICE1", "DEVICE2")
+    devices = (Device("device1", "DEVICE1"), Device("device2", "DEVICE2"))
     avail_ports = ("port1", "port2")
     avail_baudrates = range(2)
-    SerialPortControl(devices, labels, avail_ports, avail_baudrates)
+    SerialPortControl(devices, avail_ports, avail_baudrates)
 
     # Check that the appropriate DeviceControls have been created
-    for i, (device, label) in enumerate(zip(devices, labels)):
-        controls_mock.assert_any_call(
-            layout, i, device, label, avail_ports, avail_baudrates
-        )
+    for i, device in enumerate(devices):
+        controls_mock.assert_any_call(layout, i, device, avail_ports, avail_baudrates)

--- a/tests/gui/test_serial_view.py
+++ b/tests/gui/test_serial_view.py
@@ -26,7 +26,7 @@ def device_controls(qtbot: QtBot) -> DeviceControls:
     ports = ("COM0",)
     baudrates = range(3)
     return DeviceControls(
-        QGridLayout(), 0, Device("My device", DEVICE_NAME), ports, baudrates
+        QGridLayout(), 0, Device("My device", DEVICE_NAME, 1), ports, baudrates
     )
 
 
@@ -101,10 +101,11 @@ def test_device_controls_init(
     baudrates = range(3)
 
     controls = DeviceControls(
-        MagicMock(), 0, Device("My device", DEVICE_NAME), ports, baudrates
+        MagicMock(), 0, Device("My device", DEVICE_NAME, 1), ports, baudrates
     )
     assert items_equal(controls.ports, ports)
     assert items_equal(controls.baudrates, baudrates)
+    assert controls.baudrates.currentText() == "1"
 
     btn.clicked.connect.assert_called_once_with(controls._on_open_close_clicked)
 
@@ -202,7 +203,7 @@ def test_serial_port_control_init(
     layout = QGridLayout()
     grid_mock.return_value = layout
 
-    devices = (Device("device1", "DEVICE1"), Device("device2", "DEVICE2"))
+    devices = (Device("device1", "DEVICE1", 1), Device("device2", "DEVICE2", 1))
     avail_ports = ("port1", "port2")
     avail_baudrates = range(2)
     SerialPortControl(devices, avail_ports, avail_baudrates)

--- a/tests/gui/test_serial_view.py
+++ b/tests/gui/test_serial_view.py
@@ -151,7 +151,6 @@ def test_set_button_to_close(device_controls: DeviceControls) -> None:
     with patch.object(device_controls, "open_close_btn") as btn_mock:
         device_controls._set_button_to_close()
         btn_mock.setText.assert_called_once_with("Close")
-        btn_mock.setChecked.assert_called_once_with(True)
 
 
 def test_set_button_to_open(device_controls: DeviceControls) -> None:
@@ -159,7 +158,6 @@ def test_set_button_to_open(device_controls: DeviceControls) -> None:
     with patch.object(device_controls, "open_close_btn") as btn_mock:
         device_controls._set_button_to_open()
         btn_mock.setText.assert_called_once_with("Open")
-        btn_mock.setChecked.assert_called_once_with(False)
 
 
 @patch("finesse.gui.serial_view.QMessageBox")

--- a/tests/gui/test_serial_view.py
+++ b/tests/gui/test_serial_view.py
@@ -1,0 +1,212 @@
+"""Tests for SerialControl and associated code."""
+from collections import namedtuple
+from typing import Any, Sequence
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from PySide6.QtWidgets import QComboBox, QGridLayout
+from pytestqt.qtbot import QtBot
+
+from finesse.gui.serial_view import (
+    DUMMY_DEVICE_PORT,
+    DeviceControls,
+    SerialPortControl,
+    get_default_ports,
+    get_usb_serial_ports,
+)
+
+DEVICE_NAME = "device"
+"""The name to use for the mock serial device."""
+
+
+@pytest.fixture
+def device_controls(qtbot: QtBot) -> DeviceControls:
+    """A fixture providing a DeviceControls object."""
+    ports = ("COM0",)
+    baudrates = range(3)
+    return DeviceControls(QGridLayout(), 0, DEVICE_NAME, "My device", ports, baudrates)
+
+
+MockPortInfo = namedtuple("MockPortInfo", "device vid")
+
+
+@pytest.mark.parametrize(
+    "devices,expected",
+    (
+        # One USB serial device
+        (
+            [MockPortInfo(device="COM1", vid=1)],
+            ["COM1"],
+        ),
+        # One non-USB serial device
+        (
+            [MockPortInfo(device="COM1", vid=None)],
+            [],
+        ),
+        # Two USB serial devices, unsorted
+        (
+            [
+                MockPortInfo(device="COM2", vid=1),
+                MockPortInfo(device="COM1", vid=1),
+            ],
+            ["COM1", "COM2"],
+        ),
+    ),
+)
+@patch("finesse.gui.serial_view.comports")
+def test_get_usb_serial_ports(
+    comports_mock: Mock, devices: list[MockPortInfo], expected: list[str]
+) -> None:
+    """Test the get_usb_serial_ports() function."""
+    comports_mock.return_value = devices
+    assert get_usb_serial_ports() == expected
+
+
+@patch("finesse.gui.serial_view.get_usb_serial_ports")
+@patch("finesse.gui.serial_view.ALLOW_DUMMY_DEVICES", True)
+def test_get_default_ports_dummy(get_usb_mock: Mock) -> None:
+    """Test the get_default_ports() function with a dummy device."""
+    get_usb_mock.return_value = ["COM1"]
+    assert DUMMY_DEVICE_PORT in get_default_ports()
+
+
+@patch("finesse.gui.serial_view.get_usb_serial_ports")
+@patch("finesse.gui.serial_view.ALLOW_DUMMY_DEVICES", False)
+def test_get_default_ports_no_dummy(get_usb_mock: Mock) -> None:
+    """Test the get_default_ports() function when there should be no dummy devices."""
+    get_usb_mock.return_value = ["COM1"]
+    assert DUMMY_DEVICE_PORT not in get_default_ports()
+
+
+def items_equal(combo: QComboBox, values: Sequence[Any]) -> bool:
+    """Check that all items of a QComboBox match those in a Sequence."""
+    if combo.count() != len(values):
+        return False
+
+    items = (combo.itemText(i) for i in range(combo.count()))
+    return all(item == str(val) for item, val in zip(items, values))
+
+
+@patch("finesse.gui.serial_view.QPushButton")
+def test_device_controls_init(
+    btn_mock: Mock, subscribe_mock: MagicMock, qtbot: QtBot
+) -> None:
+    """Test DeviceControls' constructor."""
+    btn = MagicMock()
+    btn_mock.return_value = btn
+    ports = ("COM0",)
+    baudrates = range(3)
+
+    controls = DeviceControls(
+        MagicMock(), 0, DEVICE_NAME, "My device", ports, baudrates
+    )
+    assert items_equal(controls.ports, ports)
+    assert items_equal(controls.baudrates, baudrates)
+
+    btn.clicked.connect.assert_called_once_with(controls._on_open_close_clicked)
+
+    subscribe_mock.assert_any_call(
+        controls._set_button_to_close, f"serial.{DEVICE_NAME}.opened"
+    )
+    subscribe_mock.assert_any_call(
+        controls._set_button_to_open, f"serial.{DEVICE_NAME}.close"
+    )
+    subscribe_mock.assert_any_call(
+        controls._show_error_message, f"serial.{DEVICE_NAME}.error"
+    )
+
+
+def test_set_button_to_close(device_controls: DeviceControls) -> None:
+    """Test the _set_button_to_close() method."""
+    with patch.object(device_controls, "open_close_btn") as btn_mock:
+        device_controls._set_button_to_close()
+        btn_mock.setText.assert_called_once_with("Close")
+        btn_mock.setChecked.assert_called_once_with(True)
+
+
+def test_set_button_to_open(device_controls: DeviceControls) -> None:
+    """Test the _set_button_to_open() method."""
+    with patch.object(device_controls, "open_close_btn") as btn_mock:
+        device_controls._set_button_to_open()
+        btn_mock.setText.assert_called_once_with("Open")
+        btn_mock.setChecked.assert_called_once_with(False)
+
+
+@patch("finesse.gui.serial_view.QMessageBox")
+def test_show_error_message(msgbox_mock: Mock, device_controls: DeviceControls) -> None:
+    """Test the _show_error_message() method."""
+    msgbox = MagicMock()
+    msgbox_mock.return_value = msgbox
+    device_controls._show_error_message(RuntimeError("hello"))
+    msgbox.exec.assert_called_once_with()
+
+
+def test_on_open_close_clicked(device_controls: DeviceControls, qtbot: QtBot) -> None:
+    """Test the open/close button."""
+    # Device starts off closed
+    assert device_controls.open_close_btn.text() == "Open"
+    assert not device_controls.open_close_btn.isChecked()
+
+    with patch.object(device_controls, "_open_device") as open_mock:
+        with patch.object(device_controls, "_close_device") as close_mock:
+            # Try to open the device
+            device_controls._on_open_close_clicked()
+            open_mock.assert_called_once()
+            close_mock.assert_not_called()
+
+            # Signal that the device opened successfully
+            device_controls._set_button_to_close()
+
+            # Check that we can close it again successfully
+            open_mock.reset_mock()
+            close_mock.reset_mock()
+            device_controls._on_open_close_clicked()
+            open_mock.assert_not_called()
+            close_mock.assert_called_once()
+
+
+def test_open_device(
+    device_controls: DeviceControls,
+    qtbot: QtBot,
+    sendmsg_mock: MagicMock,
+) -> None:
+    """Test _open_device()."""
+    with patch.object(device_controls.ports, "currentText") as ports_mock:
+        ports_mock.return_value = "COM0"
+        with patch.object(device_controls.baudrates, "currentText") as baudrates_mock:
+            baudrates_mock.return_value = "1234"
+            device_controls._open_device()
+            sendmsg_mock.assert_any_call(
+                f"serial.{DEVICE_NAME}.open", port="COM0", baudrate=1234
+            )
+
+
+def test_close_device(
+    device_controls: DeviceControls, qtbot: QtBot, sendmsg_mock: MagicMock
+) -> None:
+    """Test the _close_device() method."""
+    device_controls._close_device()
+    sendmsg_mock.assert_any_call(f"serial.{DEVICE_NAME}.close")
+
+
+@patch("finesse.gui.serial_view.QGridLayout")
+@patch("finesse.gui.serial_view.DeviceControls")
+def test_serial_port_control_init(
+    controls_mock: Mock, grid_mock: Mock, qtbot: QtBot
+) -> None:
+    """Test SerialPortControl's constructor."""
+    # Make the constructor return *this* QGridLayout
+    layout = QGridLayout()
+    grid_mock.return_value = layout
+
+    devices = ("device1", "device2")
+    labels = ("DEVICE1", "DEVICE2")
+    avail_ports = ("port1", "port2")
+    avail_baudrates = range(2)
+    SerialPortControl(devices, labels, avail_ports, avail_baudrates)
+
+    # Check that the appropriate DeviceControls have been created
+    for i, (device, label) in enumerate(zip(devices, labels)):
+        controls_mock.assert_any_call(
+            layout, i, device, label, avail_ports, avail_baudrates
+        )


### PR DESCRIPTION
This PR allows the user to open and close connections to serial devices by clicking buttons in the `SerialControl`. The user can choose the desired COM port and baudrate for the device. The list of available COM ports is obtained by querying `PySerial`, whereas the list of available baudrates is hardcoded. The program remembers the last selected COM port and baudrate for each device. If there is no stored setting available for the baudrate, each device has its own preferred baudrate which will be selected by default.

Closes #131, #133.