### PR TITLE
Add ability to run measure scripts

### DIFF
--- a/finesse/gui/error_message.py
+++ b/finesse/gui/error_message.py
@@ -1,10 +1,11 @@
 """For showing error messages."""
 import logging
+from typing import Optional
 
 from PySide6.QtWidgets import QMessageBox, QWidget
 
 
-def show_error_message(parent: QWidget, msg: str) -> None:
+def show_error_message(parent: Optional[QWidget], msg: str) -> None:
     """Show an error message in the GUI and write to the program log."""
     # Show popup box in GUI
     msg_box = QMessageBox(

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -312,13 +312,13 @@ class ScriptRunner(StateMachine):
             # Poll again later
             self._measure_poll_timer.start()
 
-    def _measuring_error(self, message: str) -> None:
+    def _measuring_error(self, error: BaseException) -> None:
         """Log errors from OPUS.
 
         Todo:
             Stop script when errors occur
         """
-        logging.error(f"OPUS error: {message}")
+        logging.error(f"OPUS error: {str(error)}")
 
     def _measuring_end(self) -> None:
         """Move onto the next measurement or perform another measurement here."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -272,6 +272,10 @@ class ScriptRunner(StateMachine):
         """
         pub.sendMessage("opus.request", command="start")
 
+    def on_exit_measuring(self) -> None:
+        """Ensure that the polling timer is stopped."""
+        self._measure_poll_timer.stop()
+
     def _measuring_started(
         self,
         status: int,
@@ -299,7 +303,6 @@ class ScriptRunner(StateMachine):
             Add error handing
         """
         if status == 2:  # "connected" state, indicating measurement is finished
-            self._measure_poll_timer.stop()
             self._measuring_end()
 
     def _measuring_error(self, message: str) -> None:

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -197,11 +197,11 @@ class ScriptRunner(StateMachine):
         self.current_measurement_count: int
         """How many times a measurement has been recorded at the current angle."""
 
-        self._measure_poll_timer = QTimer()
-        """A timer which repeatedly polls the EM27."""
-        self._measure_poll_timer.setSingleShot(True)
-        self._measure_poll_timer.setInterval(round(1000 * min_poll_interval))
-        self._measure_poll_timer.timeout.connect(_poll_em27_status)  # type: ignore
+        self._check_status_timer = QTimer()
+        """A timer which checks whether the EM27's measurement is complete."""
+        self._check_status_timer.setSingleShot(True)
+        self._check_status_timer.setInterval(round(1000 * min_poll_interval))
+        self._check_status_timer.timeout.connect(_poll_em27_status)  # type: ignore
 
         # Send stop command in case motor is moving
         pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.stop")
@@ -286,7 +286,7 @@ class ScriptRunner(StateMachine):
 
     def on_exit_measuring(self) -> None:
         """Ensure that the polling timer is stopped."""
-        self._measure_poll_timer.stop()
+        self._check_status_timer.stop()
 
     def _measuring_started(
         self,
@@ -317,7 +317,7 @@ class ScriptRunner(StateMachine):
             self._measuring_end()
         else:
             # Poll again later
-            self._measure_poll_timer.start()
+            self._check_status_timer.start()
 
     def abort(self) -> None:
         """Abort the current measure script run."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -1,11 +1,12 @@
 """Code for parsing the YAML-formatted measure scripts."""
 from __future__ import annotations
 
+import itertools
 import logging
 from dataclasses import dataclass
 from io import TextIOBase
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Iterator, Optional, Sequence, Union
 
 import yaml
 from pubsub import pub
@@ -55,6 +56,12 @@ class Script:
         self.path = path
         self.repeats = repeats
         self.sequence = [Measurement(**val) for val in sequence]
+
+    def __iter__(self) -> Iterator[Measurement]:
+        """Get an iterator for the measurements."""
+        return itertools.chain.from_iterable(
+            itertools.repeat(self.sequence, self.repeats)
+        )
 
     def run(self) -> None:
         """Run this measure script."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -32,10 +32,6 @@ class Measurement:
     measurements: int
     """The number of times to record a measurement at this position."""
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert this object to a dict."""
-        return {"angle": self.angle, "measurements": self.measurements}
-
 
 class Script:
     """Represents a measure script, including its file path and data."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -208,12 +208,9 @@ class ScriptRunner(StateMachine):
 
         super().__init__()
 
-    def on_enter_state(self, target: State) -> None:
-        """Log the state every time it changes.
-
-        This is just a placeholder so we can see the measure scripts running.
-        """
-        logging.info(f"Measure script: Entering state {target.name}")
+    def on_enter_state(self, target: State, event: str) -> None:
+        """Log the state every time it changes."""
+        logging.info(f"Measure script: Entering state {target.name} (event: {event})")
 
     def on_enter_not_running(self, event: str) -> None:
         """If finished, unsubscribe from pubsub messages and send message."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -69,10 +69,10 @@ class Script:
             itertools.repeat(self.sequence, self.repeats)
         )
 
-    def run(self) -> None:
+    def run(self, parent: Optional[QWidget] = None) -> None:
         """Run this measure script."""
         logging.info(f"Running {self.path}")
-        self.runner = ScriptRunner(self)
+        self.runner = ScriptRunner(self, parent=parent)
         self.runner.start_moving()
 
     @classmethod
@@ -174,7 +174,12 @@ class ScriptRunner(StateMachine):
     finish = moving.to(not_running)
     """To be called when all measurements are complete."""
 
-    def __init__(self, script: Script, min_poll_interval: float = 1.0) -> None:
+    def __init__(
+        self,
+        script: Script,
+        min_poll_interval: float = 1.0,
+        parent: Optional[QWidget] = None,
+    ) -> None:
         """Create a new ScriptRunner.
 
         Note that the EM27 often takes more than one second to respond to requests,
@@ -183,6 +188,7 @@ class ScriptRunner(StateMachine):
         Args:
             script: The script to run
             min_poll_interval: Minimum rate at which to poll EM27 (seconds)
+            parent: The parent widget
 
         Todo:
             Error handling for the stepper motor
@@ -191,6 +197,8 @@ class ScriptRunner(StateMachine):
         """The running script."""
         self.measurement_iter = iter(self.script)
         """An iterator yielding the required sequence of measurements."""
+        self.parent = parent
+        """The parent widget."""
 
         self.current_measurement: Measurement
         """The current measurement to acquire."""
@@ -320,7 +328,7 @@ class ScriptRunner(StateMachine):
         self.cancel_measuring()
 
         show_error_message(
-            None,
+            self.parent,
             "EM27 error occurred. Measure script will stop running.\n\n"
             f"Error {errcode}: {errmsg}",
         )

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -323,19 +323,22 @@ class ScriptRunner(StateMachine):
             # Poll again later
             self._measure_poll_timer.start()
 
-    def _on_em27_error_message(self, errcode: int, errmsg: str) -> None:
+    def _on_em27_error(self, message: str) -> None:
         """Cancel current measurement and show an error message to the user."""
         self.cancel_measuring()
 
         show_error_message(
             self.parent,
-            "EM27 error occurred. Measure script will stop running.\n\n"
-            f"Error {errcode}: {errmsg}",
+            f"EM27 error occurred. Measure script will stop running.\n\n{message}",
         )
+
+    def _on_em27_error_message(self, errcode: int, errmsg: str) -> None:
+        """Error reported by EM27 system."""
+        self._on_em27_error(f"Error {errcode}: {errmsg}")
 
     def _measuring_error(self, error: BaseException) -> None:
         """Log errors from OPUS."""
-        logging.error(f"OPUS error: {str(error)}")
+        self._on_em27_error(str(error))
 
     def _measuring_end(self) -> None:
         """Move onto the next measurement or perform another measurement here."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import QWidget
 from schema import And, Or, Schema, SchemaError
 from statemachine import State, StateMachine
 
-from ...config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
+from ...config import ANGLE_PRESETS
 from ..error_message import show_error_message
 
 
@@ -35,14 +35,6 @@ class Measurement:
     def to_dict(self) -> Dict[str, Any]:
         """Convert this object to a dict."""
         return {"angle": self.angle, "measurements": self.measurements}
-
-    def run(self) -> None:
-        """A placeholder function for recording multiple measurements."""
-        # Move the mirror to the correct location
-        pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.move.begin", target=self.angle)
-
-        # Take the recordings
-        logging.info(f"Recording {self.measurements} measurements")
 
 
 class Script:

--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -1,6 +1,7 @@
 """Contains code for a dialog to create and edit measure scripts."""
 
 import logging
+from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
@@ -91,7 +92,7 @@ class ScriptEditDialog(QDialog):
 
         script = {
             "repeats": self.count.value(),
-            "sequence": [seq.to_dict() for seq in self.sequence_widget.sequence],
+            "sequence": [asdict(seq) for seq in self.sequence_widget.sequence],
         }
 
         try:

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -80,7 +80,7 @@ class ScriptControl(QGroupBox):
             return
 
         # Run the script!
-        script.run()
+        script.run(self)
 
 
 class OpenScriptPathWidget(ScriptPathWidget):

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -124,8 +124,8 @@ class OPUSControl(QGroupBox):
         if error:
             self.logger.error(f"Error ({error[0]}): {error[1]}")
 
-    def _log_error(self, message: str) -> None:
-        self.logger.error(f"Error during request: {message}")
+    def _log_error(self, error: BaseException) -> None:
+        self.logger.error(f"Error during request: {str(error)}")
 
     def on_command_button_clicked(self, command: str) -> None:
         """Execute the given command by sending a message to the appropriate topic.

--- a/finesse/hardware/opus/opus_interface_base.py
+++ b/finesse/hardware/opus/opus_interface_base.py
@@ -14,15 +14,15 @@ class OPUSInterfaceBase(QObject):
         super().__init__()
         pub.subscribe(self.request_command, "opus.request")
 
-    def error_occurred(self, exception: BaseException) -> None:
+    def error_occurred(self, error: BaseException) -> None:
         """Signal that an error occurred."""
-        traceback_str = "".join(traceback.format_tb(exception.__traceback__))
+        traceback_str = "".join(traceback.format_tb(error.__traceback__))
 
         # Write details including stack trace to program log
         logging.error(f"Error during OPUS request: {traceback_str}")
 
         # Notify listeners
-        pub.sendMessage("opus.error", message=str(exception))
+        pub.sendMessage("opus.error", error=str(error))
 
     def request_command(self, command: str) -> None:
         """Request that OPUS run the specified command.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,14 @@ def subscribe_mock(monkeypatch) -> MagicMock:
 
 
 @pytest.fixture
+def unsubscribe_mock(monkeypatch) -> MagicMock:
+    """Fixture for pub.subscribe."""
+    mock = MagicMock()
+    monkeypatch.setattr(pub, "unsubscribe", mock)
+    return mock
+
+
+@pytest.fixture
 def sendmsg_mock(monkeypatch) -> MagicMock:
     """Fixture for pub.sendMessage."""
     mock = MagicMock()

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -3,7 +3,7 @@ from contextlib import nullcontext as does_not_raise
 from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, Union
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import yaml
@@ -147,3 +147,14 @@ def test_script_iterator(num_measurements: int, repeats: int) -> None:
     # Check that calling it again still yields an error!
     with pytest.raises(StopIteration):
         next(it)
+
+
+@patch("finesse.gui.measure_script.script.ScriptRunner")
+def test_script_run(script_runner_mock: Mock) -> None:
+    """Test Script's run() method."""
+    mock2 = MagicMock()
+    script_runner_mock.return_value = mock2
+    script = Script(Path(), 1, ())
+    script.run()
+    script_runner_mock.assert_called_once()
+    mock2.start_moving.assert_called_once()

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -2,7 +2,7 @@
 from contextlib import nullcontext as does_not_raise
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -75,13 +75,6 @@ def test_parse_script(data: Dict[str, Any], raises: Any) -> None:
     """
     with raises:
         parse_script(yaml.safe_dump(data))
-
-
-@pytest.mark.parametrize("angle", ("nadir", 90.0))
-def test_measurement_to_dict(angle: Union[str, float]) -> None:
-    """Check Measurement's to_dict() method."""
-    d = Measurement(angle, 5)
-    assert d.to_dict() == {"angle": angle, "measurements": 5}
 
 
 _SCRIPT_PATH = Path(__file__).parent / "test_script.yaml"

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -116,3 +116,34 @@ def test_try_load_fail(
             script = Script.try_load(QWidget(), _SCRIPT_PATH)
             assert script is None, "Script should not have been loaded"
             show_error_mock.assert_called_once()
+
+
+_MEASUREMENTS = [Measurement(float(i), i) for i in range(1, 4)]
+
+
+@pytest.mark.parametrize(
+    "num_measurements,repeats",
+    (
+        (num_measurements, repeats)
+        for num_measurements in range(4)
+        for repeats in range(1, 4)
+    ),
+)
+def test_script_iterator(num_measurements: int, repeats: int) -> None:
+    """Test the ScriptIterator class."""
+    script = Script(Path(), repeats, [])
+    script.sequence = _MEASUREMENTS[:num_measurements]
+    it = iter(script)
+
+    # Check that we get the correct values "repeats" times
+    with does_not_raise():
+        for _ in range(repeats):
+            assert all(next(it) == m for m in script.sequence)
+
+    # Check that we get a StopIteration at the end
+    with pytest.raises(StopIteration):
+        next(it)
+
+    # Check that calling it again still yields an error!
+    with pytest.raises(StopIteration):
+        next(it)

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -153,7 +153,6 @@ def test_close(
         msgbox_mock.return_value = mock2
         mock2.exec.return_value = int(btn_pressed)
         msgbox_mock.StandardButton = QMessageBox.StandardButton
-        msgbox_mock.exec.return_value = btn_pressed
 
         with patch.object(dlg, "setResult") as set_result_mock:
             with patch.object(dlg, "_try_save") as try_save_mock:

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -242,15 +242,27 @@ def test_measuring_end(
 
 
 @patch("finesse.gui.measure_script.script.show_error_message")
-def test_on_em27_error_message(
-    show_error_message_mock: Mock, runner: ScriptRunner
-) -> None:
-    """Test the _on_em27_error_message() method."""
+def test_on_em27_error(show_error_message_mock: Mock, runner: ScriptRunner) -> None:
+    """Test the _on_em27_error() method."""
     with patch.object(runner, "cancel_measuring") as cancel_mock:
-        runner._on_em27_error_message(1, "ERROR MESSAGE")
+        runner._on_em27_error("ERROR MESSAGE")
         cancel_mock.assert_called_once_with()
         show_error_message_mock.assert_called_once_with(
             None,
-            "EM27 error occurred. Measure script will stop running.\n\n"
-            "Error 1: ERROR MESSAGE",
+            "EM27 error occurred. Measure script will stop running.\n\nERROR MESSAGE",
         )
+
+
+def test_on_em27_error_message(runner: ScriptRunner) -> None:
+    """Test the _on_em27_error_message() method."""
+    with patch.object(runner, "_on_em27_error") as em27_error_mock:
+        runner._on_em27_error_message(1, "ERROR MESSAGE")
+        em27_error_mock.assert_called_once_with("Error 1: ERROR MESSAGE")
+
+
+def test_measuring_error(runner: ScriptRunner) -> None:
+    """Test the _measuring_error() method."""
+    with patch.object(runner, "_on_em27_error") as em27_error_mock:
+        error = RuntimeError("hello")
+        runner._measuring_error(error)
+        em27_error_mock.assert_called_once_with(str(error))

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -167,13 +167,17 @@ def test_status_received(status: int, runner_measuring: ScriptRunner) -> None:
         runner_measuring._status_received(status, "", None, "")
 
         # Status code 2 indicates success
-        timer_stop = cast(MagicMock, runner_measuring._measure_poll_timer.stop)
         if status == 2:
-            timer_stop.assert_called_once()
             measuring_end_mock.assert_called_once()
         else:
-            timer_stop.assert_not_called()
             measuring_end_mock.assert_not_called()
+
+
+def test_on_exit_measuring(runner_measuring: ScriptRunner) -> None:
+    """Test that the timer is stopped when exiting measuring state."""
+    runner_measuring.on_exit_measuring()
+    timer_stop = cast(MagicMock, runner_measuring._measure_poll_timer.stop)
+    timer_stop.assert_called_once()
 
 
 @pytest.mark.parametrize("current_measurement_repeat", range(3))

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -1,0 +1,193 @@
+"""Tests for the ScriptRunner class."""
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
+
+from finesse.gui.measure_script.script import Script, ScriptRunner, _poll_em27_status
+
+
+@pytest.fixture
+def runner(subscribe_mock: MagicMock):
+    """Fixture for a ScriptRunner in its initial state."""
+    script = Script(Path(), 1, ({"angle": 0.0, "measurements": 3},))
+    runner = ScriptRunner(script)
+    runner._measure_poll_timer = MagicMock()
+    return runner
+
+
+@pytest.fixture
+def runner_measuring(runner: ScriptRunner, sendmsg_mock: MagicMock) -> ScriptRunner:
+    """Fixture for a ScriptRunner in a measuring state."""
+    runner.start_moving()
+    runner.start_measuring()
+    sendmsg_mock.reset_mock()
+    return runner
+
+
+@patch("finesse.gui.measure_script.script.QTimer")
+def test_init(
+    timer_mock: Mock, sendmsg_mock: MagicMock, subscribe_mock: MagicMock
+) -> None:
+    """Test ScriptRunner's constructor."""
+    mock2 = MagicMock()
+    timer_mock.return_value = mock2
+
+    script = Script(Path(), 1, ())
+    script_runner = ScriptRunner(script)
+
+    # Check the constructor was called once. Will need to be amended if we add timers.
+    timer_mock.assert_called_once()
+    mock2.setInterval.assert_called_once_with(1000)
+
+    # Initial state
+    assert script_runner.current_state == ScriptRunner.not_running
+
+    # Check subscriptions
+    subscribe_mock.assert_any_call(
+        script_runner.start_measuring, "serial.stepper_motor.move.end"
+    )
+    subscribe_mock.assert_any_call(script_runner._measuring_error, "opus.error")
+    subscribe_mock.assert_any_call(
+        script_runner._measuring_started, "opus.response.start"
+    )
+    subscribe_mock.assert_any_call(
+        script_runner._status_received, "opus.response.status"
+    )
+
+    # Check timer is properly set up
+    mock2.timeout.connect.assert_called_once_with(_poll_em27_status)
+
+    # Check we're stopping the motor
+    sendmsg_mock.assert_any_call("serial.stepper_motor.stop")
+
+
+def test_poll_em27_status(sendmsg_mock: Mock) -> None:
+    """Test the _poll_em27_status function."""
+    _poll_em27_status()
+    sendmsg_mock.assert_called_once_with("opus.request", command="status")
+
+
+def test_start_moving(sendmsg_mock: MagicMock, runner: ScriptRunner) -> None:
+    """Test the start_moving() method."""
+    runner.start_moving()
+    assert runner.current_state == ScriptRunner.moving
+
+    # Check that new measurement was loaded correctly
+    assert runner.current_measurement is runner.script.sequence[0]
+    assert runner.current_measurement_count == 0
+
+    # Check that we have signalled start of script and that command has been sent to
+    # stepper motor
+    calls = (
+        call("measure_script.begin"),
+        call("serial.stepper_motor.move.begin", target=runner.script.sequence[0].angle),
+        call("serial.stepper_motor.notify_on_stopped"),
+    )
+    sendmsg_mock.assert_has_calls(calls)
+
+
+@pytest.mark.parametrize("repeats", range(1, 3))
+def test_finish_moving(repeats: int, sendmsg_mock: MagicMock):
+    """Test that the ScriptRunner terminates after n repeats."""
+    script = Script(Path(), repeats, ({"angle": 0.0, "measurements": 1},))
+    script_runner = ScriptRunner(script)
+    assert script_runner.current_state == ScriptRunner.not_running
+
+    script_runner.start_moving()
+    for _ in range(repeats):
+        assert script_runner.current_state == ScriptRunner.moving
+        script_runner.start_measuring()
+        assert script_runner.current_state == ScriptRunner.measuring
+
+        sendmsg_mock.reset_mock()
+        script_runner.start_next_move()
+
+    # Check that this message is sent on the last iteration
+    sendmsg_mock.assert_called_once_with("measure_script.end")
+
+    assert script_runner.current_state == ScriptRunner.not_running
+
+
+def test_start_measuring(runner: ScriptRunner, sendmsg_mock: MagicMock) -> None:
+    """Test the start_measuring() method."""
+    runner.current_state = ScriptRunner.moving
+
+    runner.start_measuring()
+    assert runner.current_state == ScriptRunner.measuring
+
+    # Check that measuring has been triggered
+    sendmsg_mock.assert_called_once_with("opus.request", command="start")
+
+
+def test_repeat_measurement(
+    runner_measuring: ScriptRunner, sendmsg_mock: MagicMock
+) -> None:
+    """Test that repeat measurements work correctly."""
+    runner_measuring.repeat_measuring()
+    assert runner_measuring.current_state == ScriptRunner.measuring
+
+    # Check that measuring has been triggered again
+    sendmsg_mock.assert_called_once_with("opus.request", command="start")
+
+
+def test_measuring_started(runner: ScriptRunner) -> None:
+    """Test that polling starts when measurement is running."""
+    runner.current_state = ScriptRunner.measuring
+
+    # Simulate response from EM27
+    # TODO: Check for error handling
+    runner._measuring_started(0, "", None, "")
+
+    # Check the timer has been started
+    runner._measure_poll_timer.start.assert_called_once()  # type: ignore
+
+
+@pytest.mark.parametrize("status", range(7))
+def test_status_received(status: int, runner_measuring: ScriptRunner) -> None:
+    """Test that polling the EM27's status works."""
+    with patch.object(runner_measuring, "_measuring_end") as measuring_end_mock:
+        # TODO: handle errors
+        runner_measuring._status_received(status, "", None, "")
+
+        # Status code 2 indicates success
+        timer_stop = cast(MagicMock, runner_measuring._measure_poll_timer.stop)
+        if status == 2:
+            timer_stop.assert_called_once()
+            measuring_end_mock.assert_called_once()
+        else:
+            timer_stop.assert_not_called()
+            measuring_end_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("current_measurement_repeat", range(3))
+def test_measuring_end(
+    current_measurement_repeat: int, runner_measuring: ScriptRunner
+) -> None:
+    """Test that _measuring_end() works correctly.
+
+    It should trigger a repeat measurement if there are more to do and otherwise move
+    onto the next measurement.
+    """
+    runner_measuring.current_measurement_count = current_measurement_repeat
+
+    with patch.object(runner_measuring, "start_next_move") as start_next_move_mock:
+        with patch.object(
+            runner_measuring, "repeat_measuring"
+        ) as repeat_measuring_mock:
+            runner_measuring._measuring_end()
+
+            assert (
+                runner_measuring.current_measurement_count
+                == current_measurement_repeat + 1
+            )
+            if (
+                runner_measuring.current_measurement_count
+                == runner_measuring.current_measurement.measurements
+            ):
+                start_next_move_mock.assert_called_once()
+                repeat_measuring_mock.assert_not_called()
+            else:
+                start_next_move_mock.assert_not_called()
+                repeat_measuring_mock.assert_called_once()

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -15,7 +15,7 @@ def runner():
     """Fixture for a ScriptRunner in its initial state."""
     script = Script(Path(), 1, ({"angle": 0.0, "measurements": 3},))
     runner = ScriptRunner(script)
-    runner._measure_poll_timer = MagicMock()
+    runner._check_status_timer = MagicMock()
     return runner
 
 
@@ -216,7 +216,7 @@ def test_status_received_error(runner_measuring: ScriptRunner) -> None:
 def test_on_exit_measuring(runner_measuring: ScriptRunner) -> None:
     """Test that the timer is stopped when exiting measuring state."""
     runner_measuring.on_exit_measuring()
-    timer_stop = cast(MagicMock, runner_measuring._measure_poll_timer.stop)
+    timer_stop = cast(MagicMock, runner_measuring._check_status_timer.stop)
     timer_stop.assert_called_once()
 
 

--- a/tests/hardware/test_serial_manager.py
+++ b/tests/hardware/test_serial_manager.py
@@ -1,20 +1,10 @@
 """Tests for SerialManager."""
 from unittest.mock import MagicMock, Mock, patch
 
-import pytest
-from pubsub import pub
 from serial import SerialException
 
 from finesse.config import DUMMY_DEVICE_PORT
 from finesse.hardware.serial_manager import SerialManager, make_device_factory
-
-
-@pytest.fixture
-def unsubscribe_mock(monkeypatch) -> MagicMock:
-    """Fixture for pub.subscribe."""
-    mock = MagicMock()
-    monkeypatch.setattr(pub, "unsubscribe", mock)
-    return mock
 
 
 @patch("finesse.hardware.serial_manager.Serial")


### PR DESCRIPTION
This PR allows users to run measure scripts by clicking the "Run script" button. Currently, there is no dialog or anything that communicates the progress to the user, though you can see it in the console log. There is also no way for the user to stop a script once it has started running, although if an error occurs with either the EM27 or the stepper motor, then the run will be aborted. The GUI support will be hooked up in another PR.

Although it isn't obvious at present, you need to connect to the OPUS system and open the serial port to the ST10 before you try to run the script otherwise you'll just get errors.

Closes #108.