### PR TITLE
Enable/disable panels on device connect/disconnect

### DIFF
--- a/finesse/gui/serial_device_panel.py
+++ b/finesse/gui/serial_device_panel.py
@@ -1,0 +1,53 @@
+"""Contains a panel which enables/disables child controls when device opens/closes."""
+from typing import Any
+
+from pubsub import pub
+from PySide6.QtWidgets import QGroupBox, QWidget
+
+
+class SerialDevicePanel(QGroupBox):
+    """A QGroupBox which enables/disables child controls when device opens/closes."""
+
+    def __init_subclass__(cls, **kwargs):
+        """Disable controls after construction."""
+        super().__init_subclass__(**kwargs)
+
+        def init_decorator(previous_init):
+            def new_init(self, *args, **kwargs):
+                previous_init(self, *args, **kwargs)
+                self.disable_controls()
+
+            return new_init
+
+        cls.__init__ = init_decorator(cls.__init__)
+
+    def __init__(self, name: str, title: str, *args: Any, **kwargs: Any) -> None:
+        """Create a new SerialDevicePanel.
+
+        Args:
+            name: The name of the device as used in pubsub messages
+            title: The title for the underlying QGroupBox
+            args: Extra arguments for the QGroupBox constructor
+            kwargs: Extra keyword arguments for the QGroupBox constructor
+        """
+        super().__init__(title, *args, **kwargs)
+
+        # Enable/disable controls on device connect/disconnect
+        pub.subscribe(self._on_device_opened, f"serial.{name}.opened")
+        pub.subscribe(self.disable_controls, f"serial.{name}.close")
+
+    def _on_device_opened(self) -> None:
+        self.enable_controls()
+
+    def enable_controls(self, enabled: bool = True) -> None:
+        """Enable the controls in this panel.
+
+        Args:
+            enabled: Whether to enable or disable the controls
+        """
+        for widget in self.findChildren(QWidget):
+            widget.setEnabled(enabled)
+
+    def disable_controls(self) -> None:
+        """Disable the controls in this panel."""
+        self.enable_controls(False)

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -1,22 +1,17 @@
 """Code for controlling the stepper motor which moves the mirror."""
 from pubsub import pub
-from PySide6.QtWidgets import (
-    QButtonGroup,
-    QGridLayout,
-    QGroupBox,
-    QPushButton,
-    QSpinBox,
-)
+from PySide6.QtWidgets import QButtonGroup, QGridLayout, QPushButton, QSpinBox
 
 from ..config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
+from .serial_device_panel import SerialDevicePanel
 
 
-class StepperMotorControl(QGroupBox):
+class StepperMotorControl(SerialDevicePanel):
     """A control showing buttons for moving the mirror to a target."""
 
     def __init__(self) -> None:
         """Create a new StepperMotorControl."""
-        super().__init__("Target control")
+        super().__init__(STEPPER_MOTOR_TOPIC, "Target control")
 
         layout = QGridLayout()
 

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -17,7 +17,9 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from ..config import TEMPERATURE_CONTROLLER_TOPIC
 from .led_icons import LEDIcon
+from .serial_device_panel import SerialDevicePanel
 
 
 def get_temperature_data() -> Tuple[float, float, float]:
@@ -193,7 +195,7 @@ class DP9800(QGroupBox):
         return layout
 
 
-class TC4820(QGroupBox):
+class TC4820(SerialDevicePanel):
     """Widgets to view the TC4820 properties."""
 
     def __init__(self, name: str) -> None:
@@ -202,7 +204,9 @@ class TC4820(QGroupBox):
         Args:
             name (str): Name of the blackbody the TC4820 is controlling
         """
-        super().__init__(f"TC4820 {name.upper()}")
+        super().__init__(
+            f"{TEMPERATURE_CONTROLLER_TOPIC}.{name}_bb", f"TC4820 {name.upper()}"
+        )
 
         layout = self._create_controls()
         self.setLayout(layout)

--- a/tests/gui/test_serial_device_panel.py
+++ b/tests/gui/test_serial_device_panel.py
@@ -1,0 +1,65 @@
+"""Tests for the SerialDevicePanel."""
+from typing import Sequence
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QVBoxLayout, QWidget
+from pytestqt.qtbot import QtBot
+
+from finesse.gui.serial_device_panel import SerialDevicePanel
+
+
+class _ChildSerialDevicePanel(SerialDevicePanel):
+    """Inherit from SerialDevicePanel in order to test __init_subclass__."""
+
+    def __init__(self) -> None:
+        super().__init__("my_device", "My Panel")
+
+        # Add some extra widgets
+        layout = QVBoxLayout()
+        for _ in range(2):
+            layout.addWidget(QWidget())
+        self.setLayout(layout)
+
+
+@pytest.fixture
+def panel(qtbot: QtBot) -> SerialDevicePanel:
+    """A fixture providing a SerialDevicePanel."""
+    return _ChildSerialDevicePanel()
+
+
+def _check_controls_enabled(panel: SerialDevicePanel, enabled: bool) -> None:
+    widgets: Sequence[QWidget] = panel.findChildren(QWidget)
+
+    assert widgets  # no point in doing the test unless there's at least one widget!
+
+    assert all(widget.isEnabled() == enabled for widget in widgets)
+
+
+def test_init(subscribe_mock: MagicMock, qtbot: QtBot) -> None:
+    """Test SerialDevicePanel's constructor."""
+    panel = SerialDevicePanel("my_device", "My Title")
+
+    subscribe_mock.assert_any_call(panel._on_device_opened, "serial.my_device.opened")
+    subscribe_mock.assert_any_call(panel.disable_controls, "serial.my_device.close")
+
+
+def test_enable_controls(panel: SerialDevicePanel) -> None:
+    """Test the enable_controls() method."""
+    # The controls should start off disabled
+    _check_controls_enabled(panel, False)
+
+    # Re-enable them
+    panel.enable_controls()
+    _check_controls_enabled(panel, True)
+
+
+def test_disable_controls(panel: SerialDevicePanel) -> None:
+    """Test the disable_controls() method."""
+    # Enable controls
+    panel.enable_controls()
+    _check_controls_enabled(panel, True)
+
+    # Disable them
+    panel.disable_controls()
+    _check_controls_enabled(panel, False)

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -1,0 +1,63 @@
+"""Tests for StepperMotorControl."""
+from typing import cast
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from PySide6.QtWidgets import QButtonGroup, QPushButton
+from pytestqt.qtbot import QtBot
+
+from finesse.config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
+from finesse.gui.stepper_motor_view import StepperMotorControl
+
+
+@patch("finesse.gui.stepper_motor_view.QButtonGroup")
+def test_init(button_group_mock: Mock, qtbot: QtBot) -> None:
+    """Test StepperMotorControl's constructor."""
+    button_group = QButtonGroup()
+    button_group_mock.return_value = button_group
+    with patch.object(button_group, "buttonClicked") as clicked_mock:
+        control = StepperMotorControl()
+
+        # Check that button_group's signal is connected
+        clicked_mock.connect.assert_called_once_with(control._preset_clicked)
+
+        # Check that there is a button for each preset angle
+        btn_labels = {btn.text().lower() for btn in button_group.buttons()}
+        assert set(ANGLE_PRESETS.keys()).issubset(btn_labels)
+
+        # Check that there's also a goto button
+        assert "goto" in btn_labels
+
+
+@pytest.mark.parametrize("preset", ANGLE_PRESETS.keys())
+def test_preset_clicked(preset: str, sendmsg_mock: MagicMock, qtbot: QtBot) -> None:
+    """Test the _preset_clicked() method."""
+    control = StepperMotorControl()
+
+    # Get the button for this preset
+    btn = next(
+        btn for btn in control.button_group.buttons() if btn.text().lower() == preset
+    )
+    btn = cast(QPushButton, btn)
+
+    # The motor should be stopped and then moved to this preset
+    control._preset_clicked(btn)
+    sendmsg_mock.assert_any_call(f"serial.{STEPPER_MOTOR_TOPIC}.stop")
+    sendmsg_mock.assert_any_call(
+        f"serial.{STEPPER_MOTOR_TOPIC}.move.begin", target=preset
+    )
+
+
+def test_goto_clicked(sendmsg_mock: MagicMock, qtbot: QtBot) -> None:
+    """Test that the GOTO button works."""
+    control = StepperMotorControl()
+
+    with patch.object(control.angle, "value") as angle_mock:
+        angle_mock.return_value = 123
+
+        # The motor should be stopped then moved to 123°
+        control._preset_clicked(control.goto)
+        sendmsg_mock.assert_any_call(f"serial.{STEPPER_MOTOR_TOPIC}.stop")
+        sendmsg_mock.assert_any_call(
+            f"serial.{STEPPER_MOTOR_TOPIC}.move.begin", target=123.0
+        )


### PR DESCRIPTION
This doesn't actually relate to a specific issue, but I think it's a usability improvement and I had the code for this lying around anyway.

In future we should also probably enable/disable more of the controls (e.g. the various OPUS buttons) depending on the program state to indicate to the user what controls they can use at any given time.