### PR TITLE
Allow for requesting stepper motor angle via pubsub

### DIFF
--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -14,7 +14,7 @@ class StepperMotorBase(DeviceBase):
     def __init__(self) -> None:
         """Create a new StepperMotorBase.
 
-        Subscribe to stepper.move messages.
+        Subscribe to stepper motor pubsub messages.
         """
         pub.subscribe(
             self._move_to,

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -24,6 +24,9 @@ class StepperMotorBase(DeviceBase):
         pub.subscribe(
             self._notify_on_stopped, f"serial.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"
         )
+        pub.subscribe(
+            self._request_angle, f"serial.{STEPPER_MOTOR_TOPIC}.request.angle"
+        )
 
     @staticmethod
     def send_error_message(error: BaseException) -> None:
@@ -121,3 +124,9 @@ class StepperMotorBase(DeviceBase):
             self.notify_on_stopped()
         except Exception as error:
             self.send_error_message(error)
+
+    def _request_angle(self) -> None:
+        """Request the current angle from the device and return via pubsub."""
+        pub.sendMessage(
+            f"serial.{STEPPER_MOTOR_TOPIC}.response.angle", angle=self.angle
+        )

--- a/tests/hardware/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/stepper_motor/test_st10_controller.py
@@ -84,15 +84,6 @@ def test_send_move_end_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> 
     sendmsg_mock.assert_called_once_with(f"serial.{STEPPER_MOTOR_TOPIC}.move.end")
 
 
-def test_send_error_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
-    """Test the _send_error_message() method."""
-    error = Exception()
-    dev.send_error_message(error)
-    sendmsg_mock.assert_called_once_with(
-        f"serial.{STEPPER_MOTOR_TOPIC}.error", error=error
-    )
-
-
 def read_mock(dev: ST10Controller, return_value: str):
     """Patch the _read_sync() method of dev."""
     return patch.object(dev, "_read_sync", return_value=return_value)

--- a/tests/hardware/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/stepper_motor/test_stepper_motor_base.py
@@ -58,6 +58,9 @@ def test_init(subscribe_mock: MagicMock) -> None:
     subscribe_mock.assert_any_call(
         stepper._notify_on_stopped, f"serial.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"
     )
+    subscribe_mock.assert_any_call(
+        stepper._request_angle, f"serial.{STEPPER_MOTOR_TOPIC}.request.angle"
+    )
 
 
 def test_angle(stepper: _MockStepperMotor) -> None:
@@ -111,3 +114,13 @@ def test_error_wrappers_fail(
             getattr(stepper, f"_{func_name}")(*args)
             func_mock.assert_called_once_with(*args)
             send_error_message_mock.assert_called_once_with(error)
+
+
+def test_request_angle(stepper: _MockStepperMotor, sendmsg_mock: MagicMock) -> None:
+    """Test the _request_angle() method."""
+    stepper.step = 1
+    stepper._steps_per_rotation = 1
+    stepper._request_angle()
+    sendmsg_mock.assert_called_once_with(
+        f"serial.{STEPPER_MOTOR_TOPIC}.response.angle", angle=360.0
+    )

--- a/tests/hardware/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/stepper_motor/test_stepper_motor_base.py
@@ -1,0 +1,113 @@
+"""Tests for the StepperMotorBase class."""
+from typing import Any, Optional, Sequence
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from finesse.config import STEPPER_MOTOR_TOPIC
+from finesse.hardware.stepper_motor.stepper_motor_base import StepperMotorBase
+
+
+class _MockStepperMotor(StepperMotorBase):
+    def __init__(self) -> None:
+        self._steps_per_rotation = 1
+        self._step = 0
+        super().__init__()
+
+    @property
+    def steps_per_rotation(self) -> int:
+        return self._steps_per_rotation
+
+    @property
+    def step(self) -> int:
+        return self._step
+
+    @step.setter
+    def step(self, step: int) -> None:
+        self._step = step
+
+    def close(self) -> None:
+        pass
+
+    def stop_moving(self) -> None:
+        pass
+
+    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+        pass
+
+    def notify_on_stopped(self) -> None:
+        pass
+
+
+@pytest.fixture
+def stepper() -> _MockStepperMotor:
+    """Provides a basic StepperMotorBase."""
+    return _MockStepperMotor()
+
+
+def test_init(subscribe_mock: MagicMock) -> None:
+    """Test that StepperMotorBase's constructor subscribes to the right messages."""
+    stepper = _MockStepperMotor()
+    subscribe_mock.assert_any_call(
+        stepper._move_to,
+        f"serial.{STEPPER_MOTOR_TOPIC}.move.begin",
+    )
+    subscribe_mock.assert_any_call(
+        stepper._stop_moving, f"serial.{STEPPER_MOTOR_TOPIC}.stop"
+    )
+    subscribe_mock.assert_any_call(
+        stepper._notify_on_stopped, f"serial.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"
+    )
+
+
+def test_angle(stepper: _MockStepperMotor) -> None:
+    """Test that the angle property works."""
+    stepper._steps_per_rotation = 360
+    stepper.step = 180
+    assert stepper.angle == 180.0
+
+    stepper._steps_per_rotation = 180
+    stepper.step = 180
+    assert stepper.angle == 360.0
+
+
+def test_send_error_message(
+    sendmsg_mock: MagicMock, stepper: _MockStepperMotor
+) -> None:
+    """Test the send_error_message() method."""
+    error = Exception()
+    stepper.send_error_message(error)
+    sendmsg_mock.assert_called_once_with(
+        f"serial.{STEPPER_MOTOR_TOPIC}.error", error=error
+    )
+
+
+_ERROR_WRAPPED_FUNCTIONS = (
+    ("move_to", (MagicMock(),)),
+    ("stop_moving", ()),
+    ("notify_on_stopped", ()),
+)
+
+
+@pytest.mark.parametrize("func_name,args", _ERROR_WRAPPED_FUNCTIONS)
+def test_error_wrappers_success(
+    func_name: str, args: Sequence[Any], stepper: _MockStepperMotor
+) -> None:
+    """Test that error wrappers work when no errors occur."""
+    with patch.object(stepper, func_name) as func_mock:
+        getattr(stepper, f"_{func_name}")(*args)
+        func_mock.assert_called_once_with(*args)
+
+
+@pytest.mark.parametrize("func_name,args", _ERROR_WRAPPED_FUNCTIONS)
+def test_error_wrappers_fail(
+    func_name: str, args: Sequence[Any], stepper: _MockStepperMotor
+) -> None:
+    """Test that error wrappers work when an exception is raised."""
+    with patch.object(stepper, "send_error_message") as send_error_message_mock:
+        with patch.object(stepper, func_name) as func_mock:
+            error = RuntimeError("hello")
+            func_mock.side_effect = error
+            getattr(stepper, f"_{func_name}")(*args)
+            func_mock.assert_called_once_with(*args)
+            send_error_message_mock.assert_called_once_with(error)


### PR DESCRIPTION
This is a prerequisite for #21.

I also added a few more tests where they were missing for `StepperMotorBase`.

Closes #151.