### PR TITLE
Fix log spam from `EM27Scraper`

### DIFF
--- a/finesse/hardware/dummy_em27_scraper.py
+++ b/finesse/hardware/dummy_em27_scraper.py
@@ -1,5 +1,4 @@
 """This module provides an interface to a dummy EM27 monitor."""
-import logging
 from importlib import resources
 
 from .em27_scraper import EM27Error, EM27Scraper
@@ -21,8 +20,6 @@ class DummyEM27Scraper(EM27Scraper):
         """
         try:
             with open(self._url, "r") as page:
-                content = page.read()
-            logging.info("Read PSF27Sensor table")
-            return content
+                return page.read()
         except FileNotFoundError as e:
             raise EM27Error(f"Dummy EM27 server file {self._url} not found") from e

--- a/finesse/hardware/em27_scraper.py
+++ b/finesse/hardware/em27_scraper.py
@@ -104,12 +104,10 @@ class EM27Scraper:
         try:
             request = get(self._url, timeout=self._timeout)
 
-            # Check whether an error occured
+            # Check whether an error occurred
             request.raise_for_status()
 
-            content = request.text
-            logging.info("Read PSF27Sensor table")
-            return content
+            return request.text
         except (ConnectionError, HTTPError, Timeout) as e:
             raise EM27Error(f"Error connecting to {self._url}") from e
 


### PR DESCRIPTION
Currently the `EM27Scraper` logs every time it loads data, which is every other second or so. This means that if you're running the program your console log will very quickly be filled up with these messages obscuring whatever other output you might be looking for.

My bad for not clocking this during the code review.