### PR TITLE
Fix: Wait for ST10 to stop moving in constructor

### DIFF
--- a/finesse/hardware/stepper_motor/st10_controller.py
+++ b/finesse/hardware/stepper_motor/st10_controller.py
@@ -276,7 +276,7 @@ class ST10Controller(StepperMotorBase):
         self._write_check("SP0")
 
         # Make sure the motor has stopped
-        self.wait_until_stopped(20.0)
+        self.wait_until_stopped(3.0)
 
     def _relative_move(self, steps: int) -> None:
         """Move the stepper motor to the specified relative position.

--- a/finesse/hardware/stepper_motor/st10_controller.py
+++ b/finesse/hardware/stepper_motor/st10_controller.py
@@ -275,6 +275,9 @@ class ST10Controller(StepperMotorBase):
         # Tell the controller that this is step 0 ("set variable SP to 0")
         self._write_check("SP0")
 
+        # Make sure the motor has stopped
+        self.wait_until_stopped(20.0)
+
     def _relative_move(self, steps: int) -> None:
         """Move the stepper motor to the specified relative position.
 


### PR DESCRIPTION
This PR just adds a call to `wait_to_stop_moving()` to the homing code, so that it will
block until the motor has stopped moving. This prevents the user from interacting with
the device while calibration in progress.

It's a bit gross that we're blocking the main thread while this happens, but this will
do as a stopgap.

Closes #162.