### PR TITLE
Remove now-unecessary  `# type: ignore`s

### DIFF
--- a/finesse/gui/interferometer_monitor.py
+++ b/finesse/gui/interferometer_monitor.py
@@ -27,7 +27,7 @@ class EM27Monitor(QGroupBox):
         self._data_table: list[EM27Property] = []
 
         self._poll_light = LEDIcon.create_poll_icon()
-        self._poll_light.timer.timeout.connect(self._poll_server)  # type: ignore
+        self._poll_light.timer.timeout.connect(self._poll_server)
 
         self._create_layouts()
 

--- a/finesse/gui/led_icons.py
+++ b/finesse/gui/led_icons.py
@@ -38,7 +38,7 @@ class LEDIcon(QLabel):
         else:
             self._turn_off()
         self.timer = QTimer()
-        self.timer.timeout.connect(self._turn_off)  # type: ignore
+        self.timer.timeout.connect(self._turn_off)
 
     @classmethod
     def create_poll_icon(cls) -> LEDIcon:

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -201,7 +201,7 @@ class ScriptRunner(StateMachine):
         """A timer which checks whether the EM27's measurement is complete."""
         self._check_status_timer.setSingleShot(True)
         self._check_status_timer.setInterval(round(1000 * min_poll_interval))
-        self._check_status_timer.timeout.connect(_poll_em27_status)  # type: ignore
+        self._check_status_timer.timeout.connect(_poll_em27_status)
 
         # Send stop command in case motor is moving
         pub.sendMessage(f"serial.{STEPPER_MOTOR_TOPIC}.stop")

--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -58,8 +58,8 @@ class ScriptEditDialog(QDialog):
             | QDialogButtonBox.StandardButton.Cancel
         )
         self.buttonBox.setCenterButtons(True)
-        self.buttonBox.accepted.connect(self._try_accept)  # type: ignore
-        self.buttonBox.rejected.connect(self.reject)  # type: ignore
+        self.buttonBox.accepted.connect(self._try_accept)
+        self.buttonBox.rejected.connect(self.reject)
 
         layout = QVBoxLayout()
         layout.addWidget(self.count)

--- a/finesse/gui/measure_script/script_path_widget.py
+++ b/finesse/gui/measure_script/script_path_widget.py
@@ -26,7 +26,7 @@ class ScriptPathWidget(QWidget):
 
         browse = QPushButton("&Browse...")
         browse.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
-        browse.clicked.connect(self._browse_clicked)  # type: ignore
+        browse.clicked.connect(self._browse_clicked)
 
         layout = QHBoxLayout()
         layout.addWidget(self.line_edit)

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -18,15 +18,15 @@ class ScriptControl(QGroupBox):
         super().__init__("Script control")
 
         create_btn = QPushButton("Create new script")
-        create_btn.clicked.connect(self._create_btn_clicked)  # type: ignore
+        create_btn.clicked.connect(self._create_btn_clicked)
 
         edit_btn = QPushButton("Edit script")
-        edit_btn.clicked.connect(self._edit_btn_clicked)  # type: ignore
+        edit_btn.clicked.connect(self._edit_btn_clicked)
 
         self.script_path = OpenScriptPathWidget()
 
         run_btn = QPushButton("Run script")
-        run_btn.clicked.connect(self._run_btn_clicked)  # type: ignore
+        run_btn.clicked.connect(self._run_btn_clicked)
 
         layout = QGridLayout()
         layout.addWidget(create_btn, 0, 0)

--- a/finesse/gui/measure_script/sequence_widget.py
+++ b/finesse/gui/measure_script/sequence_widget.py
@@ -54,7 +54,7 @@ class SequenceWidget(QWidget):
             measurements: Number of times to take a measurement at this angle
         """
         self.sequence.append(Measurement(angle, measurements))
-        self.model.layoutChanged.emit()  # type: ignore
+        self.model.layoutChanged.emit()
         self.table.scrollToBottom()
 
     def _get_selected_rows(self, reverse: bool = False) -> List[int]:
@@ -214,7 +214,7 @@ class AddButtons(QGroupBox):
 
         # Add buttons for preset angles (e.g. zenith, nadir, etc.)
         self.group = QButtonGroup()
-        self.group.buttonClicked.connect(self._preset_clicked)  # type: ignore
+        self.group.buttonClicked.connect(self._preset_clicked)
         for preset in ANGLE_PRESETS:
             btn = QPushButton(preset.upper())
             self.group.addButton(btn)
@@ -228,7 +228,7 @@ class AddButtons(QGroupBox):
         self.angle.setMinimum(0)
         self.angle.setMaximum(270)
         self.goto = QPushButton("GOTO")
-        self.goto.clicked.connect(self._goto_clicked)  # type: ignore
+        self.goto.clicked.connect(self._goto_clicked)
         goto_layout.addWidget(self.angle)
         goto_layout.addWidget(self.goto)
 
@@ -254,16 +254,16 @@ class ChangeButtons(QGroupBox):
         super().__init__("Modify instructions")
 
         self.up = QPushButton("Up")
-        self.up.clicked.connect(sequence.move_selected_up)  # type: ignore
+        self.up.clicked.connect(sequence.move_selected_up)
 
         self.down = QPushButton("Down")
-        self.down.clicked.connect(sequence.move_selected_down)  # type: ignore
+        self.down.clicked.connect(sequence.move_selected_down)
 
         self.delete = QPushButton("Delete")
-        self.delete.clicked.connect(sequence.delete_selected)  # type: ignore
+        self.delete.clicked.connect(sequence.delete_selected)
 
         self.clear = QPushButton("Clear")
-        self.clear.clicked.connect(sequence.delete_all)  # type: ignore
+        self.clear.clicked.connect(sequence.delete_all)
 
         layout = QVBoxLayout()
         layout.addWidget(self.up)

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -64,13 +64,13 @@ class OPUSControl(QGroupBox):
 
         for name in self.commands:
             button = QPushButton(name.capitalize())
-            button.clicked.connect(  # type: ignore
+            button.clicked.connect(
                 partial(self.on_command_button_clicked, command=name.lower())
             )
             btn_layout.addWidget(button)
 
         button = QPushButton("OPUS")
-        button.clicked.connect(self.open_opus)  # type: ignore
+        button.clicked.connect(self.open_opus)
         btn_layout.addWidget(button)
 
         btn_layout.addStretch()

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -113,7 +113,7 @@ class DeviceControls:
         self.open_close_btn = QPushButton("Open")
         """A button for opening and closing the port manually."""
         self.open_close_btn.setCheckable(True)
-        self.open_close_btn.clicked.connect(self._on_open_close_clicked)  # type: ignore
+        self.open_close_btn.clicked.connect(self._on_open_close_clicked)
         layout.addWidget(self.open_close_btn, row, 3)
 
         pub.subscribe(self._on_device_opened, f"serial.{self.device.name}.opened")

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -17,7 +17,7 @@ class StepperMotorControl(SerialDevicePanel):
 
         # Bundle all the buttons for moving the mirror into one group
         self.button_group = QButtonGroup()
-        self.button_group.buttonClicked.connect(self._preset_clicked)  # type: ignore
+        self.button_group.buttonClicked.connect(self._preset_clicked)
 
         # Add all the buttons for preset positions
         BUTTONS_PER_ROW = 4

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -44,10 +44,10 @@ class TemperaturePlot(QGroupBox):
         """
         layout = QGridLayout()
         self._btns = {"hot": QPushButton("Hot BB"), "cold": QPushButton("Cold BB")}
-        self._btns["hot"].clicked.connect(  # type: ignore
+        self._btns["hot"].clicked.connect(
             partial(self._toggle_axis_visibility, name="hot")
         )
-        self._btns["cold"].clicked.connect(  # type: ignore
+        self._btns["cold"].clicked.connect(
             partial(self._toggle_axis_visibility, name="cold")
         )
         self._create_figure()
@@ -214,7 +214,7 @@ class DP9800Controls(QGroupBox):
 
         self._poll_light = LEDIcon.create_poll_icon()
         self._poll_light.timer.setInterval(self._poll_interval)
-        self._poll_light.timer.timeout.connect(self._poll_dp9800)  # type: ignore
+        self._poll_light.timer.timeout.connect(self._poll_dp9800)
         layout.addWidget(self._poll_light, 0, 10, 2, 1)
 
         return layout

--- a/finesse/gui/uncaught_exceptions.py
+++ b/finesse/gui/uncaught_exceptions.py
@@ -69,7 +69,7 @@ def _show_uncaught_exception_dialog(
     textEdit.setReadOnly(True)
     buttonBox = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
     buttonBox.setCenterButtons(True)
-    buttonBox.accepted.connect(dialog.accept)  # type: ignore
+    buttonBox.accepted.connect(dialog.accept)
 
     layout = QVBoxLayout()
     layout.addWidget(label)

--- a/finesse/hardware/opus/dummy.py
+++ b/finesse/hardware/opus/dummy.py
@@ -72,7 +72,7 @@ class OPUSStateMachine(StateMachine):
         """Timer signalling the end of a measurement."""
         self.measure_timer.setInterval(round(measure_duration * 1000))
         self.measure_timer.setSingleShot(True)
-        self.measure_timer.timeout.connect(self.stop)  # type: ignore
+        self.measure_timer.timeout.connect(self.stop)
 
         super().__init__()
 

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -101,14 +101,14 @@ def test_accept(saved: bool, qtbot, dlg: ScriptEditDialog) -> None:
         try_save_mock.return_value = saved
 
         # We only accept if _try_save() succeeds
-        with qtbot.waitSignal(dlg.accepted) if saved else nullcontext():  # type: ignore
+        with qtbot.waitSignal(dlg.accepted) if saved else nullcontext():
             save_btn = dlg.buttonBox.button(QDialogButtonBox.StandardButton.Save)
             save_btn.click()
 
 
 def test_reject(qtbot, dlg: ScriptEditDialog) -> None:
     """Check the Cancel button."""
-    with qtbot.waitSignal(dlg.rejected):  # type: ignore
+    with qtbot.waitSignal(dlg.rejected):
         cancel_btn = dlg.buttonBox.button(QDialogButtonBox.StandardButton.Cancel)
         cancel_btn.click()
 

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -6,13 +6,14 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QMessageBox, QWidget
+from pytestqt.qtbot import QtBot
 
 from finesse.gui.measure_script.script import Measurement, Script
 from finesse.gui.measure_script.script_edit_dialog import ScriptEditDialog
 
 
 @pytest.fixture()
-def dlg(qtbot):
+def dlg(qtbot: QtBot):
     """A test fixture providing a ScriptEditDialog."""
     parent = QWidget()
     yield ScriptEditDialog(parent)
@@ -34,7 +35,7 @@ _TEST_SCRIPT = Script(Path("/my/path"), 2, ({"angle": "nadir", "measurements": 3
     ),
 )
 def test_init(
-    qtbot,
+    qtbot: QtBot,
     script: Optional[Script],
     count: int,
     sequence: Sequence[Measurement],
@@ -95,7 +96,7 @@ def test_try_save(
 
 
 @pytest.mark.parametrize("saved", (True, False))
-def test_accept(saved: bool, qtbot, dlg: ScriptEditDialog) -> None:
+def test_accept(saved: bool, qtbot: QtBot, dlg: ScriptEditDialog) -> None:
     """Check the Save button."""
     with patch.object(dlg, "_try_save") as try_save_mock:
         try_save_mock.return_value = saved
@@ -106,7 +107,7 @@ def test_accept(saved: bool, qtbot, dlg: ScriptEditDialog) -> None:
             save_btn.click()
 
 
-def test_reject(qtbot, dlg: ScriptEditDialog) -> None:
+def test_reject(qtbot: QtBot, dlg: ScriptEditDialog) -> None:
     """Check the Cancel button."""
     with qtbot.waitSignal(dlg.rejected):
         cancel_btn = dlg.buttonBox.button(QDialogButtonBox.StandardButton.Cancel)
@@ -132,7 +133,7 @@ def test_close(
     nonempty_seq: bool,
     btn_pressed: int,
     saved: bool,
-    qtbot,
+    qtbot: QtBot,
     dlg: ScriptEditDialog,
 ) -> None:
     """Test the effect of closing the dialog."""

--- a/tests/gui/measure_script/test_sequence_widget.py
+++ b/tests/gui/measure_script/test_sequence_widget.py
@@ -33,7 +33,7 @@ def test_init(qtbot) -> None:
 
 def test_add_instruction(widget: SequenceWidget, qtbot) -> None:
     """Test the add_instruction() method."""
-    with qtbot.waitSignal(widget.model.layoutChanged):  # type: ignore
+    with qtbot.waitSignal(widget.model.layoutChanged):
         widget.add_instruction(90.0, 3)
         assert len(widget.sequence) == 1 and widget.sequence[0] == Measurement(90.0, 3)
 

--- a/tests/hardware/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/stepper_motor/test_st10_controller.py
@@ -1,7 +1,7 @@
 """Tests for the ST10Controller class."""
 from contextlib import nullcontext as does_not_raise
 from itertools import chain
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -59,14 +59,12 @@ def test_init() -> None:
             with patch.object(ST10Controller, "_home_and_reset") as home_mock:
                 # We assign to a variable so the destructor isn't invoked until after
                 # our checks
-                st10 = ST10Controller(serial)  # noqa
-                r = st10._reader
-                r.async_read_completed.connect.assert_called_once_with(  # type: ignore
+                st10 = ST10Controller(serial)
+                r = cast(MagicMock, st10._reader)
+                r.async_read_completed.connect.assert_called_once_with(
                     st10._send_move_end_message
                 )
-                r.read_error.connect.assert_called_once_with(  # type: ignore
-                    st10.send_error_message
-                )
+                r.read_error.connect.assert_called_once_with(st10.send_error_message)
                 check_mock.assert_called_once()
                 stop_mock.assert_called_once()
                 home_mock.assert_called_once()
@@ -113,7 +111,8 @@ def test_read_error(dev: ST10Controller) -> None:
         dev.serial.read_until.assert_called_with(b"\r")
 
     # Check that the error signal was triggered
-    dev._reader.read_error.emit.assert_called_once()  # type: ignore
+    reader = cast(MagicMock, dev._reader.read_error)
+    reader.emit.assert_called_once()
 
 
 def test_read_timed_out(dev: ST10Controller) -> None:
@@ -123,7 +122,8 @@ def test_read_timed_out(dev: ST10Controller) -> None:
         dev._read_sync()
 
     # Check that the error signal was triggered
-    dev._reader.read_error.emit.assert_called_once()  # type: ignore
+    reader = cast(MagicMock, dev._reader.read_error)
+    reader.emit.assert_called_once()
 
 
 def test_read_non_ascii(dev: ST10Controller) -> None:
@@ -133,7 +133,8 @@ def test_read_non_ascii(dev: ST10Controller) -> None:
         dev._read_sync()
 
     # Check that the error signal was triggered
-    dev._reader.read_error.emit.assert_called_once()  # type: ignore
+    reader = cast(MagicMock, dev._reader.read_error)
+    reader.emit.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -230,4 +231,5 @@ def test_notify_on_stopped(dev: ST10Controller) -> None:
     assert dev._reader._process_read()
 
     # Check that the signal was triggered
-    dev._reader.async_read_completed.emit.assert_called_once()  # type: ignore
+    signal = cast(MagicMock, dev._reader.async_read_completed)
+    signal.emit.assert_called_once()


### PR DESCRIPTION
As of PR #172 we now have PySide v6.4.3, which seemingly fixes that annoying bug where signal attributes on `QWidget`s are not found by `mypy`, so I've removed various `# type: ignore` annotations all over the place. I also had to add a couple of `cast`s to make `mypy` happy.

I was able to script most of this with:

```sh
git ls-files|xargs sed -i -r 's/(connect.*)# type: ignore/\1/'
```

Tagging @TinyMarsh and @cc-a FYI.