### PR TITLE
Remove web view from OPUS control

### DIFF
--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -293,7 +293,6 @@ class ScriptRunner(StateMachine):
         status: int,
         text: str,
         error: Optional[tuple[int, str]],
-        url: str,
     ):
         """Start polling the EM27 so we know when the measurement is finished."""
         if error:
@@ -306,7 +305,6 @@ class ScriptRunner(StateMachine):
         status: int,
         text: str,
         error: Optional[tuple[int, str]],
-        url: str,
     ):
         """Move on to the next measurement if the measurement has finished."""
         if error:

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -95,7 +95,6 @@ class OPUSControl(QGroupBox):
         status: int,
         text: str,
         error: Optional[tuple[int, str]],
-        url: str,
     ) -> None:
         self.logger.info(f"Response ({status}): {text}")
         if error:

--- a/finesse/hardware/opus/dummy.py
+++ b/finesse/hardware/opus/dummy.py
@@ -169,7 +169,6 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         state = self.state_machine.current_state
         pub.sendMessage(
             f"opus.response.{command}",
-            url="https://example.com",
             status=state.value,
             text=state.name,
             error=self.last_error.to_tuple(),

--- a/finesse/hardware/opus/em27.py
+++ b/finesse/hardware/opus/em27.py
@@ -119,9 +119,7 @@ class OPUSInterface(OPUSInterfaceBase):
             self.error_occurred(e)
             return
 
-        pub.sendMessage(
-            topic, url=response.url, status=cast(int, status), text=text, error=error
-        )
+        pub.sendMessage(topic, status=cast(int, status), text=text, error=error)
 
     def request_command(self, command: str) -> None:
         """Request that OPUS run the specified command.

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -176,7 +176,7 @@ def test_measuring_started_success(poll_em27_mock: Mock, runner: ScriptRunner) -
     runner.current_state = ScriptRunner.measuring
 
     # Simulate response from EM27
-    runner._measuring_started(0, "", None, "")
+    runner._measuring_started(0, "", None)
 
     # Check the request is sent to the EM27
     poll_em27_mock.assert_called_once()
@@ -188,7 +188,7 @@ def test_measuring_started_fail(runner: ScriptRunner) -> None:
 
     with patch.object(runner, "_on_em27_error_message") as em27_error_mock:
         # Simulate response from EM27
-        runner._measuring_started(0, "", (1, "ERROR MESSAGE"), "")
+        runner._measuring_started(0, "", (1, "ERROR MESSAGE"))
 
         em27_error_mock.assert_called_once_with(1, "ERROR MESSAGE")
 
@@ -197,7 +197,7 @@ def test_measuring_started_fail(runner: ScriptRunner) -> None:
 def test_status_received(status: int, runner_measuring: ScriptRunner) -> None:
     """Test that polling the EM27's status works."""
     with patch.object(runner_measuring, "_measuring_end") as measuring_end_mock:
-        runner_measuring._status_received(status, "", None, "")
+        runner_measuring._status_received(status, "", None)
 
         # Status code 2 indicates success
         if status == 2:
@@ -209,7 +209,7 @@ def test_status_received(status: int, runner_measuring: ScriptRunner) -> None:
 def test_status_received_error(runner_measuring: ScriptRunner) -> None:
     """Test that _on_em27_error_message is called if the status indicates an error."""
     with patch.object(runner_measuring, "_on_em27_error_message") as em27_error_mock:
-        runner_measuring._status_received(1, "", (1, "ERROR MESSAGE"), "")
+        runner_measuring._status_received(1, "", (1, "ERROR MESSAGE"))
         em27_error_mock.assert_called_once_with(1, "ERROR MESSAGE")
 
 

--- a/tests/hardware/opus/test_dummy.py
+++ b/tests/hardware/opus/test_dummy.py
@@ -57,7 +57,6 @@ def test_request_status(
     dev.request_command("status")
     send_message_mock.assert_called_once_with(
         "opus.response.status",
-        url="https://example.com",
         status=state.value,
         text=state.name,
         error=OPUSError.NOT_CONNECTED.to_tuple()
@@ -114,7 +113,6 @@ def test_request_command(
         state = dev.state_machine.current_state
         send_message_mock.assert_called_once_with(
             f"opus.response.{command}",
-            url="https://example.com",
             status=state.value,
             text=state.name,
             error=dev.last_error.to_tuple(),
@@ -130,7 +128,6 @@ def test_request_command_bad_command(
     state = dev.state_machine.current_state
     send_message_mock.assert_called_once_with(
         "opus.response.non_existent_command",
-        url="https://example.com",
         status=state.value,
         text=state.name,
         error=OPUSError.UNKNOWN_COMMAND.to_tuple(),

--- a/tests/hardware/opus/test_em27.py
+++ b/tests/hardware/opus/test_em27.py
@@ -119,7 +119,7 @@ def test_parse_response_no_error(
         opus._parse_response(response, "my.topic")
         error_mock.assert_not_called()
         sendmsg_mock.assert_called_once_with(
-            "my.topic", url=response.url, status=status, text=text, error=None
+            "my.topic", status=status, text=text, error=None
         )
 
 
@@ -135,7 +135,6 @@ def test_parse_response_error(
         error_mock.assert_not_called()
         sendmsg_mock.assert_called_once_with(
             "my.topic",
-            url=response.url,
             status=1,
             text="status text",
             error=(errcode, errtext),


### PR DESCRIPTION
This has been agreed with the researchers. Having a web view there doesn't add anything -- all the info you need is in the log view anyway.

Removing it also means that we can remove the `url` argument from OPUS `pubsub` messages, as it is now unused.

Closes #169.