### PR TITLE
Temperature monitor refactor

### DIFF
--- a/finesse/hardware/temperature/dp9800.py
+++ b/finesse/hardware/temperature/dp9800.py
@@ -1,6 +1,5 @@
 """This module provides an interface to DP9800 temperature readers."""
 import logging
-from datetime import datetime
 from decimal import Decimal
 
 from pubsub import pub
@@ -204,28 +203,9 @@ class DP9800(TemperatureMonitorBase):
         except Exception as e:
             raise DP9800Error(e)
 
-    def send_temperatures(self) -> None:
-        """Perform the complete process of reading from the DP9800.
-
-        Writes to the DP9800 requesting a read operation.
-        Reads the raw data from the DP9800.
-        Parses the data and broadcasts the temperatures.
-        """
-        try:
-            self.request_read()
-            data = self.read()
-            time_now = datetime.now().timestamp()
-            temperatures, _ = parse_data(data)
-        except DP9800Error as e:
-            self._error_occurred(e)
-        else:
-            pub.sendMessage(
-                "temperature_monitor.data.response",
-                temperatures=temperatures,
-                time=time_now,
-            )
-
-    def _error_occurred(self, exception: BaseException) -> None:
-        """Log and communicate that an error occurred."""
-        logging.error(f"Error during DP9800 query:\t{exception}")
-        pub.sendMessage("temperature_monitor.error", message=str(exception))
+    def get_temperatures(self) -> list[Decimal]:
+        """Get the current temperatures."""
+        self.request_read()
+        data = self.read()
+        temperatures, _ = parse_data(data)
+        return temperatures

--- a/finesse/hardware/temperature/dummy_temperature_monitor.py
+++ b/finesse/hardware/temperature/dummy_temperature_monitor.py
@@ -1,6 +1,5 @@
 """This module provides an interface to dummy DP9800 temperature readers."""
 import logging
-from datetime import datetime
 from decimal import Decimal
 
 from pubsub import pub
@@ -15,7 +14,7 @@ class DummyTemperatureMonitor(TemperatureMonitorBase):
     def __init__(self) -> None:
         """Create a new DummyTemperatureMonitor."""
         super().__init__("dummy")
-        self._noise_producer = NoiseProducer(seed=datetime.now().second)
+        self._noise_producer = NoiseProducer(seed=None)
 
     def close(self) -> None:
         """Close the connection to the device."""

--- a/finesse/hardware/temperature/dummy_temperature_monitor.py
+++ b/finesse/hardware/temperature/dummy_temperature_monitor.py
@@ -22,15 +22,8 @@ class DummyTemperatureMonitor(TemperatureMonitorBase):
         pub.sendMessage("temperature_monitor.close")
         logging.info("Closed connection to dummy temperature monitor")
 
-    def send_temperatures(self) -> None:
-        """Publish fluctuating temperatures."""
+    def get_temperatures(self) -> list[Decimal]:
+        """Get current temperatures."""
         _BASE_TEMPS = (19, 17, 26, 22, 24, 68, 69, 24)
         noise = self._noise_producer()
-        temperatures = [Decimal(noise + temp) for temp in _BASE_TEMPS]
-        time_now = datetime.now().timestamp()
-
-        pub.sendMessage(
-            "temperature_monitor.data.response",
-            temperatures=temperatures,
-            time=time_now,
-        )
+        return [Decimal(noise + temp) for temp in _BASE_TEMPS]

--- a/finesse/hardware/temperature/temperature_monitor_base.py
+++ b/finesse/hardware/temperature/temperature_monitor_base.py
@@ -1,6 +1,8 @@
 """Provides a base class for temperature monitor devices or mock devices."""
 import logging
 from abc import abstractmethod
+from datetime import datetime
+from decimal import Decimal
 
 from pubsub import pub
 
@@ -19,5 +21,23 @@ class TemperatureMonitorBase(DeviceBase):
         pub.subscribe(self.send_temperatures, "temperature_monitor.data.request")
 
     @abstractmethod
+    def get_temperatures(self) -> list[Decimal]:
+        """Get the current temperatures."""
+
     def send_temperatures(self) -> None:
         """Requests that temperatures are sent over pubsub."""
+        try:
+            temperatures = self.get_temperatures()
+        except Exception as e:
+            self._error_occurred(e)
+        else:
+            pub.sendMessage(
+                "temperature_monitor.data.response",
+                temperatures=temperatures,
+                time=datetime.now().timestamp(),
+            )
+
+    def _error_occurred(self, exception: BaseException) -> None:
+        """Log and communicate that an error occurred."""
+        logging.error(f"Error during temperature monitor query:\t{exception}")
+        pub.sendMessage("temperature_monitor.error", message=str(exception))


### PR DESCRIPTION
I came across this while I was working on the CSV code and thought I should fix it up. It will create merge conflicts with your new DP9800 branch, but I really don't mind rebasing this one once yours is merged if you'd prefer that.

At the moment `TemperatureMonitorBase` has `send_temperatures()` as an abstract method and the `DP9800` and `DummyTemperatureMonitor` classes each have their own implementation. I've rewritten it so that the child classes each have a `get_temperatures()` method instead and the `send_temperatures()` method which implements common functionality is in `TemperatureMonitorBase`.

I also noticed we were seeding the RNG with the current time, which is unnecessary. If you want a random seed you can just pass `None`.