### PR TITLE
Add `pubsub` decorators for convenience and safety

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: "v1.0.1"
     hooks:
       - id: mypy
-        additional_dependencies: [types-beautifulsoup4, types-PyYAML]
+        additional_dependencies: [types-beautifulsoup4, types-decorator, types-PyYAML]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.33.0
     hooks:

--- a/finesse/gui/serial_device_panel.py
+++ b/finesse/gui/serial_device_panel.py
@@ -1,6 +1,7 @@
 """Contains a panel which enables/disables child controls when device opens/closes."""
 from typing import Any
 
+from decorator import decorator
 from pubsub import pub
 from PySide6.QtWidgets import QGroupBox, QWidget
 
@@ -12,12 +13,10 @@ class SerialDevicePanel(QGroupBox):
         """Disable controls after construction."""
         super().__init_subclass__(**kwargs)
 
-        def init_decorator(previous_init):
-            def new_init(self, *args, **kwargs):
-                previous_init(self, *args, **kwargs)
-                self.set_controls_enabled(False)
-
-            return new_init
+        @decorator
+        def init_decorator(previous_init, self, *args, **kwargs):
+            previous_init(self, *args, **kwargs)
+            self.set_controls_enabled(False)
 
         cls.__init__ = init_decorator(cls.__init__)
 

--- a/finesse/hardware/pubsub_decorators.py
+++ b/finesse/hardware/pubsub_decorators.py
@@ -1,8 +1,21 @@
 """Provides a decorator for catching and forwarding errors via pubsub."""
+import logging
+import traceback
 from collections.abc import Callable
 
 from decorator import decorator
 from pubsub import pub
+
+
+def _error_occurred(error_topic: str, error: BaseException) -> None:
+    """Signal that an error occurred."""
+    traceback_str = "".join(traceback.format_tb(error.__traceback__))
+
+    # Write details including stack trace to program log
+    logging.error(f"Caught error ({error_topic}): {traceback_str}")
+
+    # Notify listeners
+    pub.sendMessage(error_topic, error=error)
 
 
 def pubsub_errors(error_topic: str) -> Callable:
@@ -16,7 +29,7 @@ def pubsub_errors(error_topic: str) -> Callable:
         try:
             return func(*args, **kwargs)
         except Exception as error:
-            pub.sendMessage(error_topic, error=error)
+            _error_occurred(error_topic, error)
 
     return decorator(wrapped)
 
@@ -39,7 +52,7 @@ def pubsub_broadcast(
         try:
             result = func(*args, **kwargs)
         except Exception as error:
-            pub.sendMessage(error_topic, error=error)
+            _error_occurred(error_topic, error)
         else:
             # Convert result to a tuple of the right size
             if result is None:

--- a/finesse/hardware/pubsub_decorators.py
+++ b/finesse/hardware/pubsub_decorators.py
@@ -1,0 +1,21 @@
+"""Provides a decorator for catching and forwarding errors via pubsub."""
+from collections.abc import Callable
+
+from decorator import decorator
+from pubsub import pub
+
+
+def pubsub_errors(error_topic: str) -> Callable:
+    """Catch exceptions and broadcast via pubsub.
+
+    Args:
+        error_topic: The topic name on which to broadcast errors
+    """
+
+    def wrapped(func: Callable, *args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as error:
+            pub.sendMessage(error_topic, error=error)
+
+    return decorator(wrapped)

--- a/finesse/hardware/pubsub_decorators.py
+++ b/finesse/hardware/pubsub_decorators.py
@@ -19,3 +19,39 @@ def pubsub_errors(error_topic: str) -> Callable:
             pub.sendMessage(error_topic, error=error)
 
     return decorator(wrapped)
+
+
+def pubsub_broadcast(
+    error_topic: str, success_topic: str, *kwarg_names: str
+) -> Callable:
+    """Broadcast success or failure of function via pubsub.
+
+    If the function returns without error, the returned values are sent as arguments to
+    the success_topic message.
+
+    Args:
+        error_topic: The topic name on which to broadcast errors
+        success_topic: The topic name on which to broadcast function result(s)
+        kwarg_names: The names of each of the returned values
+    """
+
+    def wrapped(func: Callable, *args, **kwargs):
+        try:
+            result = func(*args, **kwargs)
+        except Exception as error:
+            pub.sendMessage(error_topic, error=error)
+        else:
+            # Convert result to a tuple of the right size
+            if result is None:
+                result = ()
+            elif not isinstance(result, tuple):
+                result = (result,)
+
+            # Make sure we have the right number of return values
+            assert len(result) == len(kwarg_names)
+
+            # Send message with arguments
+            msg_kwargs = {name: res for name, res in zip(kwarg_names, result)}
+            pub.sendMessage(success_topic, **msg_kwargs)
+
+    return decorator(wrapped)

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -6,7 +6,7 @@ from pubsub import pub
 
 from ...config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 from ..device_base import DeviceBase
-from ..pubsub_decorators import pubsub_errors
+from ..pubsub_decorators import pubsub_broadcast, pubsub_errors
 
 error_wrap = pubsub_errors(f"serial.{STEPPER_MOTOR_TOPIC}.error")
 """Broadcast exceptions via pubsub."""
@@ -116,8 +116,11 @@ class StepperMotorBase(DeviceBase):
 
         self.step = round(self.steps_per_rotation * target / 360.0)
 
-    def _request_angle(self) -> None:
+    @pubsub_broadcast(
+        f"serial.{STEPPER_MOTOR_TOPIC}.error",
+        f"serial.{STEPPER_MOTOR_TOPIC}.response.angle",
+        "angle",
+    )
+    def _request_angle(self) -> float:
         """Request the current angle from the device and return via pubsub."""
-        pub.sendMessage(
-            f"serial.{STEPPER_MOTOR_TOPIC}.response.angle", angle=self.angle
-        )
+        return self.angle

--- a/finesse/hardware/temperature/temperature_monitor_base.py
+++ b/finesse/hardware/temperature/temperature_monitor_base.py
@@ -1,5 +1,4 @@
 """Provides a base class for temperature monitor devices or mock devices."""
-import logging
 from abc import abstractmethod
 from datetime import datetime
 from decimal import Decimal
@@ -8,6 +7,7 @@ from pubsub import pub
 
 from ...config import TEMPERATURE_MONITOR_TOPIC
 from ..device_base import DeviceBase
+from ..pubsub_decorators import pubsub_broadcast
 
 
 class TemperatureMonitorBase(DeviceBase):
@@ -27,22 +27,14 @@ class TemperatureMonitorBase(DeviceBase):
     def get_temperatures(self) -> list[Decimal]:
         """Get the current temperatures."""
 
-    def send_temperatures(self) -> None:
+    @pubsub_broadcast(
+        f"serial.{TEMPERATURE_MONITOR_TOPIC}.error",
+        f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.response",
+        "temperatures",
+        "time",
+    )
+    def send_temperatures(self) -> tuple[list[Decimal], float]:
         """Requests that temperatures are sent over pubsub."""
-        try:
-            temperatures = self.get_temperatures()
-        except Exception as e:
-            self._error_occurred(e)
-        else:
-            pub.sendMessage(
-                f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.response",
-                temperatures=temperatures,
-                time=datetime.now().timestamp(),
-            )
-
-    def _error_occurred(self, exception: BaseException) -> None:
-        """Log and communicate that an error occurred."""
-        logging.error(f"Error during temperature monitor query:\t{exception}")
-        pub.sendMessage(
-            f"serial.{TEMPERATURE_MONITOR_TOPIC}.error", message=str(exception)
-        )
+        temperatures = self.get_temperatures()
+        time = datetime.now().timestamp()
+        return temperatures, time

--- a/poetry.lock
+++ b/poetry.lock
@@ -402,6 +402,18 @@ files = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -1940,6 +1952,18 @@ files = [
 types-html5lib = "*"
 
 [[package]]
+name = "types-decorator"
+version = "5.1.8.3"
+description = "Typing stubs for decorator"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-decorator-5.1.8.3.tar.gz", hash = "sha256:32dd380fc88d0e7a1f27a84ba1ce6e29ba0ad42caaa1b88e7b5d27e61f6e4962"},
+    {file = "types_decorator-5.1.8.3-py3-none-any.whl", hash = "sha256:2ad329af49b824db8069ebba9bf03b1cbcafba72eb338be255a1fd902e85edb9"},
+]
+
+[[package]]
 name = "types-html5lib"
 version = "1.1.11.13"
 description = "Typing stubs for html5lib"
@@ -2056,4 +2080,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "3711660fb6ef37a63a49d42180689df79aa9586dcd9d86d09bc0a583debad2e5"
+content-hash = "f6acf6c72ac9df2317621f5048da4ffb2cd9f516b771418b36b1b4c634d92c07"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pyserial = "^3.5"
 beautifulsoup4 = "^4.12.2"
 python-statemachine = "^2.0.0"
 numpy = "^1.24.2"
+decorator = "^5.1.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
@@ -35,6 +36,7 @@ pyinstaller = "^5.6.2"
 types-pyyaml = "^6.0.12.9"
 types-beautifulsoup4 = "^4.12.0.3"
 pytest-qt = "^4.2.0"
+types-decorator = "^5.1.8.3"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.2"

--- a/tests/hardware/stepper_motor/conftest.py
+++ b/tests/hardware/stepper_motor/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures for stepper motor tests."""
+from unittest.mock import MagicMock
+
+import pytest
+from decorator import decorator
+
+from finesse.hardware.stepper_motor import stepper_motor_base
+
+
+def null_decorator(*args, **kwargs):
+    """A decorator which simply returns the provided function."""
+
+    def wrapped(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    return decorator(wrapped)
+
+
+@pytest.fixture
+def error_wrap_mock(monkeypatch) -> MagicMock:
+    """Mock the error_wrap decorator to avoid decorator errors."""
+    mock = MagicMock()
+    monkeypatch.setattr(stepper_motor_base, "error_wrap", mock)
+    return mock

--- a/tests/hardware/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/stepper_motor/test_st10_controller.py
@@ -35,7 +35,7 @@ class MockSerialReader(_SerialReader):
 
 @pytest.fixture
 @patch("finesse.hardware.stepper_motor.st10_controller._SerialReader", MockSerialReader)
-def dev() -> ST10Controller:
+def dev(error_wrap_mock: MagicMock) -> ST10Controller:
     """A fixture providing an ST10Controller with a patched Serial object."""
     serial = MagicMock()
     serial.timeout = 5.0
@@ -49,7 +49,7 @@ def dev() -> ST10Controller:
 
 
 @patch("finesse.hardware.stepper_motor.st10_controller._SerialReader", MockSerialReader)
-def test_init() -> None:
+def test_init(error_wrap_mock: MagicMock) -> None:
     """Test __init__()."""
     serial = MagicMock()
     serial.timeout = 5.0

--- a/tests/hardware/stepper_motor/test_stepper_motor.py
+++ b/tests/hardware/stepper_motor/test_stepper_motor.py
@@ -2,6 +2,7 @@
 from contextlib import nullcontext as does_not_raise
 from itertools import chain
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,7 +20,7 @@ from finesse.hardware.stepper_motor.dummy import DummyStepperMotor
         for steps in range(-5, 5)
     ],
 )
-def test_constructor(steps: int, raises: Any) -> None:
+def test_constructor(steps: int, raises: Any, error_wrap_mock: MagicMock) -> None:
     """Check arguments to constructor."""
     with raises:
         DummyStepperMotor(steps)
@@ -37,7 +38,7 @@ def test_constructor(steps: int, raises: Any) -> None:
         for target in range(-36, 2 * 36)
     ],
 )
-def test_move_to_number(target: int, raises: Any) -> None:
+def test_move_to_number(target: int, raises: Any, error_wrap_mock: MagicMock) -> None:
     """Check move_to, when an angle is given."""
     stepper = DummyStepperMotor(36)
     assert stepper.step == 0
@@ -63,7 +64,7 @@ BAD_PRESETS = ("", "ZENITH", "kevin", "badger")
         for name in chain(ANGLE_PRESETS.keys(), BAD_PRESETS)
     ],
 )
-def test_move_to_preset(name: str, raises: Any) -> None:
+def test_move_to_preset(name: str, raises: Any, error_wrap_mock: MagicMock) -> None:
     """Check move_to, when a preset name is given."""
     with raises:
         DummyStepperMotor(360).move_to(name)

--- a/tests/hardware/test_pubsub_decorators.py
+++ b/tests/hardware/test_pubsub_decorators.py
@@ -1,0 +1,33 @@
+"""Tests for the pubsub_errors decorator."""
+from unittest.mock import MagicMock, Mock
+
+from finesse.hardware.pubsub_decorators import pubsub_errors
+
+
+def test_pubsub_errors_no_error(sendmsg_mock: Mock) -> None:
+    """Test for when no errors occur."""
+    func_mock = MagicMock()
+
+    def func(*args, **kwargs):
+        func_mock(*args, **kwargs)
+        return "MAGIC"
+
+    decorated_func = pubsub_errors("my_topic.error")(func)
+    assert decorated_func(1, 2, 3) == "MAGIC"
+    func_mock.assert_called_once_with(1, 2, 3)
+    sendmsg_mock.assert_not_called()
+
+
+def test_pubsub_errors_error(sendmsg_mock: Mock) -> None:
+    """Test for when an error occurs."""
+    error = Exception()
+    func_mock = MagicMock()
+
+    def func(*args, **kwargs):
+        func_mock(*args, **kwargs)
+        raise error
+
+    decorated_func = pubsub_errors("my_topic.error")(func)
+    assert decorated_func(1, 2, 3) is None
+    func_mock.assert_called_once_with(1, 2, 3)
+    sendmsg_mock.assert_called_once_with("my_topic.error", error=error)

--- a/tests/hardware/test_pubsub_decorators.py
+++ b/tests/hardware/test_pubsub_decorators.py
@@ -1,25 +1,14 @@
 """Tests for the pubsub_errors decorator."""
-from unittest.mock import MagicMock, Mock
+from collections.abc import Callable
+from unittest.mock import MagicMock
 
-from finesse.hardware.pubsub_decorators import pubsub_errors
+from finesse.hardware.pubsub_decorators import pubsub_broadcast, pubsub_errors
 
-
-def test_pubsub_errors_no_error(sendmsg_mock: Mock) -> None:
-    """Test for when no errors occur."""
-    func_mock = MagicMock()
-
-    def func(*args, **kwargs):
-        func_mock(*args, **kwargs)
-        return "MAGIC"
-
-    decorated_func = pubsub_errors("my_topic.error")(func)
-    assert decorated_func(1, 2, 3) == "MAGIC"
-    func_mock.assert_called_once_with(1, 2, 3)
-    sendmsg_mock.assert_not_called()
+ERROR_TOPIC = "my_topic.error"
+SUCCESS_TOPIC = "my_topic.success"
 
 
-def test_pubsub_errors_error(sendmsg_mock: Mock) -> None:
-    """Test for when an error occurs."""
+def _test_decorator_error(decorator: Callable, sendmsg_mock: MagicMock) -> None:
     error = Exception()
     func_mock = MagicMock()
 
@@ -27,7 +16,72 @@ def test_pubsub_errors_error(sendmsg_mock: Mock) -> None:
         func_mock(*args, **kwargs)
         raise error
 
-    decorated_func = pubsub_errors("my_topic.error")(func)
+    decorated_func = decorator(func)
     assert decorated_func(1, 2, 3) is None
     func_mock.assert_called_once_with(1, 2, 3)
-    sendmsg_mock.assert_called_once_with("my_topic.error", error=error)
+    sendmsg_mock.assert_called_once_with(ERROR_TOPIC, error=error)
+
+
+def test_pubsub_errors_error(sendmsg_mock: MagicMock) -> None:
+    """Test pubsub_errors for when an error occurs."""
+    _test_decorator_error(pubsub_errors(ERROR_TOPIC), sendmsg_mock)
+
+
+def test_pubsub_errors_no_error(sendmsg_mock: MagicMock) -> None:
+    """Test pubsub_errors for when no errors occur."""
+    func_mock = MagicMock()
+
+    def func(*args, **kwargs):
+        func_mock(*args, **kwargs)
+        return "MAGIC"
+
+    decorated_func = pubsub_errors(ERROR_TOPIC)(func)
+    assert decorated_func(1, 2, 3) == "MAGIC"
+    func_mock.assert_called_once_with(1, 2, 3)
+    sendmsg_mock.assert_not_called()
+
+
+def test_pubsub_broadcast_error(sendmsg_mock: MagicMock) -> None:
+    """Test pubsub_broadcast for when an error occurs."""
+    _test_decorator_error(pubsub_broadcast(ERROR_TOPIC, SUCCESS_TOPIC), sendmsg_mock)
+
+
+def test_pubsub_broadcast_success_return_none(sendmsg_mock: MagicMock) -> None:
+    """Test pubsub_broadcast for when no values are returned."""
+    func_mock = MagicMock()
+
+    def func(*args, **kwargs):
+        func_mock(*args, **kwargs)
+
+    decorated_func = pubsub_broadcast(ERROR_TOPIC, SUCCESS_TOPIC)(func)
+    assert decorated_func(1, 2, 3) is None
+    func_mock.assert_called_once_with(1, 2, 3)
+    sendmsg_mock.assert_called_once_with(SUCCESS_TOPIC)
+
+
+def test_pubsub_broadcast_success_return_one(sendmsg_mock: MagicMock) -> None:
+    """Test pubsub_broadcast for when a single value is returned."""
+    func_mock = MagicMock()
+
+    def func(*args, **kwargs):
+        func_mock(*args, **kwargs)
+        return "MAGIC"
+
+    decorated_func = pubsub_broadcast(ERROR_TOPIC, SUCCESS_TOPIC, "arg")(func)
+    assert decorated_func(1, 2, 3) is None
+    func_mock.assert_called_once_with(1, 2, 3)
+    sendmsg_mock.assert_called_once_with(SUCCESS_TOPIC, arg="MAGIC")
+
+
+def test_pubsub_broadcast_success_return_multiple(sendmsg_mock: MagicMock) -> None:
+    """Test pubsub_broadcast for when multiple values are returned."""
+    func_mock = MagicMock()
+
+    def func(*args, **kwargs):
+        func_mock(*args, **kwargs)
+        return "MAGIC", 42
+
+    decorated_func = pubsub_broadcast(ERROR_TOPIC, SUCCESS_TOPIC, "arg1", "arg2")(func)
+    assert decorated_func(1, 2, 3) is None
+    func_mock.assert_called_once_with(1, 2, 3)
+    sendmsg_mock.assert_called_once_with(SUCCESS_TOPIC, arg1="MAGIC", arg2=42)


### PR DESCRIPTION
In the process of doing something else, I started this refactoring and I thought it should be its own PR.

This PR adds a couple of decorators -- `pubsub_errors` and `pubsub_broadcast` -- which can be used to decorate functions. `pubsub_errors` catches any raised exceptions and forwards them as a pubsub message. `pubsub_broadcast` does the same thing but additionally will send a different message in the case that an exception is *not* thrown (i.e. that the function has succeeded). The user needs to supply the names of the keyword arguments that will be passed to the pubsub message in this case.