### PR TITLE
Enable/disable buttons on device connect/disconnect

### DIFF
--- a/finesse/event_counter.py
+++ b/finesse/event_counter.py
@@ -1,0 +1,49 @@
+"""Provides a class for monitoring events such as device opening/closing."""
+from collections.abc import Callable
+from typing import Any
+
+from pubsub import pub
+
+
+class EventCounter:
+    """A class for monitoring events such as device opening/closing.
+
+    Callbacks are run when the desired count is reached and when the count drops below
+    the target.
+    """
+
+    def __init__(
+        self,
+        target_count: int,
+        on_target_reached: Callable[[], Any],
+        on_below_target: Callable[[], Any],
+    ) -> None:
+        """Create a new EventCounter.
+
+        Args:
+            target_count: The target count on which on_target_reached will be run
+            on_target_reached: Callback for when target_count is reached
+            on_below_target: Callback for when count drops below target_count
+        """
+        self._count = 0
+        self._target_count = target_count
+        self._on_target_reached = on_target_reached
+        self._on_below_target = on_below_target
+
+    def increment(self) -> None:
+        """Increase the counter by one and run callback if target reached."""
+        self._count += 1
+        if self._count == self._target_count:
+            self._on_target_reached()
+
+    def decrement(self) -> None:
+        """Decrease the counter by one and run callback if count drops below target."""
+        self._count -= 1
+        if self._count == self._target_count - 1:
+            self._on_below_target()
+
+    def change_on_device_open(self, *names: str) -> None:
+        """Subscribe to devices' open/close messages."""
+        for name in names:
+            pub.subscribe(self.increment, f"serial.{name}.opened")
+            pub.subscribe(self.decrement, f"serial.{name}.close")

--- a/finesse/event_counter.py
+++ b/finesse/event_counter.py
@@ -1,6 +1,6 @@
 """Provides a class for monitoring events such as device opening/closing."""
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Optional, Sequence
 
 from pubsub import pub
 
@@ -14,21 +14,33 @@ class EventCounter:
 
     def __init__(
         self,
-        target_count: int,
         on_target_reached: Callable[[], Any],
         on_below_target: Callable[[], Any],
+        target_count: Optional[int] = None,
+        device_names: Sequence[str] = (),
     ) -> None:
         """Create a new EventCounter.
 
         Args:
-            target_count: The target count on which on_target_reached will be run
             on_target_reached: Callback for when target_count is reached
             on_below_target: Callback for when count drops below target_count
+            target_count: The target count on which on_target_reached will be run
+            device_names: The names of serial device topics to subscribe to
         """
+        if target_count is None:
+            if not device_names:
+                raise ValueError("Must supply either target_count or device_names")
+            target_count = len(device_names)
+
         self._count = 0
         self._target_count = target_count
         self._on_target_reached = on_target_reached
         self._on_below_target = on_below_target
+
+        # Subscribe to devices' open/close messages
+        for name in device_names:
+            pub.subscribe(self.increment, f"serial.{name}.opened")
+            pub.subscribe(self.decrement, f"serial.{name}.close")
 
     def increment(self) -> None:
         """Increase the counter by one and run callback if target reached."""
@@ -41,9 +53,3 @@ class EventCounter:
         self._count -= 1
         if self._count == self._target_count - 1:
             self._on_below_target()
-
-    def change_on_device_open(self, *names: str) -> None:
-        """Subscribe to devices' open/close messages."""
-        for name in names:
-            pub.subscribe(self.increment, f"serial.{name}.opened")
-            pub.subscribe(self.decrement, f"serial.{name}.close")

--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -26,13 +26,17 @@ class DataFileControl(QGroupBox):
         """Lets the user choose the destination for data files."""
         layout.addWidget(self.save_path_widget)
 
-        # TODO: Enable/disable this on DP9800 connect/disconnect
         self.record_btn = QPushButton("Start recording")
         """Toggles recording state."""
         self.record_btn.clicked.connect(self._toggle_recording)
+        self.record_btn.setEnabled(False)
         layout.addWidget(self.record_btn)
 
         self.setLayout(layout)
+
+        # Backend indicates when necessary devices are all connected/disconnected
+        pub.subscribe(self._on_data_file_enable, "data_file.enable")
+        pub.subscribe(self._on_data_file_disable, "data_file.disable")
 
         # Update GUI on file open/close
         pub.subscribe(self._on_file_open, "data_file.open")
@@ -40,6 +44,20 @@ class DataFileControl(QGroupBox):
 
         # Show an error message if writing fails
         pub.subscribe(self._show_error_message, "data_file.error")
+
+    def _on_data_file_enable(self) -> None:
+        self.record_btn.setEnabled(True)
+
+    def _on_data_file_disable(self) -> None:
+        self.record_btn.setEnabled(False)
+
+        if self.record_btn.text() == "Stop recording":
+            QMessageBox.warning(
+                self,
+                "Device closed",
+                "Device was closed unexpectedly during data recording. "
+                "Recording will now stop.",
+            )
 
     def _on_file_open(self, path: Path) -> None:
         self.save_path_widget.setEnabled(False)

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -127,7 +127,7 @@ class ScriptControl(QGroupBox):
     def _on_opus_message(
         self, status: int, text: str, error: Optional[tuple[int, str]]
     ) -> None:
-        """Increase/descrease the enable counter when the EM27 connects/disconnects."""
+        """Increase/decrease the enable counter when the EM27 connects/disconnects."""
         # According to the manual, these are the possible states the EM27 can be in
         # while connected
         connected = 2 <= status <= 5

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -45,10 +45,12 @@ class ScriptControl(QGroupBox):
         run_btn.setEnabled(False)
 
         self._enable_counter = EventCounter(
-            2, lambda: run_btn.setEnabled(True), lambda: run_btn.setEnabled(False)
+            lambda: run_btn.setEnabled(True),
+            lambda: run_btn.setEnabled(False),
+            target_count=2,
+            device_names=(STEPPER_MOTOR_TOPIC,),
         )
         """A counter to enable/disable the "Run" button."""
-        self._enable_counter.change_on_device_open(STEPPER_MOTOR_TOPIC)
 
         layout = QGridLayout()
         layout.addWidget(create_btn, 0, 0)

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -55,11 +55,14 @@ class DataFileWriter:
         self._writer: Writer
         """The CSV writer."""
 
-        self._enable_counter = EventCounter(3, self.enable, self.disable)
-        self._enable_counter.change_on_device_open(
-            config.STEPPER_MOTOR_TOPIC,
-            config.TEMPERATURE_MONITOR_TOPIC,
-            f"{config.TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+        self._enable_counter = EventCounter(
+            self.enable,
+            self.disable,
+            device_names=(
+                config.STEPPER_MOTOR_TOPIC,
+                config.TEMPERATURE_MONITOR_TOPIC,
+                f"{config.TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+            ),
         )
 
         # Listen to open/close messages

--- a/tests/gui/measure_script/test_script_view.py
+++ b/tests/gui/measure_script/test_script_view.py
@@ -226,7 +226,10 @@ def test_show_run_dialog(
 
 
 def test_hide_run_dialog(
-    script_control: ScriptControl, run_dialog: ScriptRunDialog, sendmsg_mock: MagicMock
+    script_control: ScriptControl,
+    run_dialog: ScriptRunDialog,
+    sendmsg_mock: MagicMock,
+    qtbot: QtBot,
 ) -> None:
     """Test the _hide_run_dialog() method."""
     dialog = MagicMock()
@@ -238,7 +241,10 @@ def test_hide_run_dialog(
 
 
 def test_hide_run_dialog_no_abort(
-    script_control: ScriptControl, run_dialog: ScriptRunDialog, sendmsg_mock: MagicMock
+    script_control: ScriptControl,
+    run_dialog: ScriptRunDialog,
+    sendmsg_mock: MagicMock,
+    qtbot: QtBot,
 ) -> None:
     """Test the _hide_run_dialog() method doesn't abort the measure script.
 

--- a/tests/gui/test_data_file_view.py
+++ b/tests/gui/test_data_file_view.py
@@ -64,14 +64,14 @@ def test_stop_recording(
     sendmsg_mock.assert_called_once_with("data_file.close")
 
 
-def test_on_file_open(data_file: DataFileControl) -> None:
+def test_on_file_open(data_file: DataFileControl, qtbot) -> None:
     """Test the _on_file_open() method."""
     data_file._on_file_open(FILE_PATH)
     assert data_file.record_btn.text() == "Stop recording"
     assert not data_file.save_path_widget.isEnabled()
 
 
-def test_on_file_close(data_file: DataFileControl) -> None:
+def test_on_file_close(data_file: DataFileControl, qtbot) -> None:
     """Test the _on_file_close() method."""
     # Simulate file open to start with
     data_file._on_file_open(FILE_PATH)
@@ -84,7 +84,9 @@ def test_on_file_close(data_file: DataFileControl) -> None:
 
 
 @patch("finesse.gui.data_file_view.QMessageBox")
-def test_show_error_message(msgbox_mock: Mock, data_file: DataFileControl) -> None:
+def test_show_error_message(
+    msgbox_mock: Mock, data_file: DataFileControl, qtbot
+) -> None:
     """Test the _show_error_message() method."""
     msgbox_mock.return_value = msgbox = MagicMock()
     error = Exception()
@@ -104,7 +106,10 @@ def test_show_error_message(msgbox_mock: Mock, data_file: DataFileControl) -> No
 )
 @patch("finesse.gui.data_file_view.QMessageBox")
 def test_user_confirms_overwrite(
-    msgbox_mock: Mock, response: QMessageBox.StandardButton, data_file: DataFileControl
+    msgbox_mock: Mock,
+    response: QMessageBox.StandardButton,
+    data_file: DataFileControl,
+    qtbot,
 ) -> None:
     """Test the _user_confirms_overwrite() method."""
     msgbox_mock.StandardButton = QMessageBox.StandardButton
@@ -126,6 +131,7 @@ def test_try_start_recording(
     user_confirms: bool,
     sendmsg_mock: MagicMock,
     data_file: DataFileControl,
+    qtbot,
 ) -> None:
     """Test the _try_start_recording() method."""
     with patch.object(

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import yaml
 
-from finesse.config import TEMPERATURE_MONITOR_TOPIC
+from finesse.config import (
+    STEPPER_MOTOR_TOPIC,
+    TEMPERATURE_CONTROLLER_TOPIC,
+    TEMPERATURE_MONITOR_TOPIC,
+)
 from finesse.hardware.data_file_writer import DataFileWriter, _get_metadata
 
 
@@ -17,11 +21,20 @@ def writer() -> DataFileWriter:
     return DataFileWriter()
 
 
-def test_init(subscribe_mock: MagicMock) -> None:
+@patch("finesse.hardware.data_file_writer.EventCounter")
+def test_init(counter_mock: Mock, subscribe_mock: MagicMock) -> None:
     """Test DataFileWriter's constructor."""
+    counter_mock.return_value = counter = MagicMock()
     writer = DataFileWriter()
     subscribe_mock.assert_any_call(writer.open, "data_file.open")
     subscribe_mock.assert_any_call(writer.close, "data_file.close")
+
+    counter_mock.assert_called_once_with(3, writer.enable, writer.disable)
+    counter.change_on_device_open(
+        STEPPER_MOTOR_TOPIC,
+        TEMPERATURE_MONITOR_TOPIC,
+        f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+    )
 
 
 @patch("finesse.hardware.data_file_writer.config.NUM_TEMPERATURE_MONITOR_CHANNELS", 2)
@@ -76,9 +89,10 @@ def test_open_error(
 
 def test_close(writer: DataFileWriter, unsubscribe_mock: MagicMock) -> None:
     """Test the close() method."""
-    writer._writer = MagicMock()
+    writer._writer = csv_writer = MagicMock()
     writer.close()
-    writer._writer.close.assert_called_once_with()
+    assert not hasattr(writer, "_writer")  # Should have been deleted
+    csv_writer.close.assert_called_once_with()
     unsubscribe_mock.assert_called_once_with(
         writer.write, f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.response"
     )
@@ -138,3 +152,23 @@ def test_write_error(
     writer._writer.writerow.side_effect = error
     writer.write(time, data)
     sendmsg_mock.assert_called_once_with("data_file.error", error=error)
+
+
+def test_enable(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
+    """Test the enable() method."""
+    writer.enable()
+    sendmsg_mock.assert_called_once_with("data_file.enable")
+
+
+def test_disable_close(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
+    """Test the disable() method while writing."""
+    writer._writer = MagicMock()
+    writer.disable()
+    sendmsg_mock.assert_any_call("data_file.disable")
+    sendmsg_mock.assert_any_call("data_file.close")
+
+
+def test_disable_no_close(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
+    """Test the disable() method while not writing."""
+    writer.disable()
+    sendmsg_mock.assert_called_once_with("data_file.disable")

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -24,16 +24,19 @@ def writer() -> DataFileWriter:
 @patch("finesse.hardware.data_file_writer.EventCounter")
 def test_init(counter_mock: Mock, subscribe_mock: MagicMock) -> None:
     """Test DataFileWriter's constructor."""
-    counter_mock.return_value = counter = MagicMock()
+    counter_mock.return_value = MagicMock()
     writer = DataFileWriter()
     subscribe_mock.assert_any_call(writer.open, "data_file.open")
     subscribe_mock.assert_any_call(writer.close, "data_file.close")
 
-    counter_mock.assert_called_once_with(3, writer.enable, writer.disable)
-    counter.change_on_device_open(
-        STEPPER_MOTOR_TOPIC,
-        TEMPERATURE_MONITOR_TOPIC,
-        f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+    counter_mock.assert_called_once_with(
+        writer.enable,
+        writer.disable,
+        device_names=(
+            STEPPER_MOTOR_TOPIC,
+            TEMPERATURE_MONITOR_TOPIC,
+            f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
+        ),
     )
 
 

--- a/tests/test_event_counter.py
+++ b/tests/test_event_counter.py
@@ -1,0 +1,57 @@
+"""Tests for the EventCounter class."""
+from unittest.mock import MagicMock
+
+from finesse.event_counter import EventCounter
+
+
+def test_init() -> None:
+    """Test EventCounter's constructor."""
+    on_target_reached = MagicMock()
+    on_below_target = MagicMock()
+    counter = EventCounter(1, on_target_reached, on_below_target)
+    assert counter._count == 0
+    assert counter._target_count == 1
+    assert counter._on_target_reached is on_target_reached
+    assert counter._on_below_target is on_below_target
+
+
+def test_increment_call() -> None:
+    """Test the increment() method when callback is called."""
+    on_target_reached = MagicMock()
+    on_below_target = MagicMock()
+    counter = EventCounter(1, on_target_reached, on_below_target)
+    counter.increment()
+    on_target_reached.assert_called_once_with()
+    on_below_target.assert_not_called()
+
+
+def test_increment_no_call() -> None:
+    """Test the increment() method when callback is not called."""
+    on_target_reached = MagicMock()
+    on_below_target = MagicMock()
+    counter = EventCounter(2, on_target_reached, on_below_target)
+    counter.increment()
+    on_target_reached.assert_not_called()
+    on_below_target.assert_not_called()
+
+
+def test_decrement_call() -> None:
+    """Test the decrement() method when callback is called."""
+    on_target_reached = MagicMock()
+    on_below_target = MagicMock()
+    counter = EventCounter(1, on_target_reached, on_below_target)
+    counter._count = 1
+    counter.decrement()
+    on_target_reached.assert_not_called()
+    on_below_target.assert_called_once_with()
+
+
+def test_decrement_no_call() -> None:
+    """Test the decrement() method when callback is not called."""
+    on_target_reached = MagicMock()
+    on_below_target = MagicMock()
+    counter = EventCounter(2, on_target_reached, on_below_target)
+    counter._count = 1
+    counter.decrement()
+    on_target_reached.assert_not_called()
+    on_below_target.assert_not_called()

--- a/tests/test_event_counter.py
+++ b/tests/test_event_counter.py
@@ -1,5 +1,9 @@
 """Tests for the EventCounter class."""
+from contextlib import nullcontext as does_not_raise
+from typing import Any, Optional, Sequence
 from unittest.mock import MagicMock
+
+import pytest
 
 from finesse.event_counter import EventCounter
 
@@ -8,18 +12,48 @@ def test_init() -> None:
     """Test EventCounter's constructor."""
     on_target_reached = MagicMock()
     on_below_target = MagicMock()
-    counter = EventCounter(1, on_target_reached, on_below_target)
+    counter = EventCounter(on_target_reached, on_below_target, target_count=1)
     assert counter._count == 0
     assert counter._target_count == 1
     assert counter._on_target_reached is on_target_reached
     assert counter._on_below_target is on_below_target
 
 
+def test_init_with_devices(subscribe_mock: MagicMock) -> None:
+    """Test EventCounter's constructor when device names are given as arguments."""
+    counter = EventCounter(MagicMock(), MagicMock(), device_names=("device",))
+    assert counter._target_count == 1
+    subscribe_mock.assert_any_call(counter.increment, "serial.device.opened")
+    subscribe_mock.assert_any_call(counter.decrement, "serial.device.close")
+
+
+@pytest.mark.parametrize(
+    "target_count,device_names,raises",
+    (
+        (
+            target_count,
+            device_names,
+            pytest.raises(ValueError)
+            if target_count is None and not device_names
+            else does_not_raise(),
+        )
+        for target_count in (None, 2)
+        for device_names in ((), ("device",))
+    ),
+)
+def test_init_missing_args(
+    target_count: Optional[int], device_names: Sequence[str], raises: Any
+) -> None:
+    """Test that an error is raised when required arguments are missing."""
+    with raises:
+        EventCounter(MagicMock(), MagicMock(), target_count, device_names)
+
+
 def test_increment_call() -> None:
     """Test the increment() method when callback is called."""
     on_target_reached = MagicMock()
     on_below_target = MagicMock()
-    counter = EventCounter(1, on_target_reached, on_below_target)
+    counter = EventCounter(on_target_reached, on_below_target, target_count=1)
     counter.increment()
     on_target_reached.assert_called_once_with()
     on_below_target.assert_not_called()
@@ -29,7 +63,7 @@ def test_increment_no_call() -> None:
     """Test the increment() method when callback is not called."""
     on_target_reached = MagicMock()
     on_below_target = MagicMock()
-    counter = EventCounter(2, on_target_reached, on_below_target)
+    counter = EventCounter(on_target_reached, on_below_target, target_count=2)
     counter.increment()
     on_target_reached.assert_not_called()
     on_below_target.assert_not_called()
@@ -39,7 +73,7 @@ def test_decrement_call() -> None:
     """Test the decrement() method when callback is called."""
     on_target_reached = MagicMock()
     on_below_target = MagicMock()
-    counter = EventCounter(1, on_target_reached, on_below_target)
+    counter = EventCounter(on_target_reached, on_below_target, target_count=1)
     counter._count = 1
     counter.decrement()
     on_target_reached.assert_not_called()
@@ -50,7 +84,7 @@ def test_decrement_no_call() -> None:
     """Test the decrement() method when callback is not called."""
     on_target_reached = MagicMock()
     on_below_target = MagicMock()
-    counter = EventCounter(2, on_target_reached, on_below_target)
+    counter = EventCounter(on_target_reached, on_below_target, target_count=2)
     counter._count = 1
     counter.decrement()
     on_target_reached.assert_not_called()


### PR DESCRIPTION
There are a couple of buttons -- the "Run script" and "Start recording" ones -- which should only be enabled when certain devices are connected. They should be disabled again when any of the devices disconnects. This means we need a counter to track how many of the required devices are connected at any one time, updating the GUI when this changes.

To do this, I've made a simple class -- `EventCounter` -- which takes a target count and two callbacks as parameters. The first callback is invoked when the target count is reached (i.e. all of the devices are connected) and the second is invoked when the count drops below the target (i.e. one of the devices has disconnected).

Closes #203. Closes #191.