### PR TITLE
Misc tidy-ups of OPUS code

### DIFF
--- a/finesse/em27_status.py
+++ b/finesse/em27_status.py
@@ -1,0 +1,22 @@
+"""Provides an enum representing the EM27's state."""
+from enum import Enum
+
+
+class EM27Status(Enum):
+    """The state of the EM27 interferometer.
+
+    These values are taken from the manual.
+    """
+
+    IDLE = 0
+    CONNECTING = 1
+    CONNECTED = 2
+    MEASURING = 3
+    FINISHING = 4
+    CANCELLING = 5
+    UNDEFINED = 6
+
+    @property
+    def connected(self) -> bool:
+        """Whether the state represents a connected status."""
+        return 2 <= self.value <= 5

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -18,6 +18,7 @@ from schema import And, Or, Schema, SchemaError
 from statemachine import State, StateMachine
 
 from ...config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
+from ...em27_status import EM27Status
 from ..error_message import show_error_message
 
 
@@ -351,7 +352,7 @@ class ScriptRunner(StateMachine):
 
     def _measuring_started(
         self,
-        status: int,
+        status: EM27Status,
         text: str,
         error: Optional[tuple[int, str]],
     ):
@@ -363,7 +364,7 @@ class ScriptRunner(StateMachine):
 
     def _status_received(
         self,
-        status: int,
+        status: EM27Status,
         text: str,
         error: Optional[tuple[int, str]],
     ):
@@ -372,7 +373,7 @@ class ScriptRunner(StateMachine):
             self._on_em27_error_message(*error)
             return
 
-        if status == 2:  # "connected" state, indicating measurement is finished
+        if status == EM27Status.CONNECTED:  # indicates measurement is finished
             self._measuring_end()
         else:
             # Poll again later

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -6,6 +6,7 @@ from pubsub import pub
 from PySide6.QtWidgets import QFileDialog, QGridLayout, QGroupBox, QPushButton
 
 from ...config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
+from ...em27_status import EM27Status
 from ...event_counter import EventCounter
 from ...settings import settings
 from ..path_widget import OpenPathWidget
@@ -127,13 +128,10 @@ class ScriptControl(QGroupBox):
         del self.run_dialog
 
     def _on_opus_message(
-        self, status: int, text: str, error: Optional[tuple[int, str]]
+        self, status: EM27Status, text: str, error: Optional[tuple[int, str]]
     ) -> None:
         """Increase/decrease the enable counter when the EM27 connects/disconnects."""
-        # According to the manual, these are the possible states the EM27 can be in
-        # while connected
-        connected = 2 <= status <= 5
-
+        connected = status.connected
         if connected == self._opus_connected:
             # The connection status hasn't changed
             return

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -14,6 +14,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
+from ..em27_status import EM27Status
+
 
 class OPUSControl(QGroupBox):
     """Class that monitors and controls the OPUS interferometer."""
@@ -88,11 +90,11 @@ class OPUSControl(QGroupBox):
 
     def _log_response(
         self,
-        status: int,
+        status: EM27Status,
         text: str,
         error: Optional[tuple[int, str]],
     ) -> None:
-        self.logger.info(f"Response ({status}): {text}")
+        self.logger.info(f"Response ({status.value}): {text}")
         if error:
             self.logger.error(f"Error ({error[0]}): {error[1]}")
 

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -14,22 +14,18 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-COMMANDS = ["status", "cancel", "stop", "start", "connect"]
-"""The default commands shown for interacting with OPUS."""
-
 
 class OPUSControl(QGroupBox):
     """Class that monitors and controls the OPUS interferometer."""
 
-    def __init__(self, commands: Optional[list[str]] = None) -> None:
-        """Create the widgets to monitor and control the OPUS interferometer.
+    COMMANDS = ["status", "cancel", "stop", "start", "connect"]
+    """The default commands shown for interacting with OPUS."""
 
-        Args:
-            commands: OPUS commands to use
-        """
+    def __init__(self, commands: list[str] = COMMANDS) -> None:
+        """Create the widgets to monitor and control the OPUS interferometer."""
         super().__init__("OPUS client view")
 
-        self.commands = commands if commands is not None else COMMANDS
+        self.commands = commands
         self.logger = logging.getLogger("OPUS")
 
         layout = self._create_controls()

--- a/finesse/hardware/opus/dummy.py
+++ b/finesse/hardware/opus/dummy.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QTimer
 from statemachine import State, StateMachine
 from statemachine.exceptions import TransitionNotAllowed
 
+from ...em27_status import EM27Status
 from .opus_interface_base import OPUSInterfaceBase
 
 
@@ -40,12 +41,12 @@ class OPUSError(Enum):
 class OPUSStateMachine(StateMachine):
     """An FSM for keeping track of the internal state of the mock device."""
 
-    idle = State("Idle", 0, initial=True)
-    connecting = State("Connecting", 1)
-    connected = State("Connected", 2)
-    measuring = State("Measuring", 3)
-    finishing = State("Finishing current measurement", 4)
-    cancelling = State("Cancelling", 5)
+    idle = State("Idle", EM27Status.IDLE, initial=True)
+    connecting = State("Connecting", EM27Status.CONNECTING)
+    connected = State("Connected", EM27Status.CONNECTED)
+    measuring = State("Measuring", EM27Status.MEASURING)
+    finishing = State("Finishing current measurement", EM27Status.FINISHING)
+    cancelling = State("Cancelling", EM27Status.CANCELLING)
     # The manual also describes an "Undefined" state, which we aren't using
 
     _start_connecting = idle.to(connecting)

--- a/finesse/hardware/opus/em27.py
+++ b/finesse/hardware/opus/em27.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import Slot
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 
 from ...config import OPUS_IP
+from ...em27_status import EM27Status
 from .opus_interface_base import OPUSInterfaceBase
 
 STATUS_FILENAME = "stat.htm"
@@ -25,9 +26,9 @@ class OPUSError(Exception):
     """Indicates that an error occurred while communicating with the OPUS program."""
 
 
-def parse_response(response: str) -> tuple[int, str, Optional[tuple[int, str]]]:
+def parse_response(response: str) -> tuple[EM27Status, str, Optional[tuple[int, str]]]:
     """Parse EM27's HTML response."""
-    status: Optional[int] = None
+    status: Optional[EM27Status] = None
     text: Optional[str] = None
     errcode: Optional[int] = None
     errtext: str = ""
@@ -39,7 +40,7 @@ def parse_response(response: str) -> tuple[int, str, Optional[tuple[int, str]]]:
         id = td.attrs["id"]
         data = td.contents[0] if td.contents else ""
         if id == "STATUS":
-            status = int(data)
+            status = EM27Status(int(data))
         elif id == "TEXT":
             text = data
         elif id == "ERRCODE":

--- a/finesse/hardware/opus/opus_interface_base.py
+++ b/finesse/hardware/opus/opus_interface_base.py
@@ -1,12 +1,12 @@
 """Provides a base class for interfacing with the OPUS program."""
 import logging
 import traceback
+from abc import ABC, abstractmethod
 
 from pubsub import pub
-from PySide6.QtCore import QObject
 
 
-class OPUSInterfaceBase(QObject):
+class OPUSInterfaceBase(ABC):
     """Base class providing an interface to the OPUS program."""
 
     def __init__(self) -> None:
@@ -14,6 +14,7 @@ class OPUSInterfaceBase(QObject):
         super().__init__()
         pub.subscribe(self.request_command, "opus.request")
 
+    @abstractmethod
     def request_command(self, command: str) -> None:
         """Request that OPUS run the specified command.
 
@@ -23,7 +24,6 @@ class OPUSInterfaceBase(QObject):
         Args:
             command: Name of command to run
         """
-        raise NotImplementedError("request_command() must be overridden by subclass")
 
     @staticmethod
     def error_occurred(error: BaseException) -> None:

--- a/tests/gui/measure_script/test_script_view.py
+++ b/tests/gui/measure_script/test_script_view.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QPushButton, QWidget
 from pytestqt.qtbot import QtBot
 
 from finesse.config import DEFAULT_SCRIPT_PATH
+from finesse.em27_status import EM27Status
 from finesse.gui.measure_script.script_run_dialog import ScriptRunDialog
 from finesse.gui.measure_script.script_view import ScriptControl
 
@@ -267,10 +268,14 @@ def test_hide_run_dialog_no_abort(
 
 
 @pytest.mark.parametrize(
-    "status,already_connected", product(range(2, 6), (True, False))
+    "status,already_connected",
+    product((EM27Status(i) for i in range(2, 6)), (True, False)),
 )
 def test_on_opus_message_connect(
-    status: int, already_connected: bool, script_control: ScriptControl, qtbot: QtBot
+    status: EM27Status,
+    already_connected: bool,
+    script_control: ScriptControl,
+    qtbot: QtBot,
 ) -> None:
     """Test the _on_opus_message() method when connecting."""
     script_control._opus_connected = already_connected
@@ -285,9 +290,15 @@ def test_on_opus_message_connect(
         assert script_control._opus_connected
 
 
-@pytest.mark.parametrize("status,already_connected", product((1, 6), (True, False)))
+@pytest.mark.parametrize(
+    "status,already_connected",
+    product((EM27Status.CONNECTING, EM27Status.UNDEFINED), (True, False)),
+)
 def test_on_opus_message_disconnect(
-    status: int, already_connected: bool, script_control: ScriptControl, qtbot: QtBot
+    status: EM27Status,
+    already_connected: bool,
+    script_control: ScriptControl,
+    qtbot: QtBot,
 ) -> None:
     """Test the _on_opus_message() method when disconnecting."""
     script_control._opus_connected = already_connected


### PR DESCRIPTION
I've made some small cleanups to the OPUS code in the process of trying (and failing) to solve a separate issue. I figure there's probably enough here for a PR anyway, so here it is.

Commit summary:

- Use an enum to represent EM27 status in frontend and backend
- Tidy up `OPUSControl`'s `__init__`
- Make `OPUSInterfaceBase` a proper abstract class
- Remove duplicate fixture