### PR TITLE
Provide initial x and y values for temperature plot

### DIFF
--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from decimal import Decimal
 from functools import partial
+from typing import Optional  # noqa
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -83,9 +84,13 @@ class TemperaturePlot(QGroupBox):
         self._figure_num_pts = int(
             TEMPERATURE_PLOT_TIME_RANGE / TEMPERATURE_MONITOR_POLL_INTERVAL
         )
-        t = [None] * self._figure_num_pts
-        hot_bb_temp = [None] * self._figure_num_pts
-        cold_bb_temp = [None] * self._figure_num_pts
+        t = [None] * self._figure_num_pts  # type: list[Optional[float]]
+        hot_bb_temp = [None] * self._figure_num_pts  # type: list[Optional[float]]
+        cold_bb_temp = [None] * self._figure_num_pts  # type: list[Optional[float]]
+
+        t[0] = datetime.now().timestamp()
+        hot_bb_temp[0] = 25.0
+        cold_bb_temp[0] = 25.0
 
         hot_colour = "r"
         cold_colour = "b"

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from decimal import Decimal
 from functools import partial
-from typing import Optional  # noqa
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -84,9 +84,9 @@ class TemperaturePlot(QGroupBox):
         self._figure_num_pts = int(
             TEMPERATURE_PLOT_TIME_RANGE / TEMPERATURE_MONITOR_POLL_INTERVAL
         )
-        t = [None] * self._figure_num_pts  # type: list[Optional[float]]
-        hot_bb_temp = [None] * self._figure_num_pts  # type: list[Optional[float]]
-        cold_bb_temp = [None] * self._figure_num_pts  # type: list[Optional[float]]
+        t: list[Optional[float]] = [None] * self._figure_num_pts
+        hot_bb_temp: list[Optional[float]] = [None] * self._figure_num_pts
+        cold_bb_temp: list[Optional[float]] = [None] * self._figure_num_pts
 
         t[0] = datetime.now().timestamp()
         hot_bb_temp[0] = 25.0


### PR DESCRIPTION
This PR provides a fix for the bug in initialisation of the temperature plot.
Initial _x_ value is set as the current time, and initial _y_ values are set to 25 degrees, representative of room temperature.

Requires some comments to satisfy `mypy` - I _think_ I've gone about this the right way.

Closes #220 