### PR TITLE
Removed newline character for cross-platform compatibility

### DIFF
--- a/finesse/hardware/em27_scraper.py
+++ b/finesse/hardware/em27_scraper.py
@@ -57,7 +57,7 @@ def get_em27sensor_data(content: str) -> list[EM27Property]:
     """
     table_header = (
         "<TR><TH>No</TH><TH>Name</TH><TH>Description</TH>"
-        + "<TH>Status</TH><TH>Value</TH><TH>Meas. Unit</TH></TR>\n"
+        + "<TH>Status</TH><TH>Value</TH><TH>Meas. Unit</TH></TR>"
     )
     table_start = content.find(table_header)
     if table_start == -1:


### PR DESCRIPTION
This PR provides a fix for a bug in the web-scraping module.

A search is performed for the table header, which previously included a newline character. This caused an issue on Windows (`\n` vs `\r\n`), so the newline character has simply been removed.