### PR TITLE
Misc hw fixes

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -39,7 +39,7 @@ DEFAULT_DATA_FILE_PATH = Path.home()
 EM27_URL = "http://10.10.0.1/diag_autom.htm"
 """The URL of the EM27 monitoring web server."""
 
-EM27_PROPERTY_POLL_INTERVAL = 2.0
+EM27_PROPERTY_POLL_INTERVAL = 60.0
 """Poll rate for EM27 properties."""
 
 STEPPER_MOTOR_TOPIC = "stepper_motor"

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -80,3 +80,6 @@ TEMPERATURE_MONITOR_HOT_BB_IDX = 6
 
 TEMPERATURE_MONITOR_COLD_BB_IDX = 7
 """Position of the cold blackbody on the temperature monitoring device."""
+
+TC4820_MAX_POWER = 511
+"""The maximum value for the power property."""

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -125,6 +125,7 @@ class DeviceControls:
     def _on_device_closed(self):
         """Change the button to say Open."""
         self.open_close_btn.setText("Open")
+        self.open_close_btn.setChecked(False)
 
     def _on_device_opened(self):
         # Remember these settings for the next time program is run

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -259,6 +259,7 @@ class DP9800Controls(SerialDevicePanel):
 
     def _begin_polling(self) -> None:
         """Initiate polling the DP9800 device."""
+        self._poll_dp9800()
         self._poll_light.timer.start()
 
     def _end_polling(self) -> None:

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import (
 
 from ..config import (
     NUM_TEMPERATURE_MONITOR_CHANNELS,
+    TC4820_MAX_POWER,
     TEMPERATURE_CONTROLLER_POLL_INTERVAL,
     TEMPERATURE_CONTROLLER_TOPIC,
     TEMPERATURE_MONITOR_COLD_BB_IDX,
@@ -360,6 +361,7 @@ class TC4820Controls(SerialDevicePanel):
         layout.addWidget(self._pt100_val, 0, 3)
 
         self._power_bar = QProgressBar()
+        self._power_bar.setMaximum(TC4820_MAX_POWER)
         self._power_bar.setTextVisible(False)
         self._power_bar.setOrientation(Qt.Orientation.Horizontal)
         layout.addWidget(self._power_bar, 1, 1, 1, 3)

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -130,7 +130,8 @@ class DataFileWriter:
                 *temperatures,
                 secs_since_midnight,
                 get_stepper_motor_instance().angle,
-                get_hot_bb_temperature_controller_instance().power,
+                get_hot_bb_temperature_controller_instance().power
+                / (config.TC4820_MAX_POWER / 100),
             )
         )
 

--- a/finesse/hardware/temperature/dp9800.py
+++ b/finesse/hardware/temperature/dp9800.py
@@ -161,13 +161,13 @@ class DP9800(TemperatureMonitorBase):
         Raises:
             DP9800Error: Malformed message received from device
         """
-        # require at least 4 bytes else checks will fail
-        min_length = 4
         try:
-            data = self.serial.read_until(b"\x00", size=min_length)
+            data = self.serial.read_until(b"\x00")
         except SerialException as e:
             raise DP9800Error(e)
 
+        # require at least 4 bytes else checks will fail
+        min_length = 4
         if len(data) < min_length:
             raise DP9800Error("Insufficient data read from device")
 

--- a/finesse/hardware/temperature/tc4820.py
+++ b/finesse/hardware/temperature/tc4820.py
@@ -27,9 +27,6 @@ class MalformedMessageError(Exception):
 class TC4820(TemperatureControllerBase):
     """An interface for TC4820 temperature controllers."""
 
-    MAX_POWER = 511
-    """The maximum value for the power property."""
-
     def __init__(self, name: str, serial: Serial, max_attempts: int = 3) -> None:
         """Create a new TC4820 from an existing serial device.
 

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -9,6 +9,7 @@ import yaml
 
 from finesse.config import (
     STEPPER_MOTOR_TOPIC,
+    TC4820_MAX_POWER,
     TEMPERATURE_CONTROLLER_TOPIC,
     TEMPERATURE_MONITOR_TOPIC,
 )
@@ -129,7 +130,7 @@ def test_write(
     writer._writer = MagicMock()
     writer.write(time, data)
     writer._writer.writerow.assert_called_once_with(
-        ("20230414", "00:01:00", *data, 60, 90.0, 10)
+        ("20230414", "00:01:00", *data, 60, 90.0, 10 / (TC4820_MAX_POWER / 100))
     )
 
 


### PR DESCRIPTION
This PR contains some small fixes to hardware-related bits of the code following testing in the lab:

- Jon recommended polling the EM27 properties every minute (2s -> 60s)
- The TC4820 power meter is now normalised by the maximum TC4820 power, which has been moved to the config file
- TC4820 power output is written to data file as a percentage (closes #234)
- Reading from the DP9800 temperature monitor was incorrectly using the expected message size argument, which has now been removed
- DP9800 device is now polled as soon as connection is opened, for consistency with the other devices
- If error with serial device occurs, and connection closes, Open/Close button does not become appropriately "unchecked". This is now manually unchecked on device close.