### PR TITLE
Fix pre-commit autoupdate hook

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-    python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.10
+    python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
The problem seems to be that we have explicitly specified a Python version in
`.pre-commit-config.yaml` that doesn't exist on the CI runner used for the autoupdate
hook. I've tackled this by:

1. Unpinning the Python version used by `pre-commit`
2. Updating the Ubuntu version used by the hook to `ubuntu-latest`

The mystery remains as to why this wasn't causing an issue before.

NB: By using `ubuntu-latest`, the hook may break again if the hooks require an *older*
version of Python than that provided by whatever version of Ubuntu is being used, but
this will likely be trivial to fix anyway so probably isn't worth worrying about.

Fixes #235.