### PR TITLE
Fix stepper motor timeout

### DIFF
--- a/finesse/hardware/stepper_motor/st10_controller.py
+++ b/finesse/hardware/stepper_motor/st10_controller.py
@@ -275,8 +275,10 @@ class ST10Controller(StepperMotorBase):
         # Tell the controller that this is step 0 ("set variable SP to 0")
         self._write_check("SP0")
 
-        # Make sure the motor has stopped
-        self.wait_until_stopped(3.0)
+        # Make sure the motor has stopped. Note that the move commands are not run
+        # synchronously, so this time is the time taken for all of these commands to
+        # finish.
+        self.wait_until_stopped(10.0)
 
     def _relative_move(self, steps: int) -> None:
         """Move the stepper motor to the specified relative position.

--- a/finesse/hardware/stepper_motor/st10_controller.py
+++ b/finesse/hardware/stepper_motor/st10_controller.py
@@ -67,7 +67,7 @@ class _SerialReader(QThread):
 
         self.serial = serial
         self.sync_timeout = sync_timeout
-        self.out_queue: Queue = Queue()
+        self.out_queue: Queue[Union[str, BaseException]] = Queue()
         self.stopping = False
 
     def __del__(self) -> None:
@@ -89,10 +89,6 @@ class _SerialReader(QThread):
             ST10ControllerError: Malformed message received from device
         """
         raw = self.serial.read_until(b"\r")
-
-        # Check that it hasn't timed out
-        if not raw:
-            raise SerialTimeoutException()
 
         logging.debug(f"(ST10) <<< {repr(raw)}")
 
@@ -136,12 +132,17 @@ class _SerialReader(QThread):
         while self._process_read():
             pass
 
-    def read_sync(self) -> str:
-        """Read synchronously from the serial device."""
+    def read_sync(self, timeout: Optional[float] = None) -> str:
+        """Read synchronously from the serial device.
+
+        Args:
+            timeout: Amount of time to wait for a response (None==default)
+        """
+        if timeout is None:
+            timeout = self.sync_timeout
+
         try:
-            response: Union[str, BaseException] = self.out_queue.get(
-                timeout=self.sync_timeout
-            )
+            response = self.out_queue.get(timeout=timeout)
         except Exception:
             raise SerialTimeoutException()
 
@@ -336,15 +337,18 @@ class ST10Controller(StepperMotorBase):
         # "Send string"
         self._write_check(f"SS{string}")
 
-    def _read_sync(self) -> str:
+    def _read_sync(self, timeout: Optional[float] = None) -> str:
         """Read the next message from the device synchronously.
+
+        Args:
+            timeout: Amount of time to wait for a response (None==default)
 
         Raises:
             SerialException: Error communicating with device
             SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
         """
-        return self._reader.read_sync()
+        return self._reader.read_sync(timeout)
 
     def _write(self, message: str) -> None:
         """Send the specified message to the device.
@@ -448,16 +452,9 @@ class ST10Controller(StepperMotorBase):
         # Tell device to send "X" when current operations are complete
         self._send_string("X")
 
-        # Set temporary timeout
-        old_timeout, self.serial.timeout = self.serial.timeout, timeout
-        try:
-            if self._read_sync() != "X":
-                raise ST10ControllerError(
-                    "Invalid response received when waiting for X"
-                )
-        finally:
-            # Restore previous timeout setting
-            self.serial.timeout = old_timeout
+        # Wait for expected response
+        if self._read_sync(timeout) != "X":
+            raise ST10ControllerError("Invalid response received when waiting for X")
 
     def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done."""

--- a/finesse/logger.py
+++ b/finesse/logger.py
@@ -15,8 +15,7 @@ def initialise_logging() -> None:
     filename = log_path / f"{datetime.now().strftime('%Y%m%d_%H-%M-%S')}.log"
 
     # Allow user to set log level with environment variable
-    log_level = os.environ.get("FINESSE_LOG_LEVEL") or "INFO"
-    log_level = log_level.upper()
+    log_level = (os.environ.get("FINESSE_LOG_LEVEL") or "INFO").upper()
     if not hasattr(logging, log_level):
         raise ValueError(f"Invalid log level: {log_level}")
 

--- a/finesse/logger.py
+++ b/finesse/logger.py
@@ -1,5 +1,6 @@
 """Set up the program's logger."""
 import logging
+import os
 from datetime import datetime
 
 from platformdirs import user_log_path
@@ -13,9 +14,15 @@ def initialise_logging() -> None:
     log_path.mkdir(parents=True, exist_ok=True)
     filename = log_path / f"{datetime.now().strftime('%Y%m%d_%H-%M-%S')}.log"
 
+    # Allow user to set log level with environment variable
+    log_level = os.environ.get("FINESSE_LOG_LEVEL") or "INFO"
+    log_level = log_level.upper()
+    if not hasattr(logging, log_level):
+        raise ValueError(f"Invalid log level: {log_level}")
+
     # Log to console and file
     logging.basicConfig(
-        level=logging.INFO,
+        level=log_level,
         format="%(asctime)s [%(levelname)s] %(message)s",
         handlers=[logging.FileHandler(filename), logging.StreamHandler()],
     )


### PR DESCRIPTION
Fixes #237.

It took a while for me to figure out what was going on here, but it turns out there were two problems.

Firstly, the homing routine wasn't waiting for long enough before timing out. We forgot that the timeout is for *all* of the homing movements, not just the last one, so I've extended it to 10s.

Secondly, the logic around timing out for synchronous reads was broken. As we do all the reading for the device on a separate thread in order to intercept asynchronous messages (viz. the "I've stopped moving" message) that can occur at some unspecified time, we need the read timeout for the serial device to be infinity. On the other hand, we don't want the synchronous reads to wait forever (in case the device has disconnected), but the solution isn't to do what I did before and temporarily change the read timeout; what happens in that case is that the reading thread will start a new read with this new timeout then raise an exception when no new message appears, even though no message is expected. Now the timeout is set to infinity and instead we check whether synchronous reads have timed out by adding a timeout for reading the messages from `_SerialReader`'s `out_queue`.

I also changed things to allow the user to set the log level with an environment variable.