### PR TITLE
Fix stuck measure scripts

### DIFF
--- a/finesse/gui/em27_monitor.py
+++ b/finesse/gui/em27_monitor.py
@@ -1,4 +1,6 @@
 """Panel and widgets related to monitoring the interferometer."""
+import logging
+
 from pubsub import pub
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
@@ -107,6 +109,7 @@ class EM27Monitor(QGroupBox):
 
     def _poll_server(self) -> None:
         """Polls the server to obtain the latest values."""
+        logging.info("Polling EM27 sensors")
         self._poll_light.flash()
         pub.sendMessage("em27.data.request")
 

--- a/finesse/gui/measure_script/script_run_dialog.py
+++ b/finesse/gui/measure_script/script_run_dialog.py
@@ -37,6 +37,9 @@ class ScriptRunDialog(QDialog):
         self.setWindowTitle("Running measure script")
         self.setModal(True)
 
+        # Keep a reference to prevent it being GC'd mid-run
+        self._script_runner = script_runner
+
         layout = QVBoxLayout()
         self._progress_bar = QProgressBar()
         """Shows the progress of the measure script."""

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -39,6 +39,7 @@ class OPUSControl(QGroupBox):
             QSizePolicy.Policy.MinimumExpanding,
         )
 
+        pub.subscribe(self._log_request, "opus.request")
         pub.subscribe(self._log_response, "opus.response")
         pub.subscribe(self._log_error, "opus.error")
 
@@ -94,6 +95,10 @@ class OPUSControl(QGroupBox):
         layout.addWidget(log_box)
         return layout
 
+    def _log_request(self, command: str) -> None:
+        """Log when a command request is sent."""
+        self.logger.info(f'Executing command "{command}"')
+
     def _log_response(
         self,
         status: EM27Status,
@@ -113,7 +118,6 @@ class OPUSControl(QGroupBox):
         Args:
             command: OPUS command to be executed
         """
-        self.logger.info(f'Executing command "{command}"')
         pub.sendMessage("opus.request", command=command)
 
     def _request_status(self) -> None:


### PR DESCRIPTION
When the EM27 is recording measurements during a measure script, it is repeatedly polled to check when the measurement has finished and the script can move onto the next step. Sometimes it would stop polling mid-run and get stuck forever.

After some digging, I finally figured out that the problem was that the `ScriptRunner` object responsible for, among other things, the timer polling the EM27, was sometimes being GC'd mid-run, which would stop the timer. Presumably every time the timer ran, the `ScriptRunner` was temporarily "revived" and therefore spared from the GC. This took me all afternoon to figure out and the result is a one-line fix :laughing: 

Fixes #244.