### PR TITLE
Fix: Make step property return None if motor is moving

### DIFF
--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -122,6 +122,9 @@ class DataFileWriter:
         # Also include timestamp as seconds since midnight
         midnight = datetime(time.year, time.month, time.day)
         secs_since_midnight = floor((time - midnight).total_seconds())
+        angle = get_stepper_motor_instance().angle
+        if angle is None:  # Occurs when the motor is moving
+            angle = float("nan")
 
         self._writer.writerow(
             (
@@ -129,7 +132,7 @@ class DataFileWriter:
                 time.strftime("%H:%M:%S"),
                 *temperatures,
                 secs_since_midnight,
-                get_stepper_motor_instance().angle,
+                angle,
                 get_hot_bb_temperature_controller_instance().power
                 / (config.TC4820_MAX_POWER / 100),
             )

--- a/finesse/hardware/stepper_motor/dummy.py
+++ b/finesse/hardware/stepper_motor/dummy.py
@@ -47,8 +47,16 @@ class DummyStepperMotor(StepperMotorBase):
         return self._steps_per_rotation
 
     @property
-    def step(self) -> int:
+    def is_moving(self) -> bool:
+        """Whether the motor is currently moving."""
+        return self._move_end_timer.isActive()
+
+    @property
+    def step(self) -> int | None:
         """The number of steps that correspond to a full rotation."""
+        if self.is_moving:
+            return None
+
         return self._step
 
     @step.setter

--- a/finesse/hardware/stepper_motor/dummy.py
+++ b/finesse/hardware/stepper_motor/dummy.py
@@ -53,7 +53,11 @@ class DummyStepperMotor(StepperMotorBase):
 
     @property
     def step(self) -> int | None:
-        """The number of steps that correspond to a full rotation."""
+        """The number of steps that correspond to a full rotation.
+
+        As this can only be requested when the motor is stationary, if the motor is
+        moving then None will be returned.
+        """
         if self.is_moving:
             return None
 

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -102,15 +102,18 @@ class StepperMotorBase(DeviceBase):
         """Whether the motor is currently moving."""
 
     @property
-    def angle(self) -> float:
+    def angle(self) -> float | None:
         """The current angle of the motor in degrees.
 
+        As this can only be requested when the motor is stationary, if the motor is
+        moving then None will be returned.
+
         Returns:
-            The current angle or NaN if the stepper motor is moving
+            The current angle or None if the stepper motor is moving
         """
         step = self.step
         if step is None:
-            return float("nan")
+            return None
 
         return step * 360.0 / self.steps_per_rotation
 

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -6,7 +6,7 @@ from pubsub import pub
 
 from ...config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 from ..device_base import DeviceBase
-from ..pubsub_decorators import pubsub_broadcast, pubsub_errors
+from ..pubsub_decorators import pubsub_errors
 
 error_wrap = pubsub_errors(f"serial.{STEPPER_MOTOR_TOPIC}.error")
 """Broadcast exceptions via pubsub."""
@@ -32,9 +32,6 @@ class StepperMotorBase(DeviceBase):
         pub.subscribe(self._stop_moving, f"serial.{STEPPER_MOTOR_TOPIC}.stop")
         pub.subscribe(
             self._notify_on_stopped, f"serial.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"
-        )
-        pub.subscribe(
-            self._request_angle, f"serial.{STEPPER_MOTOR_TOPIC}.request.angle"
         )
 
     @staticmethod
@@ -132,12 +129,3 @@ class StepperMotorBase(DeviceBase):
             raise ValueError("Angle must be between 0° and 270°")
 
         self.step = round(self.steps_per_rotation * target / 360.0)
-
-    @pubsub_broadcast(
-        f"serial.{STEPPER_MOTOR_TOPIC}.error",
-        f"serial.{STEPPER_MOTOR_TOPIC}.response.angle",
-        "angle",
-    )
-    def _request_angle(self) -> float:
-        """Request the current angle from the device and return via pubsub."""
-        return self.angle

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -64,7 +64,7 @@ class StepperMotorBase(DeviceBase):
 
     @property
     @abstractmethod
-    def step(self) -> int:
+    def step(self) -> int | None:
         """The current state of the device's step counter."""
 
     @step.setter
@@ -96,9 +96,22 @@ class StepperMotorBase(DeviceBase):
         """
 
     @property
+    @abstractmethod
+    def is_moving(self) -> bool:
+        """Whether the motor is currently moving."""
+
+    @property
     def angle(self) -> float:
-        """The current angle of the motor in degrees."""
-        return self.step * 360.0 / self.steps_per_rotation
+        """The current angle of the motor in degrees.
+
+        Returns:
+            The current angle or NaN if the stepper motor is moving
+        """
+        step = self.step
+        if step is None:
+            return float("nan")
+
+        return step * 360.0 / self.steps_per_rotation
 
     def move_to(self, target: Union[float, str]) -> None:
         """Move the motor to a specified rotation and send message when complete.

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -65,7 +65,11 @@ class StepperMotorBase(DeviceBase):
     @property
     @abstractmethod
     def step(self) -> int | None:
-        """The current state of the device's step counter."""
+        """The current state of the device's step counter.
+
+        As this can only be requested when the motor is stationary, if the motor is
+        moving then None will be returned.
+        """
 
     @step.setter
     @abstractmethod

--- a/tests/hardware/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/stepper_motor/test_st10_controller.py
@@ -2,7 +2,7 @@
 from contextlib import nullcontext as does_not_raise
 from itertools import chain
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from serial import SerialException, SerialTimeoutException
@@ -208,8 +208,18 @@ def test_check_device_id(dev: ST10Controller) -> None:
         [(4, "SP=hello", pytest.raises(ST10ControllerError))],
     ),
 )
-def test_get_step(step: int, response: str, raises: Any, dev: ST10Controller) -> None:
+@patch(
+    "finesse.hardware.stepper_motor.ST10Controller.is_moving", new_callable=PropertyMock
+)
+def test_get_step(
+    is_moving_mock: PropertyMock,
+    step: int,
+    response: str,
+    raises: Any,
+    dev: ST10Controller,
+) -> None:
     """Test getting the step property."""
+    is_moving_mock.return_value = False
     with read_mock(dev, response):
         with raises:
             assert dev.step == step

--- a/tests/hardware/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/stepper_motor/test_stepper_motor_base.py
@@ -62,9 +62,6 @@ def test_init(subscribe_mock: MagicMock) -> None:
     subscribe_mock.assert_any_call(
         stepper._notify_on_stopped, f"serial.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"
     )
-    subscribe_mock.assert_any_call(
-        stepper._request_angle, f"serial.{STEPPER_MOTOR_TOPIC}.request.angle"
-    )
 
 
 def test_angle(stepper: _MockStepperMotor) -> None:
@@ -86,14 +83,4 @@ def test_send_error_message(
     stepper.send_error_message(error)
     sendmsg_mock.assert_called_once_with(
         f"serial.{STEPPER_MOTOR_TOPIC}.error", error=error
-    )
-
-
-def test_request_angle(stepper: _MockStepperMotor, sendmsg_mock: MagicMock) -> None:
-    """Test the _request_angle() method."""
-    stepper.step = 1
-    stepper._steps_per_rotation = 1
-    stepper._request_angle()
-    sendmsg_mock.assert_called_once_with(
-        f"serial.{STEPPER_MOTOR_TOPIC}.response.angle", angle=360.0
     )

--- a/tests/hardware/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/stepper_motor/test_stepper_motor_base.py
@@ -19,7 +19,11 @@ class _MockStepperMotor(StepperMotorBase):
         return self._steps_per_rotation
 
     @property
-    def step(self) -> int:
+    def is_moving(self) -> bool:
+        return False
+
+    @property
+    def step(self) -> int | None:
         return self._step
 
     @step.setter


### PR DESCRIPTION
It seems that you can't query the stepper motor's position while it's in motion. This isn't a problem for the experiments, as these will only be carried out when the motor is stationary, but as the motor position is continually written into the data file it was breaking things. Now if the motor is moving, a `nan` is written instead of the angle.

Fixes #250.