### PR TITLE
Make writing data files safer

### DIFF
--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -1,5 +1,6 @@
 """Provides a class for writing sensor data to a CSV file."""
 import logging
+import os
 import platform
 from datetime import datetime
 from decimal import Decimal
@@ -120,6 +121,11 @@ class DataFileWriter:
 
         if hasattr(self, "_writer"):
             logging.info("Closing data file")
+
+            # Ensure data is written to disk
+            self._writer._file.flush()
+            os.fsync(self._writer._file.fileno())
+
             self._writer.close()
             del self._writer
 

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -141,6 +141,7 @@ class DataFileWriter:
                 / (config.TC4820_MAX_POWER / 100),
             )
         )
+        self._writer._file.flush()
 
 
 _data_file_writer = DataFileWriter()

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -1,4 +1,5 @@
 """Provides a class for writing sensor data to a CSV file."""
+import logging
 import platform
 from datetime import datetime
 from decimal import Decimal
@@ -89,6 +90,7 @@ class DataFileWriter:
         Args:
             path: The path of the file to write to
         """
+        logging.info(f"Opening data file at {path}")
         self._writer = Writer(path, _get_metadata(path.name))
 
         # Write column headers
@@ -113,6 +115,8 @@ class DataFileWriter:
         pub.unsubscribe(
             self.write, f"serial.{config.TEMPERATURE_MONITOR_TOPIC}.data.response"
         )
+
+        logging.info("Closing data file")
         self._writer.close()
         del self._writer
 

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -70,6 +70,9 @@ class DataFileWriter:
         pub.subscribe(self.open, "data_file.open")
         pub.subscribe(self.close, "data_file.close")
 
+        # Close data file if GUI closes unexpectedly
+        pub.subscribe(self.close, "window.closed")
+
         # Listen for error messages
         pub.subscribe(_on_error_occurred, "data_file.error")
 

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -80,8 +80,7 @@ class DataFileWriter:
     def disable(self) -> None:
         """Send disable message and close file if open."""
         pub.sendMessage("data_file.disable")
-        if hasattr(self, "_writer"):
-            pub.sendMessage("data_file.close")
+        pub.sendMessage("data_file.close")
 
     @pubsub_errors("data_file.error")
     def open(self, path: Path) -> None:
@@ -116,9 +115,10 @@ class DataFileWriter:
             self.write, f"serial.{config.TEMPERATURE_MONITOR_TOPIC}.data.response"
         )
 
-        logging.info("Closing data file")
-        self._writer.close()
-        del self._writer
+        if hasattr(self, "_writer"):
+            logging.info("Closing data file")
+            self._writer.close()
+            del self._writer
 
     @pubsub_errors("data_file.error")
     def write(self, time: datetime, temperatures: list[Decimal]) -> None:

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -164,15 +164,9 @@ def test_enable(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
     sendmsg_mock.assert_called_once_with("data_file.enable")
 
 
-def test_disable_close(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
+def test_disable(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
     """Test the disable() method while writing."""
     writer._writer = MagicMock()
     writer.disable()
     sendmsg_mock.assert_any_call("data_file.disable")
     sendmsg_mock.assert_any_call("data_file.close")
-
-
-def test_disable_no_close(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
-    """Test the disable() method while not writing."""
-    writer.disable()
-    sendmsg_mock.assert_called_once_with("data_file.disable")


### PR DESCRIPTION
While tinkering with things I found that if you exit the program while the data file is recording, it stops abruptly without flushing to disk, so data is lost. Not ideal.

This PR addresses the problem by:

1. Ensuring the write buffer is regularly flushed (and flushed to disk on close)
2. Ensuring that data recording is stopped properly on program exit

Fixes #265.

Note that I'm doing the flushing by using a private member of the `Writer` class, which isn't ideal. In the long run, we could consider changing `pycsvy` to better support this use case: https://github.com/ImperialCollegeLondon/pycsvy/issues/60