### PR TITLE
Close serial devices on window close

### DIFF
--- a/finesse/hardware/serial_manager.py
+++ b/finesse/hardware/serial_manager.py
@@ -76,6 +76,9 @@ class SerialManager:
             # Listen for close events for this device
             pub.subscribe(self._close, f"serial.{self.name}.close")
 
+            # Also close the device if the window closes unexpectedly
+            pub.subscribe(self._close, "window.closed")
+
             # For now, assume all errors are fatal so close the port
             pub.subscribe(self._send_close_message, f"serial.{self.name}.error")
 


### PR DESCRIPTION
The devices are currently not closed cleanly on program exit. This doesn't matter in general, except that the `close()` method for the stepper motor controller turns the mirror downwards first (to prevent dust buildup), so ideally we do want this to happen.

Fixes #248.