### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, ubuntu-latest, macos-latest ]
-        python-version: [ "3.10" ]
+        python-version: [ "3.11" ]
 
     steps:
     - uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install system dependencies in Linux
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,15 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.9.0
+    hooks:
+    -   id: pyupgrade
+        args: ["--py311-plus"]
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.2.0
+    hooks:
+    -   id: autoflake
   - repo: https://github.com/timothycrosley/isort
     rev: "5.12.0"
     hooks:

--- a/finesse/event_counter.py
+++ b/finesse/event_counter.py
@@ -1,6 +1,6 @@
 """Provides a class for monitoring events such as device opening/closing."""
-from collections.abc import Callable
-from typing import Any, Optional, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
 
 from pubsub import pub
 
@@ -16,7 +16,7 @@ class EventCounter:
         self,
         on_target_reached: Callable[[], Any],
         on_below_target: Callable[[], Any],
-        target_count: Optional[int] = None,
+        target_count: int | None = None,
         device_names: Sequence[str] = (),
     ) -> None:
         """Create a new EventCounter.

--- a/finesse/gui/error_message.py
+++ b/finesse/gui/error_message.py
@@ -1,11 +1,10 @@
 """For showing error messages."""
 import logging
-from typing import Optional
 
 from PySide6.QtWidgets import QMessageBox, QWidget
 
 
-def show_error_message(parent: Optional[QWidget], msg: str) -> None:
+def show_error_message(parent: QWidget | None, msg: str) -> None:
     """Show an error message in the GUI and write to the program log."""
     # Show popup box in GUI
     msg_box = QMessageBox(

--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -3,7 +3,6 @@
 import logging
 from dataclasses import asdict
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from PySide6.QtGui import QCloseEvent
@@ -27,7 +26,7 @@ from .sequence_widget import SequenceWidget
 class ScriptEditDialog(QDialog):
     """A dialog to create and edit measure scripts."""
 
-    def __init__(self, parent: QWidget, script: Optional[Script] = None) -> None:
+    def __init__(self, parent: QWidget, script: Script | None = None) -> None:
         """Create a new ScriptEditDialog.
 
         Args:
@@ -38,7 +37,7 @@ class ScriptEditDialog(QDialog):
         self.setWindowTitle("Edit measurement script")
         self.setModal(True)
 
-        initial_save_path: Optional[Path] = None
+        initial_save_path: Path | None = None
         if script:
             self.count = CountWidget("Repeats", script.repeats)
             self.sequence_widget = SequenceWidget(script.sequence)

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -1,6 +1,6 @@
 """Contains a panel for loading and editing measure scripts."""
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 from pubsub import pub
 from PySide6.QtWidgets import QFileDialog, QGridLayout, QGroupBox, QPushButton
@@ -15,7 +15,7 @@ from .script_edit_dialog import ScriptEditDialog
 from .script_run_dialog import ScriptRunDialog
 
 
-def _get_previous_script_path() -> Optional[Path]:
+def _get_previous_script_path() -> Path | None:
     path = cast(str, settings.value("script/run_path", ""))
     return Path(path) if path else None
 
@@ -128,7 +128,7 @@ class ScriptControl(QGroupBox):
         del self.run_dialog
 
     def _on_opus_message(
-        self, status: EM27Status, text: str, error: Optional[tuple[int, str]]
+        self, status: EM27Status, text: str, error: tuple[int, str] | None
     ) -> None:
         """Increase/decrease the enable counter when the EM27 connects/disconnects."""
         if status.is_connected == self._opus_connected:

--- a/finesse/gui/measure_script/sequence_widget.py
+++ b/finesse/gui/measure_script/sequence_widget.py
@@ -1,5 +1,5 @@
 """Provides a collection of controls for editing a measure script."""
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from PySide6.QtCore import QAbstractTableModel, QModelIndex, QPersistentModelIndex, Qt
 from PySide6.QtWidgets import (
@@ -24,7 +24,7 @@ from .count_widget import CountWidget
 class SequenceWidget(QWidget):
     """A widget with a table of measure instructions and controls to modify them."""
 
-    def __init__(self, sequence: Optional[List[Measurement]] = None) -> None:
+    def __init__(self, sequence: list[Measurement] | None = None) -> None:
         """Create a new SequenceWidget."""
         super().__init__()
 
@@ -46,7 +46,7 @@ class SequenceWidget(QWidget):
         layout.addWidget(self.buttons)
         self.setLayout(layout)
 
-    def add_instruction(self, angle: Union[str, float], measurements: int) -> None:
+    def add_instruction(self, angle: str | float, measurements: int) -> None:
         """Add a new measure instruction to the sequence.
 
         Args:
@@ -57,7 +57,7 @@ class SequenceWidget(QWidget):
         self.model.layoutChanged.emit()
         self.table.scrollToBottom()
 
-    def _get_selected_rows(self, reverse: bool = False) -> List[int]:
+    def _get_selected_rows(self, reverse: bool = False) -> list[int]:
         """Get the indices of the currently selected rows in the table.
 
         Args:
@@ -133,7 +133,7 @@ class SequenceModel(QAbstractTableModel):
     _COLUMNS = ("angle", "measurements")
     """The names of the data columns."""
 
-    def __init__(self, sequence: List[Measurement]) -> None:
+    def __init__(self, sequence: list[Measurement]) -> None:
         """Create a new SequenceModel.
 
         Args:
@@ -144,7 +144,7 @@ class SequenceModel(QAbstractTableModel):
 
     def data(
         self,
-        index: Union[QModelIndex, QPersistentModelIndex],
+        index: QModelIndex | QPersistentModelIndex,
         role: int = Qt.ItemDataRole.DisplayRole,
     ) -> Any:
         """Provides the model's data."""

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -2,7 +2,6 @@
 import logging
 import weakref
 from functools import partial
-from typing import Optional
 
 from pubsub import pub
 from PySide6.QtGui import QTextCursor
@@ -103,7 +102,7 @@ class OPUSControl(QGroupBox):
         self,
         status: EM27Status,
         text: str,
-        error: Optional[tuple[int, str]],
+        error: tuple[int, str] | None,
     ) -> None:
         self.logger.info(f"Response ({status.value}): {text}")
         if error:

--- a/finesse/gui/path_widget.py
+++ b/finesse/gui/path_widget.py
@@ -1,7 +1,7 @@
 """Provides a widget for choosing the path to a measure script."""
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from PySide6.QtWidgets import (
     QFileDialog,
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
 class PathWidget(QWidget):
     """A widget containing a text box with a file path and a browse button."""
 
-    def __init__(self, initial_file_path: Optional[Path] = None) -> None:
+    def __init__(self, initial_file_path: Path | None = None) -> None:
         """Create a new PathWidget.
 
         Args:
@@ -45,10 +45,10 @@ class PathWidget(QWidget):
             self.set_path(filename)
 
     @abstractmethod
-    def try_get_path_from_dialog(self) -> Optional[Path]:
+    def try_get_path_from_dialog(self) -> Path | None:
         """Try to get the file name by raising a dialog."""
 
-    def try_get_path(self) -> Optional[Path]:
+    def try_get_path(self) -> Path | None:
         """Try to get the path of the chosen file for this widget.
 
         If the path hasn't yet been set, a QFileDialog is opened to let the user choose
@@ -80,8 +80,8 @@ class OpenPathWidget(PathWidget):
 
     def __init__(
         self,
-        initial_file_path: Optional[Path] = None,
-        extension: Optional[str] = None,
+        initial_file_path: Path | None = None,
+        extension: str | None = None,
         **file_dialog_kwargs: Any,
     ) -> None:
         """Create a new OpenPathWidget.
@@ -96,7 +96,7 @@ class OpenPathWidget(PathWidget):
             file_dialog_kwargs["filter"] = f"*.{extension}"
         self.file_dialog_kwargs = file_dialog_kwargs
 
-    def try_get_path_from_dialog(self) -> Optional[Path]:
+    def try_get_path_from_dialog(self) -> Path | None:
         """Try to get the path of the file to open by raising a dialog."""
         filename, _ = QFileDialog.getOpenFileName(**self.file_dialog_kwargs)
 
@@ -108,8 +108,8 @@ class SavePathWidget(PathWidget):
 
     def __init__(
         self,
-        initial_file_path: Optional[Path] = None,
-        extension: Optional[str] = None,
+        initial_file_path: Path | None = None,
+        extension: str | None = None,
         **file_dialog_kwargs: Any,
     ) -> None:
         """Create a new SavePathWidget.
@@ -125,7 +125,7 @@ class SavePathWidget(PathWidget):
         self.extension = extension
         self.file_dialog_kwargs = file_dialog_kwargs
 
-    def try_get_path_from_dialog(self) -> Optional[Path]:
+    def try_get_path_from_dialog(self) -> Path | None:
         """Try to get the path to save the file to by opening a dialog."""
         filename, _ = QFileDialog.getSaveFileName(**self.file_dialog_kwargs)
 

--- a/finesse/gui/serial_view.py
+++ b/finesse/gui/serial_view.py
@@ -1,6 +1,7 @@
 """Panel and widgets related to the control of the serial ports."""
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence, cast
+from typing import cast
 
 from pubsub import pub
 from PySide6.QtWidgets import (

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 from decimal import Decimal
 from functools import partial
-from typing import Optional
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -89,9 +88,9 @@ class TemperaturePlot(QGroupBox):
         self._figure_num_pts = int(
             TEMPERATURE_PLOT_TIME_RANGE / TEMPERATURE_MONITOR_POLL_INTERVAL
         )
-        t: list[Optional[float]] = [None] * self._figure_num_pts
-        hot_bb_temp: list[Optional[float]] = [None] * self._figure_num_pts
-        cold_bb_temp: list[Optional[float]] = [None] * self._figure_num_pts
+        t: list[float | None] = [None] * self._figure_num_pts
+        hot_bb_temp: list[float | None] = [None] * self._figure_num_pts
+        cold_bb_temp: list[float | None] = [None] * self._figure_num_pts
 
         t[0] = datetime.now().timestamp()
         hot_bb_temp[0] = 25.0

--- a/finesse/gui/uncaught_exceptions.py
+++ b/finesse/gui/uncaught_exceptions.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import traceback
 from functools import partial
-from typing import Any, Type
+from typing import Any
 
 from PySide6.QtWidgets import (
     QDialog,
@@ -30,7 +30,7 @@ def set_uncaught_exception_handler(parent: QWidget) -> None:
 
 def _handle_exception(
     parent: QWidget,
-    exc_type: Type[BaseException],
+    exc_type: type[BaseException],
     exc_value: BaseException,
     exc_traceback: Any,
 ) -> None:

--- a/finesse/hardware/noise_producer.py
+++ b/finesse/hardware/noise_producer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -15,7 +15,7 @@ class NoiseProducer:
         mean: float = 0.0,
         standard_deviation: float = 1.0,
         type: type = float,
-        seed: Optional[int] = 42,
+        seed: int | None = 42,
     ) -> None:
         """Create a new NoiseProducer.
 
@@ -52,4 +52,4 @@ class NoiseParameters:
 
     mean: float = 0.0
     standard_deviation: float = 1.0
-    seed: Optional[int] = 42
+    seed: int | None = 42

--- a/finesse/hardware/opus/dummy.py
+++ b/finesse/hardware/opus/dummy.py
@@ -1,8 +1,8 @@
 """Provides a dummy EM27 device for interfacing with."""
 
 import logging
+from collections.abc import Callable
 from enum import Enum
-from typing import Callable, Optional
 
 from pubsub import pub
 from PySide6.QtCore import QTimer
@@ -31,7 +31,7 @@ class OPUSError(Enum):
     NO_RESULT = (6, "No result available")
     NOT_CONNECTED = (7, "System not connected")
 
-    def to_tuple(self) -> Optional[tuple[int, str]]:
+    def to_tuple(self) -> tuple[int, str] | None:
         """Convert to a (code, message) tuple or None if no error."""
         if self == OPUSError.NO_ERROR:
             return None

--- a/finesse/hardware/opus/em27.py
+++ b/finesse/hardware/opus/em27.py
@@ -7,7 +7,6 @@ Note that this is a separate machine from the EM27!
 """
 import logging
 from functools import partial
-from typing import Optional
 
 from bs4 import BeautifulSoup
 from pubsub import pub
@@ -26,11 +25,11 @@ class OPUSError(Exception):
     """Indicates that an error occurred while communicating with the OPUS program."""
 
 
-def parse_response(response: str) -> tuple[EM27Status, str, Optional[tuple[int, str]]]:
+def parse_response(response: str) -> tuple[EM27Status, str, tuple[int, str] | None]:
     """Parse EM27's HTML response."""
-    status: Optional[EM27Status] = None
-    text: Optional[str] = None
-    errcode: Optional[int] = None
+    status: EM27Status | None = None
+    text: str | None = None
+    errcode: int | None = None
     errtext: str = ""
     soup = BeautifulSoup(response, "html.parser")
     for td in soup.find_all("td"):

--- a/finesse/hardware/stepper_motor/dummy.py
+++ b/finesse/hardware/stepper_motor/dummy.py
@@ -1,6 +1,5 @@
 """Code for a fake stepper motor device."""
 import logging
-from typing import Optional
 
 from pubsub import pub
 from PySide6.QtCore import QTimer
@@ -80,7 +79,7 @@ class DummyStepperMotor(StepperMotorBase):
         self._move_end_timer.stop()
         self._on_move_end()
 
-    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: float | None = None) -> None:
         """Wait until the motor has stopped moving.
 
         For this dummy class, this is a no-op.

--- a/finesse/hardware/stepper_motor/st10_controller.py
+++ b/finesse/hardware/stepper_motor/st10_controller.py
@@ -9,7 +9,6 @@ The specification is available online:
 
 import logging
 from queue import Queue
-from typing import Optional, Union
 
 from pubsub import pub
 from PySide6.QtCore import QThread, Signal, Slot
@@ -67,7 +66,7 @@ class _SerialReader(QThread):
 
         self.serial = serial
         self.sync_timeout = sync_timeout
-        self.out_queue: Queue[Union[str, BaseException]] = Queue()
+        self.out_queue: Queue[str | BaseException] = Queue()
         self.stopping = False
 
     def __del__(self) -> None:
@@ -132,7 +131,7 @@ class _SerialReader(QThread):
         while self._process_read():
             pass
 
-    def read_sync(self, timeout: Optional[float] = None) -> str:
+    def read_sync(self, timeout: float | None = None) -> str:
         """Read synchronously from the serial device.
 
         Args:
@@ -360,7 +359,7 @@ class ST10Controller(StepperMotorBase):
         # "Send string"
         self._write_check(f"SS{string}")
 
-    def _read_sync(self, timeout: Optional[float] = None) -> str:
+    def _read_sync(self, timeout: float | None = None) -> str:
         """Read the next message from the device synchronously.
 
         Args:
@@ -461,7 +460,7 @@ class ST10Controller(StepperMotorBase):
         """Immediately stop moving the motor."""
         self._write_check("ST")
 
-    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: float | None = None) -> None:
         """Wait until the motor has stopped moving.
 
         Args:

--- a/finesse/hardware/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/stepper_motor/stepper_motor_base.py
@@ -1,6 +1,5 @@
 """Provides the base class for stepper motor implementations."""
 from abc import abstractmethod
-from typing import Optional, Union
 
 from pubsub import pub
 
@@ -82,7 +81,7 @@ class StepperMotorBase(DeviceBase):
         """Immediately stop moving the motor."""
 
     @abstractmethod
-    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: float | None = None) -> None:
         """Wait until the motor has stopped moving.
 
         Args:
@@ -117,7 +116,7 @@ class StepperMotorBase(DeviceBase):
 
         return step * 360.0 / self.steps_per_rotation
 
-    def move_to(self, target: Union[float, str]) -> None:
+    def move_to(self, target: float | str) -> None:
         """Move the motor to a specified rotation and send message when complete.
 
         Sends a stepper.move.end message when finished.

--- a/finesse/hardware/temperature/dummy_temperature_monitor.py
+++ b/finesse/hardware/temperature/dummy_temperature_monitor.py
@@ -1,6 +1,6 @@
 """This module provides an interface to dummy DP9800 temperature readers."""
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import Sequence
 
 from ...config import NUM_TEMPERATURE_MONITOR_CHANNELS
 from ..noise_producer import NoiseParameters, NoiseProducer

--- a/poetry.lock
+++ b/poetry.lock
@@ -84,7 +84,6 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -368,9 +367,6 @@ files = [
     {file = "coverage-7.2.3.tar.gz", hash = "sha256:d298c2815fa4891edd9abe5ad6e6cb4207104c7dd9fd13aea3fdebf6f9b91259"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli"]
 
@@ -406,20 +402,6 @@ files = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
     {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
 ]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.1.1"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
-    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
@@ -1033,7 +1015,6 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -1509,11 +1490,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -1567,10 +1546,7 @@ files = [
 [package.dependencies]
 attrs = ">=19.0"
 filelock = ">=3.0"
-mypy = [
-    {version = ">=0.900", markers = "python_version >= \"3.11\""},
-    {version = ">=0.780", markers = "python_version >= \"3.9\" and python_version < \"3.11\""},
-]
+mypy = {version = ">=0.900", markers = "python_version >= \"3.11\""}
 pytest = {version = ">=6.2", markers = "python_version >= \"3.10\""}
 
 [[package]]
@@ -1859,17 +1835,6 @@ files = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "types-beautifulsoup4"
 version = "4.12.0.5"
 description = "Typing stubs for beautifulsoup4"
@@ -2004,5 +1969,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<3.12"
-content-hash = "9cb2875dfa85e269d821af7eb059593386540bdc850adf9f952e1faf2479a40d"
+python-versions = ">=3.11,<3.12"
+content-hash = "bd0a8a01ef10198283e9cfac197d1840272228911de7c82a27fa09165ae2f0b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+python = ">=3.11,<3.12"
 PySide6 = "^6.5.1"
 matplotlib = "^3.7.2"
 platformdirs = "^3.9.1"

--- a/tests/gui/measure_script/conftest.py
+++ b/tests/gui/measure_script/conftest.py
@@ -1,6 +1,6 @@
 """Provides common fixtures for measure script tests."""
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -2,7 +2,7 @@
 from contextlib import nullcontext as does_not_raise
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -29,7 +29,7 @@ def is_valid_angle(angle: Any) -> bool:
     return False
 
 
-def get_data(repeats: int, angle: Any, num_attributes: int) -> Dict[str, Any]:
+def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
     """Get all or part of data script.
 
     Passing angle==() allows for testing with an empty sequence.
@@ -67,7 +67,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> Dict[str, Any]:
         for num_attributes in range(3)
     ],
 )
-def test_parse_script(data: Dict[str, Any], raises: Any) -> None:
+def test_parse_script(data: dict[str, Any], raises: Any) -> None:
     """Check that errors are thrown for invalid data.
 
     Note that we don't check that serialisation and deserialisation work correctly as it

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -1,7 +1,8 @@
 """Tests for the ScriptEditDialog class and associated code."""
+from collections.abc import Sequence
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, List, Optional, Sequence
+from typing import Any
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -36,7 +37,7 @@ _TEST_SCRIPT = Script(Path("/my/path"), 2, ({"angle": "nadir", "measurements": 3
 )
 def test_init(
     qtbot: QtBot,
-    script: Optional[Script],
+    script: Script | None,
     count: int,
     sequence: Sequence[Measurement],
     script_path: str,
@@ -53,7 +54,7 @@ _MEASUREMENTS = [Measurement(float(i), i) for i in range(1, 4)]
 
 
 def _check_return(
-    seq: List[Measurement], selected_path: bool, read_succeeds: bool
+    seq: list[Measurement], selected_path: bool, read_succeeds: bool
 ) -> Any:
     returns = not seq or (selected_path and read_succeeds)
     return seq, selected_path, read_succeeds, returns
@@ -69,7 +70,7 @@ def _check_return(
     ],
 )
 def test_try_save(
-    seq: List[Measurement],
+    seq: list[Measurement],
     selected_path: bool,
     read_succeeds: bool,
     returns: bool,

--- a/tests/gui/measure_script/test_sequence_widget.py
+++ b/tests/gui/measure_script/test_sequence_widget.py
@@ -1,6 +1,6 @@
 """Tests for the SequenceWidget class and other associated classes."""
+from collections.abc import Sequence
 from itertools import chain
-from typing import Sequence
 from unittest.mock import patch
 
 import pytest

--- a/tests/gui/test_path_widget.py
+++ b/tests/gui/test_path_widget.py
@@ -1,6 +1,5 @@
 """Tests for the ScriptPathWidget."""
 from pathlib import Path
-from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +10,7 @@ from finesse.gui.path_widget import PathWidget
 class DummyWidget(PathWidget):
     """Override abstract member functions so we can create an instance."""
 
-    def try_get_path_from_dialog(self) -> Optional[Path]:
+    def try_get_path_from_dialog(self) -> Path | None:
         """Try to get the file name by raising a dialog."""
         return super().try_get_path_from_dialog()
 
@@ -44,7 +43,7 @@ def test_browse_button_connected(qtbot) -> None:
 
 
 @pytest.mark.parametrize("path", (None, Path("/my/path")))
-def test_browse_button_clicked(path: Optional[Path], widget: PathWidget) -> None:
+def test_browse_button_clicked(path: Path | None, widget: PathWidget) -> None:
     """Check that the correct action is performed when the button is clicked."""
     with patch.object(widget, "try_get_path_from_dialog") as dialog_mock:
         with patch.object(widget, "set_path") as set_path_mock:
@@ -73,7 +72,7 @@ def test_set_path(widget: PathWidget) -> None:
     ),
 )
 def test_try_get_path(
-    widget_path: Optional[Path], dialog_path: Optional[Path], widget: PathWidget
+    widget_path: Path | None, dialog_path: Path | None, widget: PathWidget
 ) -> None:
     """Test the try_get_path() method.
 

--- a/tests/gui/test_serial_device_panel.py
+++ b/tests/gui/test_serial_device_panel.py
@@ -1,5 +1,5 @@
 """Tests for the SerialDevicePanel."""
-from typing import Sequence
+from collections.abc import Sequence
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/gui/test_serial_view.py
+++ b/tests/gui/test_serial_view.py
@@ -1,6 +1,7 @@
 """Tests for SerialControl and associated code."""
 from collections import namedtuple
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest

--- a/tests/hardware/opus/test_dummy_opus_interface.py
+++ b/tests/hardware/opus/test_dummy_opus_interface.py
@@ -1,7 +1,7 @@
 """Tests for DummyOPUSInterface."""
 
 from itertools import product
-from typing import Optional, cast
+from typing import cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -79,7 +79,7 @@ def test_request_command(
     command: str,
     required_state: State,
     error: OPUSError,
-    timer_command: Optional[str],
+    timer_command: str | None,
     initial_state: State,
     dev: DummyOPUSInterface,
     sendmsg_mock: MagicMock,

--- a/tests/hardware/opus/test_opus_interface.py
+++ b/tests/hardware/opus/test_opus_interface.py
@@ -1,6 +1,6 @@
 """Tests for the interface to the EM27's OPUS control program."""
 from itertools import product
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -62,10 +62,10 @@ def _format_td(name: str, value: Any) -> str:
 
 
 def _get_opus_html(
-    status: Optional[int],
-    text: Optional[str],
-    errcode: Optional[int] = None,
-    errtext: Optional[str] = None,
+    status: int | None,
+    text: str | None,
+    errcode: int | None = None,
+    errtext: str | None = None,
     extra_text: str = "",
 ) -> str:
     return f"""
@@ -111,9 +111,7 @@ def test_parse_response_error(errcode: int, errtext: str) -> None:
 
 
 @pytest.mark.parametrize("status,text", ((None, "text"), (1, None), (None, None)))
-def test_parse_response_missing_fields(
-    status: Optional[int], text: Optional[str]
-) -> None:
+def test_parse_response_missing_fields(status: int | None, text: str | None) -> None:
     """Test parse_response() raises an error if fields are missing."""
     response = _get_opus_html(status, text)
     with pytest.raises(OPUSError):

--- a/tests/hardware/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/stepper_motor/test_stepper_motor_base.py
@@ -1,5 +1,4 @@
 """Tests for the StepperMotorBase class."""
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,7 +35,7 @@ class _MockStepperMotor(StepperMotorBase):
     def stop_moving(self) -> None:
         pass
 
-    def wait_until_stopped(self, timeout: Optional[float] = None) -> None:
+    def wait_until_stopped(self, timeout: float | None = None) -> None:
         pass
 
     def notify_on_stopped(self) -> None:

--- a/tests/hardware/temperature/test_tc4820.py
+++ b/tests/hardware/temperature/test_tc4820.py
@@ -2,7 +2,7 @@
 from contextlib import nullcontext as does_not_raise
 from decimal import Decimal
 from itertools import chain
-from typing import Any, Tuple
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -62,7 +62,7 @@ def format_message(message: int, checksum: int, eol: str = "^") -> bytes:
 _MESSAGE = "012345678"
 
 
-def _get_message(len: int) -> Tuple[int, bytes, Any]:
+def _get_message(len: int) -> tuple[int, bytes, Any]:
     substr = _MESSAGE[:len]
     value = int(substr, base=16)
     return (

--- a/tests/hardware/test_noise_producer.py
+++ b/tests/hardware/test_noise_producer.py
@@ -1,7 +1,6 @@
 """Tests for the NoiseProducer class."""
 from decimal import Decimal
 from itertools import product
-from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -11,7 +10,7 @@ from finesse.hardware.noise_producer import NoiseProducer
 
 @pytest.mark.parametrize("seed", (None, 0, 42))
 @patch("finesse.hardware.noise_producer.np.random.default_rng")
-def test_init(rng_mock: Mock, seed: Optional[int]) -> None:
+def test_init(rng_mock: Mock, seed: int | None) -> None:
     """Test providing different seeds to NoiseProducer."""
     NoiseProducer(seed=seed)
     rng_mock.assert_called_once_with(seed)

--- a/tests/test_event_counter.py
+++ b/tests/test_event_counter.py
@@ -1,6 +1,7 @@
 """Tests for the EventCounter class."""
+from collections.abc import Sequence
 from contextlib import nullcontext as does_not_raise
-from typing import Any, Optional, Sequence
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,7 +43,7 @@ def test_init_with_devices(subscribe_mock: MagicMock) -> None:
     ),
 )
 def test_init_missing_args(
-    target_count: Optional[int], device_names: Sequence[str], raises: Any
+    target_count: int | None, device_names: Sequence[str], raises: Any
 ) -> None:
     """Test that an error is raised when required arguments are missing."""
     with raises:


### PR DESCRIPTION
This PR updates the target version of Python to 3.11. I reran `poetry` and set the CI to use 3.11 for testing and producing binaries. I figured we might as well do this before the project's over and we still have access to the hardware for testing.

I tried this branch on the target machine with the hardware today and it all worked fine.

Closes #275. Closes #276.