### PR TITLE
Fix bug when devices are closed twice

### DIFF
--- a/finesse/hardware/serial_manager.py
+++ b/finesse/hardware/serial_manager.py
@@ -96,6 +96,8 @@ class SerialManager:
         It is ensured that devices will only be closed once.
         """
         pub.unsubscribe(self._close, f"serial.{self.name}.close")
+        pub.unsubscribe(self._close, "window.closed")
+
         self.device.close()
         del self.device
 


### PR DESCRIPTION
I forgot to unsubscribe from one of the handlers, so I was getting errors on exit about
the device member not existing.

Fixes #286.
