### PR TITLE
Measure script dialog enhancements

### DIFF
--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -196,9 +196,7 @@ class ScriptRunner(StateMachine):
     """Record another measurement at the same angle."""
     finish_waiting_for_measure = waiting_to_measure.to(measuring)
     """Stop waiting and start the next measurement."""
-    cancel_measuring = measuring.to(
-        not_running, after=lambda: pub.sendMessage("opus.request", command="cancel")
-    )
+    cancel_measuring = measuring.to(not_running)
     """Cancel the current measurement."""
     start_next_move = measuring.to(waiting_to_move)
     """Trigger a move to the angle for the next measurement."""

--- a/finesse/gui/measure_script/script_run_dialog.py
+++ b/finesse/gui/measure_script/script_run_dialog.py
@@ -36,6 +36,7 @@ class ScriptRunDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Running measure script")
         self.setModal(True)
+        self.setMinimumSize(400, 100)
 
         # Keep a reference to prevent it being GC'd mid-run
         self._script_runner = script_runner

--- a/finesse/gui/measure_script/script_run_dialog.py
+++ b/finesse/gui/measure_script/script_run_dialog.py
@@ -1,10 +1,11 @@
 """Provides a dialog to display the progress of a running measure script."""
 from pubsub import pub
-from PySide6.QtGui import QCloseEvent
+from PySide6.QtGui import QCloseEvent, QHideEvent
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QLabel,
+    QMessageBox,
     QProgressBar,
     QPushButton,
     QVBoxLayout,
@@ -41,6 +42,16 @@ class ScriptRunDialog(QDialog):
         # Keep a reference to prevent it being GC'd mid-run
         self._script_runner = script_runner
 
+        self._stop_dlg = QMessageBox(
+            QMessageBox.Icon.Warning,
+            "Stop measure script?",
+            "Do you want to cancel the currently running measure script?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            self,
+        )
+        """A dialog to let the user confirm whether they want to cancel the script."""
+        self._stop_dlg.accepted.connect(self.reject)
+
         layout = QVBoxLayout()
         self._progress_bar = QProgressBar()
         """Shows the progress of the measure script."""
@@ -57,7 +68,7 @@ class ScriptRunDialog(QDialog):
 
         buttonbox = QDialogButtonBox(QDialogButtonBox.StandardButton.Cancel)
         buttonbox.addButton(self._pause_btn, QDialogButtonBox.ButtonRole.ActionRole)
-        buttonbox.rejected.connect(self.reject)
+        buttonbox.rejected.connect(self._stop_dlg.show)
         self.rejected.connect(lambda: pub.sendMessage("measure_script.abort"))
         layout.addWidget(buttonbox)
 
@@ -99,4 +110,12 @@ class ScriptRunDialog(QDialog):
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """Abort the measure script."""
-        self.reject()
+        if self.isVisible():
+            # Make the user confirm before cancelling measure script
+            event.ignore()
+            self._stop_dlg.show()
+
+    def hideEvent(self, event: QHideEvent) -> None:
+        """Hide the dialog."""
+        super().hideEvent(event)
+        self._stop_dlg.hide()

--- a/tests/gui/measure_script/test_script_run_dialog.py
+++ b/tests/gui/measure_script/test_script_run_dialog.py
@@ -83,6 +83,7 @@ def test_cancel_button(
     """Check that clicking the cancel button aborts the measure script."""
     buttonbox = cast(QDialogButtonBox, run_dialog.findChild(QDialogButtonBox))
     buttonbox.button(QDialogButtonBox.StandardButton.Cancel).click()
+    run_dialog._stop_dlg.accept()
     sendmsg_mock.assert_any_call("measure_script.abort")
 
 
@@ -91,6 +92,7 @@ def test_close(
 ) -> None:
     """Check that closing the dialog aborts the measure script."""
     run_dialog.close()
+    run_dialog._stop_dlg.accept()
     sendmsg_mock.assert_any_call("measure_script.abort")
 
 

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -173,14 +173,11 @@ def test_repeat_measuring_paused(runner_measuring: ScriptRunner) -> None:
 
 
 def test_cancel_measuring(
-    runner_measuring: ScriptRunner, unsubscribe_mock: MagicMock, sendmsg_mock: MagicMock
+    runner_measuring: ScriptRunner, unsubscribe_mock: MagicMock
 ) -> None:
     """Test the cancel_measuring() method."""
     runner_measuring.cancel_measuring()
     assert runner_measuring.current_state == ScriptRunner.not_running
-
-    # Check that the cancel command was sent
-    sendmsg_mock.assert_called_with("opus.request", command="cancel")
 
 
 @patch("finesse.gui.measure_script.script._poll_em27_status")


### PR DESCRIPTION
This PR implements a couple of changes relating to measure scripts: https://imperialcollegelondon.github.io/FINESSE/measure_scripts/

The first is that I removed a feature whereby recording from the interferometer would stop if the measure script dialog was closed (fixes #283), because the researcher said they might want this data.

The second is that I added a warning if users try to close the measure script dialog while it is running (fixes #284).