### PR TITLE
Data recording enhancements

### DIFF
--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -1,17 +1,20 @@
 """Provides a panel which lets the user start and stop recording of data files."""
+from datetime import datetime
 from pathlib import Path
 
 from pubsub import pub
 from PySide6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
+    QLabel,
+    QLineEdit,
     QMessageBox,
     QPushButton,
     QSizePolicy,
 )
 
 from ..config import DEFAULT_DATA_FILE_PATH
-from .path_widget import SavePathWidget
+from .path_widget import OpenDirectoryWidget
 
 
 class DataFileControl(QGroupBox):
@@ -23,14 +26,18 @@ class DataFileControl(QGroupBox):
 
         layout = QHBoxLayout()
 
-        self.save_path_widget = SavePathWidget(
-            extension="csv",
+        self.open_dir_widget = OpenDirectoryWidget(
             parent=self,
             caption="Choose destination for data file",
             dir=str(DEFAULT_DATA_FILE_PATH),
         )
         """Lets the user choose the destination for data files."""
-        layout.addWidget(self.save_path_widget)
+        layout.addWidget(QLabel("Destination directory:"))
+        layout.addWidget(self.open_dir_widget)
+
+        self.filename_prefix_widget = QLineEdit()
+        layout.addWidget(QLabel("Filename prefix:"))
+        layout.addWidget(self.filename_prefix_widget)
 
         self.record_btn = QPushButton("Start recording")
         """Toggles recording state."""
@@ -52,34 +59,50 @@ class DataFileControl(QGroupBox):
         pub.subscribe(self._show_error_message, "data_file.error")
 
     def _on_file_open(self, path: Path) -> None:
-        self.save_path_widget.setEnabled(False)
+        self.open_dir_widget.setEnabled(False)
+        self.filename_prefix_widget.setEnabled(False)
         self.record_btn.setText("Stop recording")
 
     def _on_file_close(self) -> None:
-        self.save_path_widget.setEnabled(True)
+        self.open_dir_widget.setEnabled(True)
+        self.filename_prefix_widget.setEnabled(True)
         self.record_btn.setText("Start recording")
 
-    def _user_confirms_overwrite(self, path: Path) -> bool:
-        """Confirm with the user whether to overwrite file via a dialog."""
-        response = QMessageBox.question(
-            self,
-            "Overwrite file?",
-            f"The file {path.name} already exists. Would you like to overwrite it?",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-        )
-        return response == QMessageBox.StandardButton.Yes
+    def _try_get_data_file_path(self) -> Path | None:
+        dest_dir = self.open_dir_widget.try_get_path()
+        if not dest_dir:
+            # User cancelled
+            return None
 
-    def _try_start_recording(self, path: Path) -> None:
-        """Start recording if path doesn't exist or user accepts overwriting it."""
-        if not path.exists() or self._user_confirms_overwrite(path):
-            pub.sendMessage("data_file.open", path=path)
+        filename_prefix = self.filename_prefix_widget.text()
+        if not filename_prefix:
+            # Check that the user has added a prefix
+            QMessageBox(
+                QMessageBox.Icon.Critical,
+                "No filename prefix specified",
+                "The filename prefix cannot be blank.",
+            ).exec()
+            return None
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        path = dest_dir / f"{filename_prefix}_{timestamp}.csv"
+        if path.exists():
+            # It's unlikely that the file will already exist, but let's make doubly sure
+            QMessageBox(
+                QMessageBox.Icon.Critical,
+                "File already exists",
+                "The destination file already exists.",
+            ).exec()
+            return None
+
+        return path
 
     def _toggle_recording(self) -> None:
         """Starts or stops recording as needed."""
         if self.record_btn.text() == "Stop recording":
             pub.sendMessage("data_file.close")
-        elif path := self.save_path_widget.try_get_path():
-            self._try_start_recording(path)
+        elif path := self._try_get_data_file_path():
+            pub.sendMessage("data_file.open", path=path)
 
     def _show_error_message(self, error: BaseException) -> None:
         """Show an error dialog."""

--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -35,7 +35,6 @@ class DataFileControl(QGroupBox):
         self.record_btn = QPushButton("Start recording")
         """Toggles recording state."""
         self.record_btn.clicked.connect(self._toggle_recording)
-        self.record_btn.setEnabled(False)
         layout.addWidget(self.record_btn)
 
         self.setLayout(layout)
@@ -45,30 +44,12 @@ class DataFileControl(QGroupBox):
             QSizePolicy.Policy.Fixed,
         )
 
-        # Backend indicates when necessary devices are all connected/disconnected
-        pub.subscribe(self._on_data_file_enable, "data_file.enable")
-        pub.subscribe(self._on_data_file_disable, "data_file.disable")
-
         # Update GUI on file open/close
         pub.subscribe(self._on_file_open, "data_file.open")
         pub.subscribe(self._on_file_close, "data_file.close")
 
         # Show an error message if writing fails
         pub.subscribe(self._show_error_message, "data_file.error")
-
-    def _on_data_file_enable(self) -> None:
-        self.record_btn.setEnabled(True)
-
-    def _on_data_file_disable(self) -> None:
-        self.record_btn.setEnabled(False)
-
-        if self.record_btn.text() == "Stop recording":
-            QMessageBox.warning(
-                self,
-                "Device closed",
-                "Device was closed unexpectedly during data recording. "
-                "Recording will now stop.",
-            )
 
     def _on_file_open(self, path: Path) -> None:
         self.save_path_widget.setEnabled(False)

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -9,7 +9,7 @@ from ...config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
 from ...em27_status import EM27Status
 from ...event_counter import EventCounter
 from ...settings import settings
-from ..path_widget import OpenPathWidget
+from ..path_widget import OpenDirectoryWidget
 from .script import Script, ScriptRunner
 from .script_edit_dialog import ScriptEditDialog
 from .script_run_dialog import ScriptRunDialog
@@ -33,8 +33,8 @@ class ScriptControl(QGroupBox):
         edit_btn = QPushButton("Edit script")
         edit_btn.clicked.connect(self._edit_btn_clicked)
 
-        self.script_path = OpenPathWidget(
-            initial_file_path=_get_previous_script_path(),
+        self.script_path = OpenDirectoryWidget(
+            initial_dir_path=_get_previous_script_path(),
             extension="yaml",
             parent=self,
             caption="Choose measure script to load",

--- a/finesse/gui/path_widget.py
+++ b/finesse/gui/path_widget.py
@@ -103,6 +103,30 @@ class OpenPathWidget(PathWidget):
         return Path(filename) if filename else None
 
 
+class OpenDirectoryWidget(PathWidget):
+    """A widget that lets the user choose the path to an existing directory."""
+
+    def __init__(
+        self,
+        initial_dir_path: Path | None = None,
+        **file_dialog_kwargs: Any,
+    ) -> None:
+        """Create a new OpenDirectoryWidget.
+
+        Args:
+            initial_dir_path: The initial file path to display
+            file_dialog_kwargs: Arguments to pass to QFileDialog.getOpenFileName
+        """
+        super().__init__(initial_dir_path)
+        self.file_dialog_kwargs = file_dialog_kwargs
+
+    def try_get_path_from_dialog(self) -> Path | None:
+        """Try to get the path of the dir to open by raising a dialog."""
+        dir_path = QFileDialog.getExistingDirectory(**self.file_dialog_kwargs)
+
+        return Path(dir_path) if dir_path else None
+
+
 class SavePathWidget(PathWidget):
     """A widget that lets the user choose the path to save a file."""
 

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -213,11 +213,11 @@ class DP9800Controls(SerialDevicePanel):
             QSizePolicy.Policy.Fixed,
         )
 
-        pub.subscribe(self._begin_polling, f"serial.{TEMPERATURE_MONITOR_TOPIC}.opened")
-        pub.subscribe(self._end_polling, f"serial.{TEMPERATURE_MONITOR_TOPIC}.close")
         pub.subscribe(
             self._update_pt100s, f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.response"
         )
+
+        self._begin_polling()
 
     def _create_controls(self) -> QGridLayout:
         """Creates the overall layout for the panel.
@@ -257,10 +257,6 @@ class DP9800Controls(SerialDevicePanel):
         """Initiate polling the DP9800 device."""
         self._poll_dp9800()
         self._poll_light.timer.start()
-
-    def _end_polling(self) -> None:
-        """Terminate polling the DP9800 device."""
-        self._poll_light.timer.stop()
 
     def _poll_dp9800(self) -> None:
         """Polls the device to obtain the latest values."""

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -45,6 +45,50 @@ def _get_metadata(filename: str) -> dict[str, Any]:
     }
 
 
+def _get_stepper_motor_angle() -> tuple[float, bool]:
+    """Get the current angle of the stepper motor.
+
+    This function returns a float indicating the angle in degrees and a boolean
+    indicating whether the motor is currently moving. If an error occurs or the motor is
+    moving, the angle returned will be nan.
+    """
+    stepper = get_stepper_motor_instance()
+
+    # Stepper motor not connected
+    if not stepper:
+        return (float("nan"), False)
+
+    try:
+        if angle := stepper.angle:
+            return (angle, False)
+        else:
+            return (float("nan"), True)
+    except Exception as error:
+        pub.sendMessage(f"serial.{config.STEPPER_MOTOR_TOPIC}.error", error=error)
+        return (float("nan"), False)
+
+
+def _get_hot_bb_power() -> float:
+    """Get the current power of the hot BB temperature controller as a percentage.
+
+    If an error occurs, nan will be returned.
+    """
+    hot_bb = get_hot_bb_temperature_controller_instance()
+
+    # Hot BB temperature controller not connected
+    if not hot_bb:
+        return float("nan")
+
+    try:
+        return hot_bb.power * 100 / config.TC4820_MAX_POWER
+    except Exception as error:
+        pub.sendMessage(
+            f"serial.{config.TEMPERATURE_CONTROLLER_TOPIC}.{hot_bb.name}.error",
+            error=error,
+        )
+        return float("nan")
+
+
 class DataFileWriter:
     """A class for writing sensor data to a CSV file.
 
@@ -60,11 +104,7 @@ class DataFileWriter:
         self._enable_counter = EventCounter(
             self.enable,
             self.disable,
-            device_names=(
-                config.STEPPER_MOTOR_TOPIC,
-                config.TEMPERATURE_MONITOR_TOPIC,
-                f"{config.TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
-            ),
+            device_names=(config.TEMPERATURE_MONITOR_TOPIC,),
         )
 
         # Listen to open/close messages
@@ -104,6 +144,7 @@ class DataFileWriter:
                 *(f"Temp{i+1}" for i in range(config.NUM_TEMPERATURE_MONITOR_CHANNELS)),
                 "TimeAsSeconds",
                 "Angle",
+                "IsMoving",
                 "TemperatureControllerPower",
             )
         )
@@ -135,10 +176,8 @@ class DataFileWriter:
         # Also include timestamp as seconds since midnight
         midnight = datetime(time.year, time.month, time.day)
         secs_since_midnight = floor((time - midnight).total_seconds())
-        angle = get_stepper_motor_instance().angle
-        if angle is None:  # Occurs when the motor is moving
-            angle = float("nan")
 
+        angle, is_moving = _get_stepper_motor_angle()
         self._writer.writerow(
             (
                 time.strftime("%Y%m%d"),
@@ -146,8 +185,8 @@ class DataFileWriter:
                 *temperatures,
                 secs_since_midnight,
                 angle,
-                get_hot_bb_temperature_controller_instance().power
-                / (config.TC4820_MAX_POWER / 100),
+                int(is_moving),
+                _get_hot_bb_power(),
             )
         )
         self._writer._file.flush()

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -12,7 +12,6 @@ from csvy import Writer
 from pubsub import pub
 
 from .. import config
-from ..event_counter import EventCounter
 from .pubsub_decorators import pubsub_errors
 from .stepper_motor import get_stepper_motor_instance
 from .temperature import get_hot_bb_temperature_controller_instance
@@ -101,12 +100,6 @@ class DataFileWriter:
         self._writer: Writer
         """The CSV writer."""
 
-        self._enable_counter = EventCounter(
-            self.enable,
-            self.disable,
-            device_names=(config.TEMPERATURE_MONITOR_TOPIC,),
-        )
-
         # Listen to open/close messages
         pub.subscribe(self.open, "data_file.open")
         pub.subscribe(self.close, "data_file.close")
@@ -116,15 +109,6 @@ class DataFileWriter:
 
         # Listen for error messages
         pub.subscribe(_on_error_occurred, "data_file.error")
-
-    def enable(self) -> None:
-        """Send enable message."""
-        pub.sendMessage("data_file.enable")
-
-    def disable(self) -> None:
-        """Send disable message and close file if open."""
-        pub.sendMessage("data_file.disable")
-        pub.sendMessage("data_file.close")
 
     @pubsub_errors("data_file.error")
     def open(self, path: Path) -> None:

--- a/finesse/hardware/serial_manager.py
+++ b/finesse/hardware/serial_manager.py
@@ -59,6 +59,11 @@ class SerialManager:
         # Listen for open events for this device
         pub.subscribe(self._open, f"serial.{name}.open")
 
+    @property
+    def is_open(self) -> bool:
+        """Return whether the device is open."""
+        return hasattr(self, "device")
+
     def _open(self, port: str, baudrate: int) -> None:
         """Open the device.
 

--- a/finesse/hardware/stepper_motor/__init__.py
+++ b/finesse/hardware/stepper_motor/__init__.py
@@ -23,7 +23,9 @@ def create_stepper_motor_serial_manager() -> None:
     )
 
 
-def get_stepper_motor_instance() -> StepperMotorBase:
+def get_stepper_motor_instance() -> StepperMotorBase | None:
     """Get the global instance of the stepper motor object."""
     global _serial_manager
+    if not _serial_manager.is_open:
+        return None
     return cast(StepperMotorBase, _serial_manager.device)

--- a/finesse/hardware/temperature/__init__.py
+++ b/finesse/hardware/temperature/__init__.py
@@ -1,14 +1,23 @@
 """This module contains interfaces for temperature-related hardware."""
+from datetime import datetime
+from decimal import Decimal
 from functools import partial
 from typing import cast
 
-from ...config import TEMPERATURE_CONTROLLER_TOPIC, TEMPERATURE_MONITOR_TOPIC
+from pubsub import pub
+
+from ...config import (
+    NUM_TEMPERATURE_MONITOR_CHANNELS,
+    TEMPERATURE_CONTROLLER_TOPIC,
+    TEMPERATURE_MONITOR_TOPIC,
+)
 from ..serial_manager import SerialManager, make_device_factory
 from .dp9800 import DP9800
 from .dummy_temperature_controller import DummyTemperatureController
 from .dummy_temperature_monitor import DummyTemperatureMonitor
 from .tc4820 import TC4820
 from .temperature_controller_base import TemperatureControllerBase
+from .temperature_monitor_base import TemperatureMonitorBase
 
 _serial_manager_hot_bb: SerialManager
 _serial_manager_cold_bb: SerialManager
@@ -40,9 +49,50 @@ def create_temperature_monitor_serial_manager() -> None:
     )
 
 
+def get_temperature_monitor_serial_manager() -> TemperatureMonitorBase | None:
+    """Get the instance of the temperature monitor."""
+    global _serial_manager_dp9800
+    if not _serial_manager_dp9800.is_open:
+        return None
+    return cast(TemperatureMonitorBase, _serial_manager_dp9800.device)
+
+
 def get_hot_bb_temperature_controller_instance() -> TemperatureControllerBase | None:
     """Get the instance of the hot blackbody's temperature controller."""
     global _serial_manager_hot_bb
     if not _serial_manager_hot_bb.is_open:
         return None
     return cast(TemperatureControllerBase, _serial_manager_hot_bb.device)
+
+
+def _try_get_temperatures() -> list[Decimal] | None:
+    """Try to read the current temperatures from the temperature monitor.
+
+    If the device is not connected or the operation fails, None is returned.
+    """
+    dev = get_temperature_monitor_serial_manager()
+    if not dev:
+        return None
+
+    try:
+        return dev.get_temperatures()
+    except Exception as error:
+        pub.sendMessage(f"serial.{TEMPERATURE_MONITOR_TOPIC}.error", error=error)
+        return None
+
+
+_DEFAULT_TEMPS = [Decimal("nan")] * NUM_TEMPERATURE_MONITOR_CHANNELS
+
+
+def _send_temperatures() -> None:
+    """Send the current temperatures (or NaNs) via pubsub."""
+    temperatures = _try_get_temperatures() or _DEFAULT_TEMPS
+    time = datetime.utcnow()
+    pub.sendMessage(
+        f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.response",
+        temperatures=temperatures,
+        time=time,
+    )
+
+
+pub.subscribe(_send_temperatures, f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.request")

--- a/finesse/hardware/temperature/__init__.py
+++ b/finesse/hardware/temperature/__init__.py
@@ -40,7 +40,9 @@ def create_temperature_monitor_serial_manager() -> None:
     )
 
 
-def get_hot_bb_temperature_controller_instance() -> TemperatureControllerBase:
+def get_hot_bb_temperature_controller_instance() -> TemperatureControllerBase | None:
     """Get the instance of the hot blackbody's temperature controller."""
     global _serial_manager_hot_bb
+    if not _serial_manager_hot_bb.is_open:
+        return None
     return cast(TemperatureControllerBase, _serial_manager_hot_bb.device)

--- a/finesse/hardware/temperature/dp9800.py
+++ b/finesse/hardware/temperature/dp9800.py
@@ -94,8 +94,8 @@ class DP9800(TemperatureMonitorBase):
         Args:
             serial: Serial device
         """
-        super().__init__("DP9800")
         self.serial = serial
+        super().__init__()
 
     def close(self) -> None:
         """Close the connection to the device."""

--- a/finesse/hardware/temperature/dummy_temperature_monitor.py
+++ b/finesse/hardware/temperature/dummy_temperature_monitor.py
@@ -30,11 +30,12 @@ class DummyTemperatureMonitor(TemperatureMonitorBase):
                 f"Must provide {NUM_TEMPERATURE_MONITOR_CHANNELS} parameters"
             )
 
-        super().__init__("dummy")
         self._temperature_producers = [
             NoiseProducer.from_parameters(params, type=Decimal)
             for params in temperature_params
         ]
+
+        super().__init__()
 
     def close(self) -> None:
         """Close the connection to the device."""

--- a/finesse/hardware/temperature/temperature_monitor_base.py
+++ b/finesse/hardware/temperature/temperature_monitor_base.py
@@ -1,40 +1,13 @@
 """Provides a base class for temperature monitor devices or mock devices."""
 from abc import abstractmethod
-from datetime import datetime
 from decimal import Decimal
 
-from pubsub import pub
-
-from ...config import TEMPERATURE_MONITOR_TOPIC
 from ..device_base import DeviceBase
-from ..pubsub_decorators import pubsub_broadcast
 
 
 class TemperatureMonitorBase(DeviceBase):
-    """The base class for temperature monitor devices or mock devices.
-
-    Subscribes to incoming requests.
-    """
-
-    def __init__(self, name: str) -> None:
-        """Create a new TemperatureMonitorBase object."""
-        super().__init__()
-        pub.subscribe(
-            self.send_temperatures, f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.request"
-        )
+    """The base class for temperature monitor devices or mock devices."""
 
     @abstractmethod
     def get_temperatures(self) -> list[Decimal]:
         """Get the current temperatures."""
-
-    @pubsub_broadcast(
-        f"serial.{TEMPERATURE_MONITOR_TOPIC}.error",
-        f"serial.{TEMPERATURE_MONITOR_TOPIC}.data.response",
-        "temperatures",
-        "time",
-    )
-    def send_temperatures(self) -> tuple[list[Decimal], datetime]:
-        """Requests that temperatures are sent over pubsub."""
-        temperatures = self.get_temperatures()
-        time = datetime.utcnow()
-        return temperatures, time

--- a/tests/gui/test_data_file_view.py
+++ b/tests/gui/test_data_file_view.py
@@ -1,10 +1,8 @@
 """Tests for DataFileControl."""
-from itertools import product
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from PySide6.QtWidgets import QMessageBox
 
 from finesse.gui.data_file_view import DataFileControl
 
@@ -22,7 +20,8 @@ def test_init(subscribe_mock: MagicMock, qtbot) -> None:
     data_file = DataFileControl()
     assert data_file.record_btn.text() == "Start recording"
     assert data_file.record_btn.isEnabled()
-    assert data_file.save_path_widget.isEnabled()
+    assert data_file.open_dir_widget.isEnabled()
+    assert data_file.filename_prefix_widget.isEnabled()
 
     subscribe_mock.assert_any_call(data_file._on_file_open, "data_file.open")
     subscribe_mock.assert_any_call(data_file._on_file_close, "data_file.close")
@@ -33,24 +32,24 @@ def test_start_recording(
     data_file: DataFileControl, sendmsg_mock: MagicMock, qtbot
 ) -> None:
     """Test that recording starts correctly."""
-    with patch.object(data_file, "_try_start_recording") as try_start_mock:
+    with patch.object(data_file, "_try_get_data_file_path") as get_path_mock:
+        get_path_mock.return_value = FILE_PATH
         assert data_file.record_btn.text() == "Start recording"
-        data_file.save_path_widget.set_path(FILE_PATH)
         data_file.record_btn.click()
-        try_start_mock.assert_called_once_with(FILE_PATH)
+        sendmsg_mock.assert_called_once_with("data_file.open", path=FILE_PATH)
 
 
 def test_start_recording_path_dialog_cancelled(
     data_file: DataFileControl, sendmsg_mock: MagicMock, qtbot
 ) -> None:
     """Check that recording isn't started if the user closes the file dialog."""
-    assert data_file.save_path_widget.line_edit.text() == ""
-    with patch.object(data_file.save_path_widget, "try_get_path") as path_mock:
+    assert data_file.open_dir_widget.line_edit.text() == ""
+    with patch.object(data_file.open_dir_widget, "try_get_path") as path_mock:
         path_mock.return_value = None
         data_file.record_btn.click()
         path_mock.assert_called_once()
         assert data_file.record_btn.text() == "Start recording"
-        assert data_file.save_path_widget.isEnabled()
+        assert data_file.open_dir_widget.isEnabled()
         sendmsg_mock.assert_not_called()
 
 
@@ -69,7 +68,7 @@ def test_on_file_open(data_file: DataFileControl, qtbot) -> None:
     """Test the _on_file_open() method."""
     data_file._on_file_open(FILE_PATH)
     assert data_file.record_btn.text() == "Stop recording"
-    assert not data_file.save_path_widget.isEnabled()
+    assert not data_file.open_dir_widget.isEnabled()
 
 
 def test_on_file_close(data_file: DataFileControl, qtbot) -> None:
@@ -81,7 +80,7 @@ def test_on_file_close(data_file: DataFileControl, qtbot) -> None:
     data_file._on_file_close()
 
     assert data_file.record_btn.text() == "Start recording"
-    assert data_file.save_path_widget.isEnabled()
+    assert data_file.open_dir_widget.isEnabled()
 
 
 @patch("finesse.gui.data_file_view.QMessageBox")
@@ -100,50 +99,3 @@ def test_show_error_message(
         data_file,
     )
     msgbox.exec.assert_called_once_with()
-
-
-@pytest.mark.parametrize(
-    "response", (QMessageBox.StandardButton.Yes, QMessageBox.StandardButton.No)
-)
-@patch("finesse.gui.data_file_view.QMessageBox")
-def test_user_confirms_overwrite(
-    msgbox_mock: Mock,
-    response: QMessageBox.StandardButton,
-    data_file: DataFileControl,
-    qtbot,
-) -> None:
-    """Test the _user_confirms_overwrite() method."""
-    msgbox_mock.StandardButton = QMessageBox.StandardButton
-    msgbox_mock.question.return_value = response
-    assert data_file._user_confirms_overwrite(FILE_PATH) == (
-        response == QMessageBox.StandardButton.Yes
-    )
-    msgbox_mock.question.assert_called_once_with(
-        data_file,
-        "Overwrite file?",
-        f"The file {FILE_PATH.name} already exists. Would you like to overwrite it?",
-        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-    )
-
-
-@pytest.mark.parametrize("exists,user_confirms", product((True, False), repeat=2))
-def test_try_start_recording(
-    exists: bool,
-    user_confirms: bool,
-    sendmsg_mock: MagicMock,
-    data_file: DataFileControl,
-    qtbot,
-) -> None:
-    """Test the _try_start_recording() method."""
-    with patch.object(
-        data_file, "_user_confirms_overwrite", MagicMock(return_value=user_confirms)
-    ) as confirm_mock:
-        confirm_mock.return_value = user_confirms
-        path = MagicMock()
-        path.exists.return_value = exists
-        data_file._try_start_recording(path)
-
-        if not exists or user_confirms:
-            sendmsg_mock.assert_called_once_with("data_file.open", path=path)
-        else:
-            sendmsg_mock.assert_not_called()

--- a/tests/gui/test_data_file_view.py
+++ b/tests/gui/test_data_file_view.py
@@ -43,7 +43,6 @@ def test_start_recording_path_dialog_cancelled(
     data_file: DataFileControl, sendmsg_mock: MagicMock, qtbot
 ) -> None:
     """Check that recording isn't started if the user closes the file dialog."""
-    assert data_file.open_dir_widget.line_edit.text() == ""
     with patch.object(data_file.open_dir_widget, "try_get_path") as path_mock:
         path_mock.return_value = None
         data_file.record_btn.click()

--- a/tests/gui/test_data_file_view.py
+++ b/tests/gui/test_data_file_view.py
@@ -14,20 +14,16 @@ FILE_PATH = Path("/path/to/file.csv")
 @pytest.fixture
 def data_file(subscribe_mock: MagicMock, qtbot) -> DataFileControl:
     """Provides a DataFileControl."""
-    control = DataFileControl()
-    control._on_data_file_enable()
-    return control
+    return DataFileControl()
 
 
 def test_init(subscribe_mock: MagicMock, qtbot) -> None:
     """Test DataFileControl's constructor."""
     data_file = DataFileControl()
     assert data_file.record_btn.text() == "Start recording"
-    assert not data_file.record_btn.isEnabled()
+    assert data_file.record_btn.isEnabled()
     assert data_file.save_path_widget.isEnabled()
 
-    subscribe_mock.assert_any_call(data_file._on_data_file_enable, "data_file.enable")
-    subscribe_mock.assert_any_call(data_file._on_data_file_disable, "data_file.disable")
     subscribe_mock.assert_any_call(data_file._on_file_open, "data_file.open")
     subscribe_mock.assert_any_call(data_file._on_file_close, "data_file.close")
     subscribe_mock.assert_any_call(data_file._show_error_message, "data_file.error")
@@ -37,7 +33,6 @@ def test_start_recording(
     data_file: DataFileControl, sendmsg_mock: MagicMock, qtbot
 ) -> None:
     """Test that recording starts correctly."""
-    data_file._on_data_file_enable()
     with patch.object(data_file, "_try_start_recording") as try_start_mock:
         assert data_file.record_btn.text() == "Start recording"
         data_file.save_path_widget.set_path(FILE_PATH)
@@ -152,33 +147,3 @@ def test_try_start_recording(
             sendmsg_mock.assert_called_once_with("data_file.open", path=path)
         else:
             sendmsg_mock.assert_not_called()
-
-
-def test_on_data_file_enable(data_file: DataFileControl, qtbot) -> None:
-    """Test the _on_data_file_enable() method."""
-    with patch.object(data_file, "record_btn") as btn_mock:
-        data_file._on_data_file_enable()
-        btn_mock.setEnabled.assert_called_once_with(True)
-
-
-@patch("finesse.gui.data_file_view.QMessageBox")
-def test_on_data_file_disable_recording(
-    msgbox_mock: Mock, data_file: DataFileControl, qtbot
-) -> None:
-    """Test the _on_data_file_disable() method when recording."""
-    # Simulate start of file recording
-    data_file._on_file_open(FILE_PATH)
-
-    data_file._on_data_file_disable()
-    assert not data_file.record_btn.isEnabled()
-    msgbox_mock.warning.assert_called()
-
-
-@patch("finesse.gui.data_file_view.QMessageBox")
-def test_on_data_file_disable_not_recording(
-    msgbox_mock: Mock, data_file: DataFileControl, qtbot
-) -> None:
-    """Test the _on_data_file_disable() method when not recording."""
-    data_file._on_data_file_disable()
-    assert not data_file.record_btn.isEnabled()
-    msgbox_mock.warning.assert_not_called()

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -17,19 +17,11 @@ def writer() -> DataFileWriter:
     return DataFileWriter()
 
 
-@patch("finesse.hardware.data_file_writer.EventCounter")
-def test_init(counter_mock: Mock, subscribe_mock: MagicMock) -> None:
+def test_init(subscribe_mock: MagicMock) -> None:
     """Test DataFileWriter's constructor."""
-    counter_mock.return_value = MagicMock()
     writer = DataFileWriter()
     subscribe_mock.assert_any_call(writer.open, "data_file.open")
     subscribe_mock.assert_any_call(writer.close, "data_file.close")
-
-    counter_mock.assert_called_once_with(
-        writer.enable,
-        writer.disable,
-        device_names=(TEMPERATURE_MONITOR_TOPIC,),
-    )
 
 
 @patch("finesse.hardware.data_file_writer.config.NUM_TEMPERATURE_MONITOR_CHANNELS", 2)
@@ -155,17 +147,3 @@ def test_write_error(
     writer._writer.writerow.side_effect = error
     writer.write(time, data)
     sendmsg_mock.assert_called_once_with("data_file.error", error=error)
-
-
-def test_enable(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
-    """Test the enable() method."""
-    writer.enable()
-    sendmsg_mock.assert_called_once_with("data_file.enable")
-
-
-def test_disable(writer: DataFileWriter, sendmsg_mock: MagicMock) -> None:
-    """Test the disable() method while writing."""
-    writer._writer = MagicMock()
-    writer.disable()
-    sendmsg_mock.assert_any_call("data_file.disable")
-    sendmsg_mock.assert_any_call("data_file.close")

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -7,12 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import yaml
 
-from finesse.config import (
-    STEPPER_MOTOR_TOPIC,
-    TC4820_MAX_POWER,
-    TEMPERATURE_CONTROLLER_TOPIC,
-    TEMPERATURE_MONITOR_TOPIC,
-)
+from finesse.config import TC4820_MAX_POWER, TEMPERATURE_MONITOR_TOPIC
 from finesse.hardware.data_file_writer import DataFileWriter, _get_metadata
 
 
@@ -33,11 +28,7 @@ def test_init(counter_mock: Mock, subscribe_mock: MagicMock) -> None:
     counter_mock.assert_called_once_with(
         writer.enable,
         writer.disable,
-        device_names=(
-            STEPPER_MOTOR_TOPIC,
-            TEMPERATURE_MONITOR_TOPIC,
-            f"{TEMPERATURE_CONTROLLER_TOPIC}.hot_bb",
-        ),
+        device_names=(TEMPERATURE_MONITOR_TOPIC,),
     )
 
 
@@ -67,6 +58,7 @@ def test_open(
             "Temp2",
             "TimeAsSeconds",
             "Angle",
+            "IsMoving",
             "TemperatureControllerPower",
         )
     )
@@ -137,7 +129,7 @@ def test_write(
     writer._writer = MagicMock()
     writer.write(time, data)
     writer._writer.writerow.assert_called_once_with(
-        ("20230414", "00:01:00", *data, 60, 90.0, 10 / (TC4820_MAX_POWER / 100))
+        ("20230414", "00:01:00", *data, 60, 90.0, False, 10 / (TC4820_MAX_POWER / 100))
     )
 
 


### PR DESCRIPTION
This PR implements a couple of changes to the way we're recording data files.

Currently, you can only start a data recording when all the devices whose data will be used are connected (viz. the ST10, the hot BB's TC4820 and the DP9800). The problem is that @jonemurray reports he may want to record data without some of these devices present. Additionally, if the USB connection drops, currently the data recording stops, but it would be better if it carried on in some form. I've changed things to write NaNs for any sensor values that we don't have, which has required a bit of refactoring.

Secondly, @jonemurray asked that timestamps be included in the CSV file names, so I've reworked the GUI side a bit to accommodate this. Now instead of choosing the destination filename directly, the user chooses the destination folder and the filename prefix and the timestamp is appended.

Closes #281. Closes #282. Closes #249.