### PR TITLE
Fix "Browse" script button

### DIFF
--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import (
 
 from ...config import DEFAULT_SCRIPT_PATH
 from ..error_message import show_error_message
-from ..path_widget import SavePathWidget
+from ..path_widget import SaveFileWidget
 from .count_widget import CountWidget
 from .script import Script
 from .sequence_widget import SequenceWidget
@@ -45,7 +45,7 @@ class ScriptEditDialog(QDialog):
         else:
             self.count = CountWidget("Repeats")
             self.sequence_widget = SequenceWidget()
-        self.script_path = SavePathWidget(
+        self.script_path = SaveFileWidget(
             initial_save_path,
             extension="yaml",
             parent=self,

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -9,7 +9,7 @@ from ...config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
 from ...em27_status import EM27Status
 from ...event_counter import EventCounter
 from ...settings import settings
-from ..path_widget import OpenDirectoryWidget
+from ..path_widget import OpenPathWidget
 from .script import Script, ScriptRunner
 from .script_edit_dialog import ScriptEditDialog
 from .script_run_dialog import ScriptRunDialog
@@ -33,8 +33,8 @@ class ScriptControl(QGroupBox):
         edit_btn = QPushButton("Edit script")
         edit_btn.clicked.connect(self._edit_btn_clicked)
 
-        self.script_path = OpenDirectoryWidget(
-            initial_dir_path=_get_previous_script_path(),
+        self.script_path = OpenPathWidget(
+            initial_file_path=_get_previous_script_path(),
             extension="yaml",
             parent=self,
             caption="Choose measure script to load",

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -9,7 +9,7 @@ from ...config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
 from ...em27_status import EM27Status
 from ...event_counter import EventCounter
 from ...settings import settings
-from ..path_widget import OpenPathWidget
+from ..path_widget import OpenFileWidget
 from .script import Script, ScriptRunner
 from .script_edit_dialog import ScriptEditDialog
 from .script_run_dialog import ScriptRunDialog
@@ -33,7 +33,7 @@ class ScriptControl(QGroupBox):
         edit_btn = QPushButton("Edit script")
         edit_btn.clicked.connect(self._edit_btn_clicked)
 
-        self.script_path = OpenPathWidget(
+        self.script_path = OpenFileWidget(
             initial_file_path=_get_previous_script_path(),
             extension="yaml",
             parent=self,

--- a/finesse/gui/path_widget.py
+++ b/finesse/gui/path_widget.py
@@ -75,7 +75,7 @@ class PathWidget(QWidget):
         self.line_edit.setText(str(path))
 
 
-class OpenPathWidget(PathWidget):
+class OpenFileWidget(PathWidget):
     """A widget that lets the user choose the path to an existing file."""
 
     def __init__(
@@ -84,7 +84,7 @@ class OpenPathWidget(PathWidget):
         extension: str | None = None,
         **file_dialog_kwargs: Any,
     ) -> None:
-        """Create a new OpenPathWidget.
+        """Create a new OpenFileWidget.
 
         Args:
             initial_file_path: The initial file path to display
@@ -127,7 +127,7 @@ class OpenDirectoryWidget(PathWidget):
         return Path(dir_path) if dir_path else None
 
 
-class SavePathWidget(PathWidget):
+class SaveFileWidget(PathWidget):
     """A widget that lets the user choose the path to save a file."""
 
     def __init__(
@@ -136,7 +136,7 @@ class SavePathWidget(PathWidget):
         extension: str | None = None,
         **file_dialog_kwargs: Any,
     ) -> None:
-        """Create a new SavePathWidget.
+        """Create a new SaveFileWidget.
 
         Args:
             initial_file_path: The initial file path to display


### PR DESCRIPTION
This PR fixes the bug we just saw with Jon.

Seemingly at some point I replaced the `OpenPathWidget` in `ScriptControl` with an `OpenDirectoryWidget`, presumably because I did a dodgy autoreplace. In any case, it meant that when you clicked the "Browse" button to open a script file, it was trying to open a directory, then complaining that the `extension` argument wasn't valid for this case.

I'm slightly surprised we didn't see this earlier, but I'm guessing I just didn't do a thorough test after this change.