### PR TITLE
Express TC4820 power as a percentage of maximum

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -80,6 +80,3 @@ TEMPERATURE_MONITOR_HOT_BB_IDX = 6
 
 TEMPERATURE_MONITOR_COLD_BB_IDX = 7
 """Position of the cold blackbody on the temperature monitoring device."""
-
-TC4820_MAX_POWER = 511
-"""The maximum value for the power property."""

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -422,7 +422,7 @@ class TC4820Controls(SerialDevicePanel):
         """
         self._control_val.setText(f"{properties['temperature']: .2f}")
         self._power_bar.setValue(properties["power"])
-        self._power_label.setText(f"{properties['power']}")
+        self._power_label.setText(f"{round(properties['power'])}")
         self._set_sbox.setValue(int(properties["set_point"]))
         if properties["alarm_status"] != 0:
             self._alarm_light._turn_on()

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -22,7 +22,6 @@ from PySide6.QtWidgets import (
 
 from ..config import (
     NUM_TEMPERATURE_MONITOR_CHANNELS,
-    TC4820_MAX_POWER,
     TEMPERATURE_CONTROLLER_POLL_INTERVAL,
     TEMPERATURE_CONTROLLER_TOPIC,
     TEMPERATURE_MONITOR_COLD_BB_IDX,
@@ -359,7 +358,7 @@ class TC4820Controls(SerialDevicePanel):
         layout.addWidget(self._pt100_val, 0, 3)
 
         self._power_bar = QProgressBar()
-        self._power_bar.setMaximum(TC4820_MAX_POWER)
+        self._power_bar.setRange(0, 100)
         self._power_bar.setTextVisible(False)
         self._power_bar.setOrientation(Qt.Orientation.Horizontal)
         layout.addWidget(self._power_bar, 1, 1, 1, 3)

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -79,7 +79,7 @@ def _get_hot_bb_power() -> float:
         return float("nan")
 
     try:
-        return hot_bb.power * 100 / config.TC4820_MAX_POWER
+        return hot_bb.power
     except Exception as error:
         pub.sendMessage(
             f"serial.{config.TEMPERATURE_CONTROLLER_TOPIC}.{hot_bb.name}.error",

--- a/finesse/hardware/temperature/tc4820.py
+++ b/finesse/hardware/temperature/tc4820.py
@@ -17,7 +17,6 @@ from decimal import Decimal
 
 from serial import Serial, SerialException
 
-from ...config import TC4820_MAX_POWER
 from .temperature_controller_base import TemperatureControllerBase
 
 
@@ -41,6 +40,7 @@ class TC4820(TemperatureControllerBase):
 
         self.serial = serial
         self.max_attempts = max_attempts
+        self.max_power = 511
 
         super().__init__(name)
 
@@ -155,9 +155,9 @@ class TC4820(TemperatureControllerBase):
         return self.request_decimal("010000")
 
     @property
-    def power(self) -> int:
+    def power(self) -> float:
         """The current power output of the device, as a percentage of maximum."""
-        return int(self.request_int("020000") * 100 / TC4820_MAX_POWER)
+        return self.request_int("020000") * 100.0 / self.max_power
 
     @property
     def alarm_status(self) -> int:

--- a/finesse/hardware/temperature/tc4820.py
+++ b/finesse/hardware/temperature/tc4820.py
@@ -19,6 +19,8 @@ from serial import Serial, SerialException
 
 from .temperature_controller_base import TemperatureControllerBase
 
+MAX_POWER = 511
+
 
 class MalformedMessageError(Exception):
     """Raised when a message sent or received was malformed."""
@@ -40,7 +42,6 @@ class TC4820(TemperatureControllerBase):
 
         self.serial = serial
         self.max_attempts = max_attempts
-        self.max_power = 511
 
         super().__init__(name)
 
@@ -157,7 +158,7 @@ class TC4820(TemperatureControllerBase):
     @property
     def power(self) -> float:
         """The current power output of the device, as a percentage of maximum."""
-        return self.request_int("020000") * 100.0 / self.max_power
+        return self.request_int("020000") * 100.0 / MAX_POWER
 
     @property
     def alarm_status(self) -> int:

--- a/finesse/hardware/temperature/tc4820.py
+++ b/finesse/hardware/temperature/tc4820.py
@@ -17,6 +17,7 @@ from decimal import Decimal
 
 from serial import Serial, SerialException
 
+from ...config import TC4820_MAX_POWER
 from .temperature_controller_base import TemperatureControllerBase
 
 
@@ -155,8 +156,8 @@ class TC4820(TemperatureControllerBase):
 
     @property
     def power(self) -> int:
-        """The current power output of the device."""
-        return self.request_int("020000")
+        """The current power output of the device, as a percentage of maximum."""
+        return int(self.request_int("020000") * 100 / TC4820_MAX_POWER)
 
     @property
     def alarm_status(self) -> int:

--- a/finesse/hardware/temperature/temperature_controller_base.py
+++ b/finesse/hardware/temperature/temperature_controller_base.py
@@ -60,7 +60,7 @@ class TemperatureControllerBase(DeviceBase):
 
     @property
     @abstractmethod
-    def power(self) -> int:
+    def power(self) -> float:
         """The current power output of the device."""
 
     @property

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import yaml
 
-from finesse.config import TC4820_MAX_POWER, TEMPERATURE_MONITOR_TOPIC
+from finesse.config import TEMPERATURE_MONITOR_TOPIC
 from finesse.hardware.data_file_writer import DataFileWriter, _get_metadata
 
 
@@ -121,7 +121,7 @@ def test_write(
     writer._writer = MagicMock()
     writer.write(time, data)
     writer._writer.writerow.assert_called_once_with(
-        ("20230414", "00:01:00", *data, 60, 90.0, False, 10 / (TC4820_MAX_POWER / 100))
+        ("20230414", "00:01:00", *data, 60, 90.0, False, 10)
     )
 
 


### PR DESCRIPTION
This PR changes `TC4820.power()` to return the current power level as a percentage of maximum (`config.TC4820_MAX_POWER`), as it is only ever used (i.e. when written to file and displayed on GUI) as a percentage.
Essentially, the scaling is just performed in `TC4820.power()` rather than wherever it is used.

Note that the textbox next to the power meter on the GUI also shows the numerical value. In the original GUI, this instead showed an integer corresponding to the alarm status of the device, but I'm not sure whether that was useful (or even known, hence the assumption that this is instead the percentage power). It seems unnecessary to have this textbox since we could instead just use `setTextVisible(True)` and show this value on the power meter itself, but maybe there's a preference to have this next to, rather than on top of, the power meter - especially if no one cares about the alarm status value.

Closes #289 