### PR TITLE
Device frontend fixlets

### DIFF
--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -14,8 +14,10 @@ class DeviceParameter:
     possible_values: Sequence[Any]
     """Possible values the parameter can take."""
 
-    default_value: Any | None = None
-    """The default value for this parameter."""
+    default_value: Any = None
+    """The default value for this parameter.
+
+    A value of None indicates that there is no default value."""
 
     def __post_init__(self) -> None:
         """Check that default value is valid."""

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -1,6 +1,7 @@
 """Provides common dataclasses about devices for using in backend and frontend."""
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -10,10 +11,10 @@ class DeviceParameter:
     name: str
     """Name for the parameter."""
 
-    possible_values: list[str]
+    possible_values: Sequence[Any]
     """Possible values the parameter can take."""
 
-    default_value: str | None = None
+    default_value: Any | None = None
     """The default value for this parameter."""
 
     def __post_init__(self) -> None:

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -1,4 +1,5 @@
 """Provides a control for viewing and connecting to devices."""
+from dataclasses import dataclass
 from typing import Any, cast
 
 from pubsub import pub
@@ -18,61 +19,68 @@ from finesse.settings import settings
 from .error_message import show_error_message
 
 
-def _create_device_widgets(
-    instance: DeviceInstanceRef, device_types: list[DeviceTypeInfo]
-) -> list[QWidget | None]:
-    """Create widgets for the specified device types."""
-    widgets: list[QWidget | None] = []
-    for t in device_types:
-        params = t.parameters
+@dataclass
+class DeviceTypeItem:
+    """User data associated with a given device type."""
 
-        # Don't bother making a widget if there are no parameters
-        if not params:
-            widgets.append(None)
-            continue
+    device_type: DeviceTypeInfo
+    widget: QWidget | None
 
-        # Previous parameter values are saved if a device opens successfully
-        previous_param_values = cast(
-            dict[str, Any] | None,
-            settings.value(f"device/{instance.topic}/{t.description}/params"),
-        )
 
-        widget = QWidget()
-        widget.hide()
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        widget.setLayout(layout)
-        widgets.append(widget)
+def _create_device_widget(
+    instance: DeviceInstanceRef, device_type: DeviceTypeInfo
+) -> QWidget | None:
+    """Create a widget for the specified device type.
 
-        # Make a combo box for each parameter
-        for param in params:
-            combo = QComboBox()
-            combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+    If there are no parameters, return None.
+    """
+    params = device_type.parameters
 
-            # Keep the "real" value along with its string representation, so that we can
-            # pass it back to the backend on device open
-            for value in param.possible_values:
-                combo.addItem(str(value), value)
+    # Don't bother making a widget if there are no parameters
+    if not params:
+        return None
 
-            curval = None
-            if (
-                previous_param_values
-                and previous_param_values[param.name] in param.possible_values
-            ):
-                curval = previous_param_values[param.name]
-            elif param.default_value is not None:
-                curval = param.default_value
+    # Previous parameter values are saved if a device opens successfully
+    previous_param_values = cast(
+        dict[str, Any] | None,
+        settings.value(f"device/{instance.topic}/{device_type.description}/params"),
+    )
 
-            if curval is not None:
-                try:
-                    combo.setCurrentIndex(param.possible_values.index(curval))
-                except ValueError:
-                    # curval is not in param.possible_values (although it should be)
-                    pass
+    widget = QWidget()
+    widget.hide()
+    layout = QHBoxLayout()
+    layout.setContentsMargins(0, 0, 0, 0)
+    widget.setLayout(layout)
 
-            layout.addWidget(combo)
+    # Make a combo box for each parameter
+    for param in params:
+        combo = QComboBox()
+        combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
-    return widgets
+        # Keep the "real" value along with its string representation, so that we can
+        # pass it back to the backend on device open
+        for value in param.possible_values:
+            combo.addItem(str(value), value)
+
+        curval = None
+        if (
+            previous_param_values
+            and previous_param_values[param.name] in param.possible_values
+        ):
+            curval = previous_param_values[param.name]
+        elif param.default_value is not None:
+            curval = param.default_value
+
+        if curval is not None:
+            try:
+                combo.setCurrentIndex(param.possible_values.index(curval))
+            except ValueError:
+                # curval is not in param.possible_values (although it should be)
+                pass
+
+        layout.addWidget(combo)
+
+    return widget
 
 
 class DeviceTypeControl(QGroupBox):
@@ -112,31 +120,28 @@ class DeviceTypeControl(QGroupBox):
         self._device_combo.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
         )
-        descriptions = [t.description for t in device_types]
-        self._device_combo.addItems(descriptions)
+
+        # Add names for devices to combo box along with relevant user data
+        for t in device_types:
+            user_data = DeviceTypeItem(t, _create_device_widget(instance, t))
+            self._device_combo.addItem(t.description, user_data)
 
         # Select the last device that was successfully opened, if there is one
         topic = instance.topic
         previous_device = cast(
             str | None, settings.value(f"device/{instance.topic}/type")
         )
+        descriptions = (t.description for t in device_types)
         if previous_device and previous_device in descriptions:
             self._device_combo.setCurrentText(previous_device)
 
         self._device_combo.currentIndexChanged.connect(self._on_device_selected)
         layout.addWidget(self._device_combo)
 
-        self._device_widgets: list[QWidget | None] = _create_device_widgets(
-            instance, device_types
-        )
-        """Widgets containing combo boxes specific to each parameter."""
-
-        if self._device_widgets and (
-            current := self._device_widgets[self._get_device_idx()]
-        ):
+        if (cur_item := self._get_current_device_type_item()) and cur_item.widget:
             # Show the combo boxes for the device's parameters
-            current.show()
-            layout.addWidget(current)
+            cur_item.widget.show()
+            layout.addWidget(cur_item.widget)
 
         self._open_close_btn = QPushButton("Open")
         self._open_close_btn.setSizePolicy(
@@ -159,15 +164,11 @@ class DeviceTypeControl(QGroupBox):
         The "open" button should be disabled if there are no possible values for any
         of the params.
         """
-        all_params = self._device_types[self._get_device_idx()].parameters
+        all_params = self._get_current_device_type_item().device_type.parameters
         self._open_close_btn.setEnabled(all(p.possible_values for p in all_params))
 
-    def _on_device_selected(self, device_idx: int) -> None:
-        """Swap out the parameter combo boxes for the current device.
-
-        Args:
-            device_idx: Which device has been selected.
-        """
+    def _on_device_selected(self) -> None:
+        """Swap out the parameter combo boxes for the current device."""
         layout = cast(QHBoxLayout, self.layout())
 
         # If there's already a widget in place, remove it
@@ -177,41 +178,38 @@ class DeviceTypeControl(QGroupBox):
             layout.takeAt(1).widget().hide()
 
         # Add the widget for the newly selected parameter if needed
-        if widget := self._device_widgets[device_idx]:
+        if widget := self._get_current_device_type_item().widget:
             widget.show()
             layout.insertWidget(1, widget)
 
         # Enable/disable the "open" button
         self._update_open_btn_enabled_state()
 
-    def _get_device_idx(self) -> int:
-        """Get the index of the currently selected device type."""
-        return self._device_combo.currentIndex()
+    def _get_current_device_type_item(self) -> DeviceTypeItem:
+        return self._device_combo.currentData()
 
     def _get_current_device_and_params(self) -> tuple[DeviceTypeInfo, dict[str, Any]]:
         """Get the current device type and associated parameters."""
-        device_idx = self._get_device_idx()
-        device_type = self._device_types[device_idx]
+        item = self._get_current_device_type_item()
 
         # The current device widget contains combo boxes with the values
-        widget = self._device_widgets[device_idx]
-        if not widget:
+        if not item.widget:
             # No parameters needed for this device type
-            return device_type, {}
+            return item.device_type, {}
 
         # Get the parameter values
-        combos: list[QComboBox] = widget.findChildren(QComboBox)
+        combos: list[QComboBox] = item.widget.findChildren(QComboBox)
         device_params = {
-            p.name: c.currentData() for p, c in zip(device_type.parameters, combos)
+            p.name: c.currentData() for p, c in zip(item.device_type.parameters, combos)
         }
 
-        return device_type, device_params
+        return item.device_type, device_params
 
     def _set_combos_enabled(self, enabled: bool) -> None:
         """Set the enabled state of the combo boxes."""
         self._device_combo.setEnabled(enabled)
 
-        if widget := self._device_widgets[self._get_device_idx()]:
+        if widget := self._get_current_device_type_item().widget:
             widget.setEnabled(enabled)
 
     def _open_device(self) -> None:

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -1,7 +1,7 @@
 """This module contains code for interfacing with different hardware devices."""
 import logging
 from importlib import import_module
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from pubsub import pub
 
@@ -28,7 +28,7 @@ def get_device_instance(base_type: type[_T], name: str | None = None) -> _T | No
 
 
 def _open_device(
-    class_name: str, instance: DeviceInstanceRef, params: dict[str, str]
+    class_name: str, instance: DeviceInstanceRef, params: dict[str, Any]
 ) -> None:
     """Open the specified device type.
 

--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -50,9 +50,7 @@ class SerialDevice(AbstractDevice):
         # Extra, serial-specific parameters
         cls.add_device_parameters(
             DeviceParameter("port", _get_usb_serial_ports()),
-            DeviceParameter(
-                "baudrate", list(map(str, BAUDRATES)), str(default_baudrate)
-            ),
+            DeviceParameter("baudrate", BAUDRATES, default_baudrate),
         )
 
     def __init__(self, *serial_args: Any, **serial_kwargs: Any) -> None:


### PR DESCRIPTION
This PR fixes a few minor issues to do with the device management code. I started doing this as part of my work on #323, but figured there was enough here for a separate PR.

- Allow for having non-string device parameters (now used for baudrate, but we will also need it for serial device attributes)
- Refactor `DeviceTypeControl` to save relevant device-type info in the `QComboBox` along with the string label (I only just learned you can do this, but it makes things cleaner)
- Disable the "open" button if a device has any parameters for which there are no possible values given (this occurs if there are no COM ports on the current machine)

Fixes #369. Fixes #370.