### PR TITLE
Use persistent attributes to distinguish USB serial devices

### DIFF
--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -1,9 +1,10 @@
 """Provides a base class for USB serial devices."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
-from serial import Serial
+from serial import Serial, SerialException
 from serial.tools.list_ports import comports
 
 from finesse.config import BAUDRATES
@@ -11,10 +12,32 @@ from finesse.device_info import DeviceParameter
 
 from .device import AbstractDevice
 
-_serial_ports: list[str] | None = None
+_serial_ports: dict[_USBSerialPortInfo, str] | None = None
 
 
-def _get_usb_serial_ports() -> list[str]:
+@dataclass(frozen=True)
+class _USBSerialPortInfo:
+    """Info to distinguish between USB serial ports."""
+
+    vendor_id: int
+    """USB vendor ID."""
+    product_id: int
+    """USB product ID."""
+    serial_number: str | None
+    """USB serial number."""
+    count: int
+    """How many previous devices match the above parameters."""
+
+    def __str__(self) -> str:
+        out = f"{self.vendor_id:04x}:{self.product_id:04x}"
+        if self.serial_number:
+            out += f" {self.serial_number}"
+        if self.count > 0:
+            out += f" ({self.count+1})"
+        return out
+
+
+def _get_usb_serial_ports() -> dict[_USBSerialPortInfo, str]:
     """Get the ports for connected USB serial devices.
 
     The list of ports is only requested from the OS once and the result is cached.
@@ -23,9 +46,24 @@ def _get_usb_serial_ports() -> list[str]:
     if _serial_ports is not None:
         return _serial_ports
 
-    # Vendor ID is a USB-specific field, so we can use this to check whether the device
-    # is USB or not
-    _serial_ports = sorted(port.device for port in comports() if port.vid is not None)
+    # Keep track of ports with the same vendor ID, product ID and serial number and
+    # assign them an additional number to distinguish them
+    counter: dict[tuple[int, int, str | None], int] = {}
+    _serial_ports = {}
+    for port in comports():
+        # Vendor ID is a USB-specific field, so we can use this to check whether the
+        # device is USB or not
+        if port.vid is None:
+            continue
+
+        key = (port.vid, port.pid, port.serial_number)
+        if key not in counter:
+            counter[key] = 0
+        _serial_ports[_USBSerialPortInfo(*key, count=counter[key])] = port.device
+        counter[key] += 1
+
+    # Sort by the string representation of the key
+    _serial_ports = dict(sorted(_serial_ports.items(), key=lambda item: str(item[0])))
 
     return _serial_ports
 
@@ -49,13 +87,18 @@ class SerialDevice(AbstractDevice):
 
         # Extra, serial-specific parameters
         cls.add_device_parameters(
-            DeviceParameter("port", _get_usb_serial_ports()),
+            DeviceParameter("port", list(_get_usb_serial_ports().keys())),
             DeviceParameter("baudrate", BAUDRATES, default_baudrate),
         )
 
-    def __init__(self, *serial_args: Any, **serial_kwargs: Any) -> None:
+    def __init__(self, port: _USBSerialPortInfo, baudrate: int) -> None:
         """Create a new serial device."""
-        self.serial = Serial(*serial_args, **serial_kwargs)
+        try:
+            device = _serial_ports[port]  # type: ignore[index]
+        except KeyError:
+            raise SerialException(f'Device not present: "{port!s}"')
+
+        self.serial = Serial(port=device, baudrate=baudrate)
 
     def close(self) -> None:
         """Close the connection to the device."""

--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -1,36 +1,43 @@
 """Tests for core serial device code."""
 from unittest.mock import MagicMock, Mock, patch
 
-from finesse.hardware.serial_device import _get_usb_serial_ports
+from finesse.hardware.serial_device import _get_usb_serial_ports, _USBSerialPortInfo
 
 
 @patch("finesse.hardware.serial_device.comports")
 def test_get_usb_serial_ports_cached(comports_mock: Mock) -> None:
     """Check that _get_usb_serial_ports() works when results have been cached."""
-    serial_ports = ["COM10"]
+    serial_ports = {_USBSerialPortInfo(1, 2, "SERIAL", 0): "COM1"}
     with patch("finesse.hardware.serial_device._serial_ports", serial_ports):
         assert _get_usb_serial_ports() == serial_ports
         comports_mock.assert_not_called()
 
 
 @patch("finesse.hardware.serial_device.comports")
-def test_get_usb_serial_ports_not_cached(comports_mock: Mock) -> None:
+def test_get_usb_serial_ports(comports_mock: Mock) -> None:
     """Test _get_usb_serial_ports()."""
-    comports = [f"COM{i}" for i in range(3)]
-    port_infos = []
-    for comport in comports:
+    VID = 1
+    PID = 2
+    SERIAL = "SERIAL"
+
+    ports = []
+    for comport in ("COM1", "COM2", "COM3"):
         info = MagicMock()
         info.device = comport
 
-        # USB devices should have a vendor ID
-        info.vid = 1
+        info.vid = VID
+        info.pid = PID
+        info.serial_number = SERIAL
 
-        port_infos.append(info)
+        ports.append(info)
 
     # Pretend that this device isn't USB
-    port_infos[1].vid = None
+    ports[1].vid = None
 
-    comports_mock.return_value = port_infos
+    comports_mock.return_value = ports
 
     with patch("finesse.hardware.serial_device._serial_ports", None):
-        assert _get_usb_serial_ports() == ["COM0", "COM2"]
+        assert _get_usb_serial_ports() == {
+            _USBSerialPortInfo(VID, PID, SERIAL, 0): "COM1",
+            _USBSerialPortInfo(VID, PID, SERIAL, 1): "COM3",
+        }


### PR DESCRIPTION
Currently, devices are distinguished based on their COM-port number (or the Unix equivalent), which is not guaranteed to be constitent between runs. For example, on Windows the COM-port number is fixed to specific USB ports for a given PC.

Change the USB serial code to use various persistent attributes of devices instead: viz. vendor ID, product ID and serial number (which is sometimes, but not always present). Devices which provide multiple serial ports (of which we are using one for FINESSE at present) will yield ports with the same attributes, so an additional "count" field is also used to distinguish devices in this case. It appears in this latter case that the serial ports will be in the same order for a given device, so this should be robust (e.g. if the stepper motor is the second port for this device, it will be always be given a higher COM-port number than the first).

I haven't tried this with real hardware yet (though I did hack the code so I could test parts of it without), but I wanted to get this reviewed before I try it out (hopefully on Monday).

Closes #323.