### PR TITLE
pyinstaller: Bundle all hardware plugins with executable

### DIFF
--- a/FINESSE.spec
+++ b/FINESSE.spec
@@ -1,18 +1,21 @@
 # -*- mode: python ; coding: utf-8 -*-
 import docs.gen_user_guide as gen_guide
+from finesse.hardware.plugins import load_all_plugins
 
 block_cipher = None
 
 gen_guide.generate_html()
 
 a = Analysis(
-    ['stub.py'],
+    ["stub.py"],
     pathex=[],
     binaries=[],
-    datas=[('finesse/gui/images/*.png', 'finesse/gui/images'),
-           ('finesse/hardware/diag_autom.htm', 'finesse/hardware'),
-           ('docs/user_guide.html', 'docs')],
-    hiddenimports=['finesse.gui.images'],
+    datas=[
+        ("finesse/gui/images/*.png", "finesse/gui/images"),
+        ("finesse/hardware/diag_autom.htm", "finesse/hardware"),
+        ("docs/user_guide.html", "docs"),
+    ],
+    hiddenimports=["finesse.gui.images", *load_all_plugins()],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -31,7 +34,7 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     [],
-    name='FINESSE',
+    name="FINESSE",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/finesse/hardware/plugins/__init__.py
+++ b/finesse/hardware/plugins/__init__.py
@@ -1,17 +1,29 @@
 """Plugins for the hardware module."""
 import sys
+from collections.abc import Iterable
 from importlib import import_module
 from pkgutil import iter_modules
 from types import ModuleType
 
 
-def _import_recursively(module: ModuleType) -> None:
-    """Recursively import module's submodules."""
-    if hasattr(module, "__path__"):
-        for modinfo in iter_modules(module.__path__):
-            _import_recursively(import_module(f"{module.__name__}.{modinfo.name}"))
+def _import_recursively(module: ModuleType) -> Iterable[str]:
+    """Recursively import module's submodules.
+
+    Yields the names of the imported packages.
+    """
+    if not hasattr(module, "__path__"):
+        return
+
+    for modinfo in iter_modules(module.__path__):
+        package = f"{module.__name__}.{modinfo.name}"
+        yield package
+        yield from _import_recursively(import_module(package))
 
 
-def load_all_plugins() -> None:
-    """Load all the device types from this module and its submodules."""
-    _import_recursively(sys.modules[__name__])
+def load_all_plugins() -> list[str]:
+    """Load all the device types from this module and its submodules.
+
+    Returns:
+        A list of imported plugins
+    """
+    return list(_import_recursively(sys.modules[__name__]))

--- a/tests/hardware/plugins/test_plugin_loading.py
+++ b/tests/hardware/plugins/test_plugin_loading.py
@@ -26,7 +26,9 @@ def test_import_recursively(iter_modules_mock: Mock, import_mock: Mock) -> None:
     with patch(
         "finesse.hardware.plugins._import_recursively"
     ) as import_recursively_mock:
-        _import_recursively(root_module)
+        expected = [f"root.{info.name}" for info in modinfos]
+        import_recursively_mock.return_value = []
+        assert list(_import_recursively(root_module)) == expected
 
         # Check that all submodules were imported
         import_mock.assert_has_calls([call(f"root.{info.name}") for info in modinfos])
@@ -38,5 +40,9 @@ def test_import_recursively(iter_modules_mock: Mock, import_mock: Mock) -> None:
 @patch("finesse.hardware.plugins._import_recursively")
 def test_load_all_plugins(import_mock: Mock) -> None:
     """Test the load_all_plugins() function."""
-    load_all_plugins()
+    ret = load_all_plugins()
+
+    # No plugins will be found because we're mocking _import_recursively
+    assert len(ret) == 0
+
     import_mock.assert_called_once_with(sys.modules["finesse.hardware.plugins"])


### PR DESCRIPTION
It turns out that #336 broke the generated binaries for FINESSE. The problem is that the hardware modules are now loaded dynamically via the plugin system and so cannot be autodetected by `pyinstaller`. The solution is to add them to the `hiddenimports` in the spec file.

To implement this, I modified the `load_all_plugins()` function so that it returns a `list` of loaded plugins, so it can be used by the spec file.

Fixes #382.