### PR TITLE
Allow for managing devices as hardware sets

### DIFF
--- a/FINESSE.spec
+++ b/FINESSE.spec
@@ -11,6 +11,7 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[
+        ("finesse/gui/hardware_set/*.yaml", "finesse/gui/hardware_set"),
         ("finesse/gui/images/*.png", "finesse/gui/images"),
         ("finesse/hardware/plugins/em27/diag_autom.htm", "finesse/hardware/plugins/em27"),
         ("docs/user_guide.html", "docs"),

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -39,7 +39,7 @@ EM27_URL = "http://10.10.0.1/diag_autom.htm"
 EM27_SENSORS_POLL_INTERVAL = 60.0
 """Poll rate for EM27 properties."""
 
-EM27_SENSORS_TOPIC = "em27"
+EM27_SENSORS_TOPIC = "em27_sensors"
 """The topic name to use for EM27 sensor-related messages."""
 
 DEFAULT_HTTP_TIMEOUT = 2.0

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -1,4 +1,6 @@
 """Provides common dataclasses about devices for using in backend and frontend."""
+from __future__ import annotations
+
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -67,6 +69,12 @@ class DeviceInstanceRef:
 
     Used for disambiguating devices where there can be multiple instances.
     """
+
+    @staticmethod
+    def from_str(s: str) -> DeviceInstanceRef:
+        """Convert from a string in the format base_type.name."""
+        base_type, _, name = s.partition(".")
+        return DeviceInstanceRef(base_type, name if name else None)
 
     @property
     def topic(self) -> str:

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -72,9 +72,9 @@ class DeviceInstanceRef:
 
     @staticmethod
     def from_str(s: str) -> DeviceInstanceRef:
-        """Convert from a string in the format base_type.name."""
+        """Convert from a string in the format "base_type.name" or "base_type"."""
         base_type, _, name = s.partition(".")
-        return DeviceInstanceRef(base_type, name if name else None)
+        return DeviceInstanceRef(base_type, name or None)
 
     @property
     def topic(self) -> str:

--- a/finesse/event_counter.py
+++ b/finesse/event_counter.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from pubsub import pub
 
+from finesse.device_info import DeviceInstanceRef
+
 
 class EventCounter:
     """A class for monitoring events such as device opening/closing.
@@ -40,7 +42,10 @@ class EventCounter:
         # Subscribe to devices' open/close messages
         for name in device_names:
             pub.subscribe(self.increment, f"device.opened.{name}")
-            pub.subscribe(self.decrement, f"device.closed.{name}")
+            pub.subscribe(self._on_device_closed, f"device.closed.{name}")
+
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        self.decrement()
 
     def increment(self) -> None:
         """Increase the counter by one and run callback if target reached."""

--- a/finesse/event_counter.py
+++ b/finesse/event_counter.py
@@ -4,8 +4,6 @@ from typing import Any
 
 from pubsub import pub
 
-from finesse.device_info import DeviceInstanceRef
-
 
 class EventCounter:
     """A class for monitoring events such as device opening/closing.
@@ -42,10 +40,7 @@ class EventCounter:
         # Subscribe to devices' open/close messages
         for name in device_names:
             pub.subscribe(self.increment, f"device.opened.{name}")
-            pub.subscribe(self._on_device_closed, f"device.closed.{name}")
-
-    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
-        self.decrement()
+            pub.subscribe(self.decrement, f"device.closed.{name}")
 
     def increment(self) -> None:
         """Increase the counter by one and run callback if target reached."""
@@ -53,7 +48,7 @@ class EventCounter:
         if self._count == self._target_count:
             self._on_target_reached()
 
-    def decrement(self) -> None:
+    def decrement(self, **kwargs) -> None:
         """Decrease the counter by one and run callback if count drops below target."""
         self._count -= 1
         if self._count == self._target_count - 1:

--- a/finesse/gui/device_connection.py
+++ b/finesse/gui/device_connection.py
@@ -1,0 +1,21 @@
+"""Helper functions for managing connections to devices."""
+from typing import Any
+
+from frozendict import frozendict
+from pubsub import pub
+
+from finesse.device_info import DeviceInstanceRef
+
+
+def open_device(
+    class_name: str, instance: DeviceInstanceRef, params: frozendict[str, Any]
+) -> None:
+    """Open a connection to a device."""
+    pub.sendMessage(
+        "device.open", class_name=class_name, instance=instance, params=params
+    )
+
+
+def close_device(instance: DeviceInstanceRef) -> None:
+    """Close a connection to a device."""
+    pub.sendMessage("device.close", instance=instance)

--- a/finesse/gui/device_connection.py
+++ b/finesse/gui/device_connection.py
@@ -1,14 +1,14 @@
 """Helper functions for managing connections to devices."""
+from collections.abc import Mapping
 from typing import Any
 
-from frozendict import frozendict
 from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
 
 
 def open_device(
-    class_name: str, instance: DeviceInstanceRef, params: frozendict[str, Any]
+    class_name: str, instance: DeviceInstanceRef, params: Mapping[str, Any]
 ) -> None:
     """Open a connection to a device."""
     pub.sendMessage(

--- a/finesse/gui/device_panel.py
+++ b/finesse/gui/device_panel.py
@@ -5,6 +5,8 @@ from decorator import decorator
 from pubsub import pub
 from PySide6.QtWidgets import QGroupBox, QWidget
 
+from finesse.device_info import DeviceInstanceRef
+
 
 class DevicePanel(QGroupBox):
     """A QGroupBox which enables/disables child controls when device opens/closes."""
@@ -40,7 +42,7 @@ class DevicePanel(QGroupBox):
     def _on_device_opened(self) -> None:
         self.set_controls_enabled(True)
 
-    def _on_device_closed(self) -> None:
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
         self.set_controls_enabled(False)
 
     def set_controls_enabled(self, enabled: bool) -> None:

--- a/finesse/gui/device_panel.py
+++ b/finesse/gui/device_panel.py
@@ -40,9 +40,11 @@ class DevicePanel(QGroupBox):
         pub.subscribe(self._on_device_closed, f"device.closed.{name}")
 
     def _on_device_opened(self) -> None:
+        """Enable the controls when the device opens."""
         self.set_controls_enabled(True)
 
     def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        """Disable the controls when the device closes."""
         self.set_controls_enabled(False)
 
     def set_controls_enabled(self, enabled: bool) -> None:

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -220,16 +220,15 @@ class DeviceTypeControl(QGroupBox):
             params=device_params,
         )
 
-    def _on_device_opened(self, params: dict[str, Any]) -> None:
+    def _on_device_opened(
+        self, instance: DeviceInstanceRef, params: dict[str, Any]
+    ) -> None:
         """Update the GUI for when the device is successfully opened."""
-        settings.setValue(
-            f"device/{self._device_instance.topic}/type",
-            self._device_combo.currentText(),
-        )
+        device_name = self._device_combo.currentText()
+        settings.setValue(f"device/{instance.topic}/type", device_name)
         if params:
             settings.setValue(
-                f"device/{self._device_instance.topic}/"
-                f"{self._device_combo.currentText()}/params",
+                f"device/{instance.topic}/{device_name}/params",
                 params,
             )
 
@@ -240,7 +239,7 @@ class DeviceTypeControl(QGroupBox):
         """Close the device."""
         pub.sendMessage("device.close", instance=self._device_instance)
 
-    def _on_device_closed(self) -> None:
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
         """Update the GUI for when the device is closed."""
         self._set_combos_enabled(True)
         self._open_close_btn.setText("Open")

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -109,9 +109,6 @@ class DeviceTypeControl(QGroupBox):
         super().__init__(description)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
-        self._device_types = device_types
-        """Type information for each of the device types for this base type."""
-
         layout = QHBoxLayout()
         self.setLayout(layout)
 

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -3,7 +3,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
-from frozendict import frozendict
 from pubsub import pub
 from PySide6.QtWidgets import (
     QComboBox,
@@ -187,14 +186,14 @@ class DeviceTypeControl(QGroupBox):
 
     def _get_current_device_and_params(
         self,
-    ) -> tuple[DeviceTypeInfo, frozendict[str, Any]]:
+    ) -> tuple[DeviceTypeInfo, dict[str, Any]]:
         """Get the current device type and associated parameters."""
         item = self._get_current_device_type_item()
 
         # The current device widget contains combo boxes with the values
         if not item.widget:
             # No parameters needed for this device type
-            return item.device_type, frozendict()
+            return item.device_type, {}
 
         # Get the parameter values
         combos: list[QComboBox] = item.widget.findChildren(QComboBox)
@@ -202,7 +201,7 @@ class DeviceTypeControl(QGroupBox):
             p.name: c.currentData() for p, c in zip(item.device_type.parameters, combos)
         }
 
-        return item.device_type, frozendict(device_params)
+        return item.device_type, device_params
 
     def _set_combos_enabled(self, enabled: bool) -> None:
         """Set the enabled state of the combo boxes."""

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -1,4 +1,5 @@
 """Provides a control for viewing and connecting to devices."""
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -219,7 +220,7 @@ class DeviceTypeControl(QGroupBox):
         open_device(device_type.class_name, self._device_instance, device_params)
 
     def _on_device_opened(
-        self, instance: DeviceInstanceRef, class_name: str, params: frozendict[str, Any]
+        self, instance: DeviceInstanceRef, class_name: str, params: Mapping[str, Any]
     ) -> None:
         """Update the GUI for when the device is successfully opened."""
         settings.setValue(f"device/{instance.topic}/type", class_name)

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -43,7 +43,7 @@ def _create_device_widget(
     # Previous parameter values are saved if a device opens successfully
     previous_param_values = cast(
         dict[str, Any] | None,
-        settings.value(f"device/{instance.topic}/{device_type.description}/params"),
+        settings.value(f"device/{instance.topic}/{device_type.class_name}/params"),
     )
 
     widget = QWidget()
@@ -221,14 +221,13 @@ class DeviceTypeControl(QGroupBox):
         )
 
     def _on_device_opened(
-        self, instance: DeviceInstanceRef, params: dict[str, Any]
+        self, instance: DeviceInstanceRef, class_name: str, params: dict[str, Any]
     ) -> None:
         """Update the GUI for when the device is successfully opened."""
-        device_name = self._device_combo.currentText()
-        settings.setValue(f"device/{instance.topic}/type", device_name)
+        settings.setValue(f"device/{instance.topic}/type", class_name)
         if params:
             settings.setValue(
-                f"device/{instance.topic}/{device_name}/params",
+                f"device/{instance.topic}/{class_name}/params",
                 params,
             )
 

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -102,8 +102,6 @@ class DeviceTypeControl(QGroupBox):
         if not device_types:
             raise RuntimeError("At least one device type must be specified")
 
-        self._cur_device_params: dict[str, Any]
-        """Cache the device params used for opening the device."""
         self._device_instance = instance
 
         super().__init__(description)
@@ -214,25 +212,25 @@ class DeviceTypeControl(QGroupBox):
 
     def _open_device(self) -> None:
         """Open the currently selected device."""
-        device_type, self._cur_device_params = self._get_current_device_and_params()
+        device_type, device_params = self._get_current_device_and_params()
         pub.sendMessage(
             "device.open",
             class_name=device_type.class_name,
             instance=self._device_instance,
-            params=self._cur_device_params,
+            params=device_params,
         )
 
-    def _on_device_opened(self) -> None:
+    def _on_device_opened(self, params: dict[str, Any]) -> None:
         """Update the GUI for when the device is successfully opened."""
         settings.setValue(
             f"device/{self._device_instance.topic}/type",
             self._device_combo.currentText(),
         )
-        if self._cur_device_params:
+        if params:
             settings.setValue(
                 f"device/{self._device_instance.topic}/"
                 f"{self._device_combo.currentText()}/params",
-                self._cur_device_params,
+                params,
             )
 
         self._set_combos_enabled(False)

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -1,5 +1,5 @@
 """Provides a control for viewing and connecting to devices."""
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -92,7 +92,7 @@ class DeviceTypeControl(QGroupBox):
         self,
         description: str,
         instance: DeviceInstanceRef,
-        device_types: list[DeviceTypeInfo],
+        device_types: Sequence[DeviceTypeInfo],
     ) -> None:
         """Create a new DeviceTypeControl.
 
@@ -274,7 +274,7 @@ class DeviceControl(QGroupBox):
         pub.subscribe(self._on_device_list, "device.list")
 
     def _on_device_list(
-        self, device_types: dict[DeviceBaseTypeInfo, list[DeviceTypeInfo]]
+        self, device_types: Mapping[DeviceBaseTypeInfo, Sequence[DeviceTypeInfo]]
     ) -> None:
         layout = cast(QVBoxLayout, self.layout())
 

--- a/finesse/gui/device_view.py
+++ b/finesse/gui/device_view.py
@@ -1,4 +1,5 @@
 """Provides a control for viewing and connecting to devices."""
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
@@ -124,12 +125,16 @@ class DeviceTypeControl(QGroupBox):
 
         # Select the last device that was successfully opened, if there is one
         topic = instance.topic
-        previous_device = cast(
-            str | None, settings.value(f"device/{instance.topic}/type")
-        )
-        descriptions = (t.description for t in device_types)
-        if previous_device and previous_device in descriptions:
-            self._device_combo.setCurrentText(previous_device)
+        if previous_device := settings.value(f"device/{instance.topic}/type"):
+            try:
+                idx = next(
+                    i
+                    for i, device_type in enumerate(device_types)
+                    if device_type.class_name == previous_device
+                )
+                self._device_combo.setCurrentIndex(idx)
+            except StopIteration:
+                logging.warn(f"Unknown class name: {previous_device}")
 
         self._device_combo.currentIndexChanged.connect(self._on_device_selected)
         layout.addWidget(self._device_combo)

--- a/finesse/gui/hardware_set/__init__.py
+++ b/finesse/gui/hardware_set/__init__.py
@@ -1,0 +1,4 @@
+"""Contains code for working with sets of hardware for a specific rig.
+
+This allows the user to choose between, e.g., the FINESSE and UNIRAS rigs.
+"""

--- a/finesse/gui/hardware_set/finesse.yaml
+++ b/finesse/gui/hardware_set/finesse.yaml
@@ -1,0 +1,24 @@
+name: FINESSE
+devices:
+  stepper_motor:
+    class_name: finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller
+    params:
+      port: "0403:6011 FT1NMSVR (4)"
+      baudrate: 9600
+  temperature_controller.hot_bb:
+    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    params:
+      port: "0403:6011 FT1NMSVR (2)"
+      baudrate: 115200
+  temperature_controller.cold_bb:
+    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    params:
+      port: "0403:6011 FT1NMSVR (3)"
+      baudrate: 115200
+  temperature_monitor:
+    class_name: finesse.hardware.plugins.temperature.dp9800.DP9800
+    params:
+      port: "0403:6001"
+      baudrate: 38400
+  em27_sensors:
+    class_name: finesse.hardware.plugins.em27.em27_sensors.EM27Sensors

--- a/finesse/gui/hardware_set/finesse_dummy.yaml
+++ b/finesse/gui/hardware_set/finesse_dummy.yaml
@@ -1,0 +1,12 @@
+name: "FINESSE (dummy devices)"
+devices:
+  stepper_motor:
+    class_name: finesse.hardware.plugins.stepper_motor.dummy.DummyStepperMotor
+  temperature_controller.hot_bb:
+    class_name: finesse.hardware.plugins.temperature.dummy_temperature_controller.DummyTemperatureController
+  temperature_controller.cold_bb:
+    class_name: finesse.hardware.plugins.temperature.dummy_temperature_controller.DummyTemperatureController
+  temperature_monitor:
+    class_name: finesse.hardware.plugins.temperature.dummy_temperature_monitor.DummyTemperatureMonitor
+  em27_sensors:
+    class_name: finesse.hardware.plugins.em27.dummy_em27_sensors.DummyEM27Sensors

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -48,8 +48,8 @@ class HardwareSet:
     file_path: Path
     read_only: bool
 
-    @staticmethod
-    def load(file_path: Path, read_only: bool = False) -> HardwareSet:
+    @classmethod
+    def load(cls, file_path: Path, read_only: bool = False) -> HardwareSet:
         """Load a HardwareSet from a YAML file."""
         logging.info(f"Loading hardware set from {file_path}")
 
@@ -61,7 +61,7 @@ class HardwareSet:
             for k, v in plain_data.get("devices", {}).items()
         )
 
-        return HardwareSet(plain_data["name"], devices, file_path, read_only)
+        return cls(plain_data["name"], devices, file_path, read_only)
 
 
 def load_builtin_hardware_sets() -> Generator[HardwareSet, None, None]:

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
@@ -31,14 +31,12 @@ class OpenDeviceArgs:
         """Close the device."""
         close_device(self.instance)
 
-    @staticmethod
+    @classmethod
     def create(
-        instance: str, class_name: str, params: dict[str, Any] = {}
+        cls, instance: str, class_name: str, params: Mapping[str, Any] = frozendict()
     ) -> OpenDeviceArgs:
         """Create an OpenDeviceArgs using basic types."""
-        return OpenDeviceArgs(
-            DeviceInstanceRef.from_str(instance), class_name, frozendict(params)
-        )
+        return cls(DeviceInstanceRef.from_str(instance), class_name, frozendict(params))
 
 
 @dataclass(frozen=True)

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -1,0 +1,73 @@
+"""The HardwareSet dataclass and associated helper functions."""
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+from frozendict import frozendict
+
+from finesse.device_info import DeviceInstanceRef
+from finesse.gui.device_connection import close_device, open_device
+
+
+@dataclass(frozen=True)
+class OpenDeviceArgs:
+    """Arguments needed to open a device."""
+
+    instance: DeviceInstanceRef
+    class_name: str
+    params: frozendict[str, Any] = field(default_factory=frozendict)
+
+    def open(self) -> None:
+        """Open the device."""
+        open_device(self.class_name, self.instance, self.params)
+
+    def close(self) -> None:
+        """Close the device."""
+        close_device(self.instance)
+
+    @staticmethod
+    def create(
+        instance: str, class_name: str, params: dict[str, Any] = {}
+    ) -> OpenDeviceArgs:
+        """Create an OpenDeviceArgs using basic types."""
+        return OpenDeviceArgs(
+            DeviceInstanceRef.from_str(instance), class_name, frozendict(params)
+        )
+
+
+@dataclass(frozen=True)
+class HardwareSet:
+    """Represents a collection of devices for a particular hardware configuration."""
+
+    name: str
+    devices: frozenset[OpenDeviceArgs]
+    file_path: Path
+    read_only: bool
+
+    @staticmethod
+    def load(file_path: Path, read_only: bool = False) -> HardwareSet:
+        """Load a HardwareSet from a YAML file."""
+        logging.info(f"Loading hardware set from {file_path}")
+
+        with file_path.open() as file:
+            plain_data: dict[str, Any] = yaml.safe_load(file)
+
+        devices = frozenset(
+            OpenDeviceArgs.create(k, **v)
+            for k, v in plain_data.get("devices", {}).items()
+        )
+
+        return HardwareSet(plain_data["name"], devices, file_path, read_only)
+
+
+def load_builtin_hardware_sets() -> Generator[HardwareSet, None, None]:
+    """Load all the default hardware sets included with FINESSE."""
+    pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
+    for filepath in Path(pkg_path).glob("*.yaml"):
+        yield HardwareSet.load(filepath, read_only=True)

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -1,4 +1,5 @@
 """Provides a panel for choosing between hardware sets and (dis)connecting."""
+from collections.abc import Mapping
 from typing import Any, cast
 
 from frozendict import frozendict
@@ -124,9 +125,11 @@ class HardwareSetsControl(QGroupBox):
         self._update_control_state()
 
     def _on_device_opened(
-        self, instance: DeviceInstanceRef, class_name: str, params: frozendict[str, Any]
+        self, instance: DeviceInstanceRef, class_name: str, params: Mapping[str, Any]
     ) -> None:
-        self._connected_devices.add(OpenDeviceArgs(instance, class_name, params))
+        self._connected_devices.add(
+            OpenDeviceArgs(instance, class_name, frozendict(params))
+        )
         self._update_control_state()
 
     def _on_device_closed(self, instance: DeviceInstanceRef) -> None:

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -111,6 +111,12 @@ class HardwareSetsControl(QGroupBox):
         skip it. If a device of the same type but with different parameters has been
         opened, then it will be closed as we open the new device.
         """
+        # Remember which hardware set was selected for next time we run the program
+        settings.setValue(
+            "hardware_set/selected", self._hardware_sets_combo.currentText()
+        )
+
+        # Open each of the devices in turn
         for device in self.current_hardware_set.difference(self._connected_devices):
             device.open()
 

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -1,0 +1,145 @@
+"""Provides a panel for choosing between hardware sets and (dis)connecting."""
+from typing import Any, cast
+
+from frozendict import frozendict
+from pubsub import pub
+from PySide6.QtWidgets import (
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QPushButton,
+    QSizePolicy,
+)
+
+from finesse.device_info import DeviceInstanceRef
+from finesse.gui.hardware_set.hardware_set import (
+    HardwareSet,
+    OpenDeviceArgs,
+    load_builtin_hardware_sets,
+)
+from finesse.settings import settings
+
+
+class HardwareSetsControl(QGroupBox):
+    """A panel for choosing between hardware sets and (dis)connecting."""
+
+    def __init__(self) -> None:
+        """Create a new HardwareSetsControl."""
+        super().__init__("Hardware set")
+
+        self._connected_devices: set[OpenDeviceArgs] = set()
+        pub.subscribe(self._on_device_opened, "device.opening")
+        pub.subscribe(self._on_device_closed, "device.closed")
+
+        self._hardware_sets_combo = QComboBox()
+        self._hardware_sets_combo.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
+        )
+
+        # Populate combo box
+        for hw_set in load_builtin_hardware_sets():
+            self._add_hardware_set(hw_set)
+
+        # Remember which hardware set was in use the last time the program was run
+        last_selected = cast(str | None, settings.value("hardware_set/selected"))
+        if last_selected:
+            self._hardware_sets_combo.setCurrentText(last_selected)
+
+        self._hardware_sets_combo.currentIndexChanged.connect(
+            self._update_control_state
+        )
+
+        self._connect_btn = QPushButton("Connect")
+        self._connect_btn.setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum
+        )
+        self._connect_btn.pressed.connect(self._on_connect_btn_pressed)
+        self._disconnect_btn = QPushButton("Disconnect all")
+        self._disconnect_btn.setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum
+        )
+        self._disconnect_btn.pressed.connect(self._on_disconnect_btn_pressed)
+
+        # Enable/disable controls
+        self._update_control_state()
+
+        layout = QHBoxLayout()
+        layout.addWidget(self._hardware_sets_combo)
+        layout.addWidget(self._connect_btn)
+        layout.addWidget(self._disconnect_btn)
+        self.setLayout(layout)
+
+    def _add_hardware_set(self, hw_set: HardwareSet) -> None:
+        """Add a new hardware set to the combo box."""
+        labels = {
+            self._hardware_sets_combo.itemText(i)
+            for i in range(self._hardware_sets_combo.count())
+        }
+        if hw_set.name not in labels:
+            self._hardware_sets_combo.addItem(hw_set.name, hw_set)
+            return
+
+        # If there is already a hardware set by that name, append a number
+        i = 2
+        while True:
+            name = f"{hw_set.name} ({i})"
+            if name not in labels:
+                self._hardware_sets_combo.addItem(name, hw_set)
+                return
+            i += 1
+
+    @property
+    def current_hardware_set(self) -> frozenset[OpenDeviceArgs]:
+        """Return the currently selected hardware set."""
+        return self._hardware_sets_combo.currentData().devices
+
+    def _update_control_state(self) -> None:
+        # Enable the "Connect" button if there are any devices left to connect for this
+        # hardware set
+        all_connected = self._connected_devices.issuperset(self.current_hardware_set)
+        self._connect_btn.setEnabled(not all_connected)
+
+        # Enable the "Disconnect all" button if there are *any* devices connected at all
+        self._disconnect_btn.setEnabled(bool(self._connected_devices))
+
+    def _on_connect_btn_pressed(self) -> None:
+        """Connect to all devices in current hardware set.
+
+        If a device has already been opened with the same type and parameters, then we
+        skip it. If a device of the same type but with different parameters has been
+        opened, then it will be closed as we open the new device.
+        """
+        for device in self.current_hardware_set.difference(self._connected_devices):
+            device.open()
+
+        self._update_control_state()
+
+    def _on_disconnect_btn_pressed(self) -> None:
+        """Disconnect from all devices in current hardware set."""
+        # We need to copy the set because its size will change as we close devices
+        for device in self._connected_devices.copy():
+            device.close()
+
+        self._update_control_state()
+
+    def _on_device_opened(
+        self, instance: DeviceInstanceRef, class_name: str, params: frozendict[str, Any]
+    ) -> None:
+        self._connected_devices.add(OpenDeviceArgs(instance, class_name, params))
+        self._update_control_state()
+
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        try:
+            # Remove the device matching this instance type (there should be only one)
+            self._connected_devices.remove(
+                next(
+                    device
+                    for device in self._connected_devices
+                    if device.instance == instance
+                )
+            )
+
+            self._update_control_state()
+        except StopIteration:
+            # No device of this type found
+            pass

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -94,6 +94,7 @@ class HardwareSetsControl(QGroupBox):
         return self._hardware_sets_combo.currentData().devices
 
     def _update_control_state(self) -> None:
+        """Enable or disable the connect and disconnect buttons as appropriate."""
         # Enable the "Connect" button if there are any devices left to connect for this
         # hardware set
         all_connected = self._connected_devices.issuperset(self.current_hardware_set)

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -127,12 +127,14 @@ class HardwareSetsControl(QGroupBox):
     def _on_device_opened(
         self, instance: DeviceInstanceRef, class_name: str, params: Mapping[str, Any]
     ) -> None:
+        """Add instance to _connected_devices and update GUI."""
         self._connected_devices.add(
             OpenDeviceArgs(instance, class_name, frozendict(params))
         )
         self._update_control_state()
 
     def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        """Remove instance from _connected devices and update GUI."""
         try:
             # Remove the device matching this instance type (there should be only one)
             self._connected_devices.remove(

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -11,6 +11,7 @@ from ..config import (
 from .data_file_view import DataFileControl
 from .device_view import DeviceControl
 from .em27_monitor import EM27Monitor
+from .hardware_set.hardware_sets_view import HardwareSetsControl
 from .measure_script.script_view import ScriptControl
 from .opus_view import OPUSControl
 from .stepper_motor_view import StepperMotorControl
@@ -30,6 +31,9 @@ class MainWindow(QMainWindow):
 
         layout_left = QGridLayout()
 
+        # For choosing hardware set
+        hardware_sets = HardwareSetsControl()
+
         # Setup for stepper motor control
         stepper_motor = StepperMotorControl()
 
@@ -44,11 +48,12 @@ class MainWindow(QMainWindow):
 
         opus: QGroupBox = OPUSControl()
 
-        layout_left.addWidget(stepper_motor, 0, 0, 1, 2)
-        layout_left.addWidget(opus, 1, 0, 1, 2)
-        layout_left.addWidget(measure_script, 2, 0, 1, 2)
-        layout_left.addWidget(device_control, 3, 0, 1, 1)
-        layout_left.addWidget(em27_monitor, 3, 1, 1, 1)
+        layout_left.addWidget(hardware_sets, 0, 0, 1, 2)
+        layout_left.addWidget(stepper_motor, 1, 0, 1, 2)
+        layout_left.addWidget(opus, 2, 0, 1, 2)
+        layout_left.addWidget(measure_script, 3, 0, 1, 2)
+        layout_left.addWidget(device_control, 4, 0, 1, 1)
+        layout_left.addWidget(em27_monitor, 4, 1, 1, 1)
 
         layout_right = QGridLayout()
 

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -20,6 +20,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from finesse.device_info import DeviceInstanceRef
+
 from ..config import (
     NUM_TEMPERATURE_MONITOR_CHANNELS,
     TEMPERATURE_CONTROLLER_POLL_INTERVAL,
@@ -303,9 +305,6 @@ class TC4820Controls(DevicePanel):
             f"device.opened.{TEMPERATURE_CONTROLLER_TOPIC}.{name}_bb",
         )
         pub.subscribe(
-            self._end_polling, f"device.closed.{TEMPERATURE_CONTROLLER_TOPIC}.{name}_bb"
-        )
-        pub.subscribe(
             self._update_controls,
             f"device.{TEMPERATURE_CONTROLLER_TOPIC}.{name}_bb.response",
         )
@@ -392,6 +391,10 @@ class TC4820Controls(DevicePanel):
             self._set_new_set_point()
             self._set_sbox.setEnabled(False)
             self._begin_polling()
+
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        super()._on_device_closed(instance)
+        self._end_polling()
 
     def _begin_polling(self) -> None:
         """Initiate polling the TC4820 device."""

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -3,6 +3,7 @@ import logging
 from importlib import import_module
 from typing import Any, TypeVar, cast
 
+from frozendict import frozendict
 from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
@@ -28,7 +29,7 @@ def get_device_instance(base_type: type[_T], name: str | None = None) -> _T | No
 
 
 def _open_device(
-    instance: DeviceInstanceRef, class_name: str, params: dict[str, Any]
+    instance: DeviceInstanceRef, class_name: str, params: frozendict[str, Any]
 ) -> None:
     """Open the specified device type.
 

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -51,6 +51,7 @@ def _open_device(
 
     # If this instance also has a name (e.g. "hot_bb") then we also need to pass this as
     # an argument
+    params_orig = params
     if instance.name:
         # Note that we create a new dict here so we're not modifying the original one
         params = params | {"name": instance.name}
@@ -68,7 +69,7 @@ def _open_device(
         # Signal that device is now open. The reason for the two different topics is
         # because we want to ensure that some listeners always run before others, in
         # case an error occurs and we have to undo the work.
-        pub.sendMessage(f"device.opening.{instance.topic}")
+        pub.sendMessage(f"device.opening.{instance.topic}", params=params_orig)
         pub.sendMessage(f"device.opened.{instance.topic}")
 
 

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -45,8 +45,9 @@ def _open_device(
 
     logging.info(f"Opening device of type {instance.base_type}: {class_name}")
 
-    if instance in _devices:
+    if device := _devices.get(instance):
         logging.warn(f"Replacing existing instance of device of type {instance.topic}")
+        _try_close_device(device)
 
     # If this instance also has a name (e.g. "hot_bb") then we also need to pass this as
     # an argument

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -37,13 +37,13 @@ def _open_device(
         class_name: The name of the device type's class
         params: Device parameters
     """
-    module, _, class_name = class_name.rpartition(".")
+    module, _, class_name_part = class_name.rpartition(".")
 
     # Assume this is safe because module and class_name will not be provided directly by
     # the user
-    cls: Device = getattr(import_module(module), class_name)
+    cls: Device = getattr(import_module(module), class_name_part)
 
-    logging.info(f"Opening device of type {instance.base_type}: {class_name}")
+    logging.info(f"Opening device of type {instance.base_type}: {class_name_part}")
 
     if device := _devices.get(instance):
         logging.warn(f"Replacing existing instance of device of type {instance.topic}")
@@ -70,7 +70,10 @@ def _open_device(
         # because we want to ensure that some listeners always run before others, in
         # case an error occurs and we have to undo the work.
         pub.sendMessage(
-            f"device.opening.{instance.topic}", instance=instance, params=params_orig
+            f"device.opening.{instance.topic}",
+            instance=instance,
+            class_name=class_name,
+            params=params_orig,
         )
         pub.sendMessage(f"device.opened.{instance.topic}")
 

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -28,13 +28,13 @@ def get_device_instance(base_type: type[_T], name: str | None = None) -> _T | No
 
 
 def _open_device(
-    class_name: str, instance: DeviceInstanceRef, params: dict[str, Any]
+    instance: DeviceInstanceRef, class_name: str, params: dict[str, Any]
 ) -> None:
     """Open the specified device type.
 
     Args:
-        class_name: The name of the device type's class
         instance: The instance that this device will be when opened
+        class_name: The name of the device type's class
         params: Device parameters
     """
     module, _, class_name = class_name.rpartition(".")

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -1,9 +1,9 @@
 """This module contains code for interfacing with different hardware devices."""
 import logging
+from collections.abc import Mapping
 from importlib import import_module
 from typing import Any, TypeVar, cast
 
-from frozendict import frozendict
 from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
@@ -29,7 +29,7 @@ def get_device_instance(base_type: type[_T], name: str | None = None) -> _T | No
 
 
 def _open_device(
-    instance: DeviceInstanceRef, class_name: str, params: frozendict[str, Any]
+    instance: DeviceInstanceRef, class_name: str, params: Mapping[str, Any]
 ) -> None:
     """Open the specified device type.
 

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -69,7 +69,9 @@ def _open_device(
         # Signal that device is now open. The reason for the two different topics is
         # because we want to ensure that some listeners always run before others, in
         # case an error occurs and we have to undo the work.
-        pub.sendMessage(f"device.opening.{instance.topic}", params=params_orig)
+        pub.sendMessage(
+            f"device.opening.{instance.topic}", instance=instance, params=params_orig
+        )
         pub.sendMessage(f"device.opened.{instance.topic}")
 
 
@@ -85,10 +87,8 @@ def _try_close_device(device: Device) -> None:
     except Exception as ex:
         logging.warn(f"Error while closing {device.__class__.__name__}: {ex!s}")
 
-    topic = device.get_device_base_type_info().name
-    if device.name:
-        topic += f".{device.name}"
-    pub.sendMessage(f"device.closed.{topic}")
+    instance = device.get_instance_ref()
+    pub.sendMessage(f"device.closed.{instance.topic}", instance=instance)
 
 
 def _close_device(instance: DeviceInstanceRef) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -485,6 +485,52 @@ unicode = ["unicodedata2 (>=15.0.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
+name = "frozendict"
+version = "2.3.8"
+description = "A simple immutable dictionary"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "frozendict-2.3.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d188d062084fba0e4bf32719ff7380b26c050b932ff164043ce82ab90587c52b"},
+    {file = "frozendict-2.3.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f2a4e818ac457f6354401dcb631527af25e5a20fcfc81e6b5054b45fc245caca"},
+    {file = "frozendict-2.3.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a506d807858fa961aaa5b48dab6154fdc6bd045bbe9310788bbff141bb42d13"},
+    {file = "frozendict-2.3.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:750632cc890d8ee9484fe6d31b261159144b6efacc08e1317fe46accd1410373"},
+    {file = "frozendict-2.3.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:7ee5fe2658a8ac9a57f748acaf563f6a47f80b8308cbf0a04fac0ba057d41f75"},
+    {file = "frozendict-2.3.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23c4bb46e6b8246e1e7e49b5593c2bc09221db0d8f31f7c092be8dfb42b9e620"},
+    {file = "frozendict-2.3.8-cp310-cp310-win_amd64.whl", hash = "sha256:c31abc8acea309b132dde441856829f6003a3d242da8b54bce4c0f2a3c8c63f0"},
+    {file = "frozendict-2.3.8-cp310-cp310-win_arm64.whl", hash = "sha256:9ea5520e85447ff8d4681e181941e482662817ccba921b7cb3f87922056d892a"},
+    {file = "frozendict-2.3.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f83fed36497af9562ead5e9fb8443224ba2781786bd3b92b1087cb7d0ff20135"},
+    {file = "frozendict-2.3.8-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e27c5c1d29d0eda7979253ec88abc239da1313b38f39f4b16984db3b3e482300"},
+    {file = "frozendict-2.3.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c785de7f1a13f15963945f400656b18f057c2fc76c089dacf127a2bb188c03"},
+    {file = "frozendict-2.3.8-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8cf35ddd25513428ec152614def9696afb93ae5ec0eb54fa6aa6206eda77ac4c"},
+    {file = "frozendict-2.3.8-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ffc684773de7c88724788fa9787d0016fd75830412d58acbd9ed1a04762c675b"},
+    {file = "frozendict-2.3.8-cp36-cp36m-win_amd64.whl", hash = "sha256:4c258aab9c8488338634f2ec670ef049dbf0ab0e7a2fa9bc2c7b5009cb614801"},
+    {file = "frozendict-2.3.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:47fc26468407fdeb428cfc89495b7921419e670355c21b383765482fdf6c5c14"},
+    {file = "frozendict-2.3.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ea638228692db2bf94bce40ea4b25f4077588497b516bd16576575560094bd9"},
+    {file = "frozendict-2.3.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a75bf87e76c4386caecdbdd02a99e53ad43a6b5c38fb3d5a634a9fc9ce41462"},
+    {file = "frozendict-2.3.8-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ed5a6c5c7a0f57269577c2a338a6002949aea21a23b7b7d06da7e7dced8b605b"},
+    {file = "frozendict-2.3.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d086440328a465dea9bef2dbad7548d75d1a0a0d21f43a08c03e1ec79ac5240e"},
+    {file = "frozendict-2.3.8-cp37-cp37m-win_amd64.whl", hash = "sha256:0bc4767e2f83db5b701c787e22380296977368b0c57e485ca71b2eedfa11c4a3"},
+    {file = "frozendict-2.3.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:638cf363d3cbca31a341503cf2219eac52a5f5140449676fae3d9644cd3c5487"},
+    {file = "frozendict-2.3.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2b2fd8ce36277919b36e3c834d2389f3cd7ac068ae730c312671dd4439a5dd65"},
+    {file = "frozendict-2.3.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3957d52f1906b0c85f641a1911d214255873f6408ab4e5ad657cc27a247fb145"},
+    {file = "frozendict-2.3.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72cfe08ab8ae524e54848fa90b22d02c1b1ecfb3064438696bcaa4b953f18772"},
+    {file = "frozendict-2.3.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4742e76c4111bd09198d3ab66cef94be8506212311338f9182d6ef5f5cb60493"},
+    {file = "frozendict-2.3.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:313ed8d9ba6bac35d7635cd9580ee5721a0fb016f4d2d20f0efa05dbecbdb1be"},
+    {file = "frozendict-2.3.8-cp38-cp38-win_amd64.whl", hash = "sha256:d3c6ce943946c2a61501c8cf116fff0892d11dd579877eb36e2aea2c27fddfef"},
+    {file = "frozendict-2.3.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0f573dc4861dd7ec9e055c8cceaf45355e894e749f621f199aab7b311ac4bdb"},
+    {file = "frozendict-2.3.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b3435e5f1ca5ae68a5e95e64b09d6d5c645cadd6b87569a0b3019dd248c8d00"},
+    {file = "frozendict-2.3.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:145afd033ebfade28416093335261b8ec1af5cccc593482309e7add062ec8668"},
+    {file = "frozendict-2.3.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da98427de26b5a2865727947480cbb53860089c4d195baa29c539da811cea617"},
+    {file = "frozendict-2.3.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5e82befa7c385a668d569cebbebbdf49cee6fea4083f08e869a1b08cfb640a9f"},
+    {file = "frozendict-2.3.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:80abe81d36e889ceec665e06ec764a7638000fa3e7be09786ac4d3ddc64b76db"},
+    {file = "frozendict-2.3.8-cp39-cp39-win_amd64.whl", hash = "sha256:8ccc94ac781710db44e142e1a11ff9b31d02c032c01c6868d51fcbef73086225"},
+    {file = "frozendict-2.3.8-cp39-cp39-win_arm64.whl", hash = "sha256:e72dbc1bcc2203cef38d205f692396f5505921a5680f66aa9a7e8bb71fd38f28"},
+    {file = "frozendict-2.3.8-py311-none-any.whl", hash = "sha256:ba41a7ed019bd03b62d63ed3f8dea35b8243d1936f7c9ed4b5298ca45a01928e"},
+    {file = "frozendict-2.3.8.tar.gz", hash = "sha256:5526559eca8f1780a4ee5146896f59afc31435313560208dd394a3a5e537d3ff"},
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
@@ -1637,7 +1683,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1645,15 +1690,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1670,7 +1708,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1678,7 +1715,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2021,4 +2057,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "663c1b06a9590721bcfb04335968dead7fcf507470b3f7bda51345047ace3e06"
+content-hash = "52932e338bc3b53cf6be27e6a07ebe2b279b6d79e7d4b62a965164d7b8f2959f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ python-statemachine = "^2.1.2"
 numpy = "^1.26.1"
 decorator = "^5.1.1"
 pycsvy = "^0.2.2"
+frozendict = "^2.3.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -1,0 +1,85 @@
+"""Tests for the HardwareSet class and associated helper functions."""
+from importlib import resources
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, call, mock_open, patch
+
+import pytest
+import yaml
+
+from finesse.gui.hardware_set import hardware_set
+from finesse.gui.hardware_set.hardware_set import (
+    HardwareSet,
+    OpenDeviceArgs,
+    load_builtin_hardware_sets,
+)
+
+FILE_PATH = Path("test/file.yaml")
+NAME = "Test hardware set"
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    (
+        # Devices attribute missing
+        ({"name": NAME}, HardwareSet(NAME, frozenset(), FILE_PATH, False)),
+        # Device given with params
+        (
+            {
+                "name": NAME,
+                "devices": {"stepper_motor": {"class_name": "MyStepperMotor"}},
+            },
+            HardwareSet(
+                NAME,
+                frozenset((OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),)),
+                FILE_PATH,
+                False,
+            ),
+        ),
+        # Device given without params
+        (
+            {
+                "name": NAME,
+                "devices": {
+                    "stepper_motor": {
+                        "class_name": "MyStepperMotor",
+                        "params": {"param1": "value1"},
+                    }
+                },
+            },
+            HardwareSet(
+                NAME,
+                frozenset(
+                    (
+                        OpenDeviceArgs.create(
+                            "stepper_motor",
+                            "MyStepperMotor",
+                            {"param1": "value1"},
+                        ),
+                    )
+                ),
+                FILE_PATH,
+                False,
+            ),
+        ),
+        # TODO: Test errors
+    ),
+)
+def test_load(data: dict[str, Any], expected: HardwareSet) -> None:
+    """Test HardwareSet's static load() method."""
+    with patch.object(
+        hardware_set.Path,
+        "open",
+        mock_open(read_data=yaml.dump(data)),
+    ):
+        result = HardwareSet.load(FILE_PATH, False)
+        assert result == expected
+
+
+@patch.object(HardwareSet, "load")
+def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
+    """Test the load_builtin_hardware_sets() function."""
+    pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
+    yaml_files = Path(pkg_path).glob("*.yaml")
+    list(load_builtin_hardware_sets())  # assume return value is correct
+    load_mock.assert_has_calls([call(file, read_only=True) for file in yaml_files])

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -148,9 +148,11 @@ def test_update_control_state(
     "connected_devices,hardware_set,open_called",
     (((), range(2), range(2)), (range(2), range(2), ()), ((0,), range(2), (1,))),
 )
+@patch("finesse.gui.hardware_set.hardware_sets_view.settings")
 @patch("finesse.gui.hardware_set.hardware_set.open_device")
 def test_connect_btn(
     open_mock: Mock,
+    settings_mock: Mock,
     connected_devices: Sequence[int],
     hardware_set: Sequence[int],
     open_called: Sequence[int],
@@ -175,6 +177,10 @@ def test_connect_btn(
                     for dev in _get_devices(open_called)
                 ),
                 any_order=True,
+            )
+
+            settings_mock.setValue.assert_called_once_with(
+                "hardware_set/selected", "Test 1"
             )
 
 

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -1,0 +1,222 @@
+"""Tests for the HardwareSetsControl class."""
+from collections.abc import Sequence
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
+
+import pytest
+
+from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
+from finesse.gui.hardware_set.hardware_sets_view import HardwareSetsControl
+
+HW_SETS = [
+    HardwareSet(
+        "Test 1",
+        frozenset(
+            (
+                OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
+                OpenDeviceArgs.create(
+                    "temperature_monitor",
+                    "MyTemperatureMonitor",
+                    {"param1": "value1"},
+                ),
+            )
+        ),
+        Path("path/test.yaml"),
+        False,
+    ),
+    HardwareSet(
+        "Test 2",
+        frozenset(
+            (
+                OpenDeviceArgs.create("stepper_motor", "OtherStepperMotor"),
+                OpenDeviceArgs.create("temperature_monitor", "OtherTemperatureMonitor"),
+            )
+        ),
+        Path("path/test2.yaml"),
+        False,
+    ),
+]
+
+
+@pytest.fixture
+@patch("finesse.gui.hardware_set.hardware_sets_view.load_builtin_hardware_sets")
+def hw_sets(
+    load_hw_sets_mock: Mock, subscribe_mock: MagicMock, qtbot
+) -> HardwareSetsControl:
+    """A fixture for the control."""
+    load_hw_sets_mock.return_value = HW_SETS
+    return HardwareSetsControl()
+
+
+@pytest.mark.parametrize("selected_hw_set", (hw_set.name for hw_set in HW_SETS))
+@patch("finesse.gui.hardware_set.hardware_sets_view.load_builtin_hardware_sets")
+def test_init(
+    load_hw_sets_mock: Mock, selected_hw_set: str, subscribe_mock: MagicMock, qtbot
+) -> None:
+    """Test the constructor."""
+    with patch("finesse.gui.hardware_set.hardware_sets_view.settings") as settings_mock:
+        settings_mock.value.return_value = selected_hw_set
+        load_hw_sets_mock.return_value = HW_SETS
+        hw_sets = HardwareSetsControl()
+        settings_mock.value.assert_called_once_with("hardware_set/selected")
+        assert hw_sets._hardware_sets_combo.count() == 2
+        assert hw_sets._hardware_sets_combo.currentText() == selected_hw_set
+        assert hw_sets._connect_btn.isEnabled()
+        assert not hw_sets._disconnect_btn.isEnabled()
+
+        subscribe_mock.assert_has_calls(
+            [
+                call(hw_sets._on_device_opened, "device.opening"),
+                call(hw_sets._on_device_closed, "device.closed"),
+            ]
+        )
+
+
+def test_add_hardware_set(hw_sets: HardwareSetsControl, qtbot) -> None:
+    """Test the add_hardware_set() method."""
+    with patch.object(hw_sets._hardware_sets_combo, "addItem") as add_mock:
+        hw_set = MagicMock()
+        hw_set.name = "New name"
+        hw_sets._add_hardware_set(hw_set)
+        add_mock.assert_called_once_with("New name", hw_set)
+
+        # Check a number is appended if the name already exists
+        add_mock.reset_mock()
+        hw_set2 = MagicMock()
+        hw_set2.name = "Test 1"
+        hw_sets._add_hardware_set(hw_set2)
+        add_mock.assert_called_once_with("Test 1 (2)", hw_set2)
+
+    # Check that the number increments
+    hw_sets._hardware_sets_combo.addItem("Test 1 (2)")
+    with patch.object(hw_sets._hardware_sets_combo, "addItem") as add_mock:
+        add_mock.reset_mock()
+        hw_set3 = MagicMock()
+        hw_set3.name = "Test 1"
+        hw_sets._add_hardware_set(hw_set3)
+        add_mock.assert_called_once_with("Test 1 (3)", hw_set3)
+
+
+DEVICES = [OpenDeviceArgs.create(f"type{i}", f"class{i}") for i in range(2)]
+
+
+def _get_devices(indexes: Sequence[int]) -> set[OpenDeviceArgs]:
+    return {DEVICES[idx] for idx in indexes}
+
+
+@pytest.mark.parametrize(
+    "connect_enabled,disconnect_enabled,connected_devices,hardware_set",
+    (
+        (True, False, (), range(2)),
+        (False, True, range(2), range(2)),
+        (True, True, (1,), range(2)),
+        (False, False, (), ()),
+    ),
+)
+def test_update_control_state(
+    connect_enabled: bool,
+    disconnect_enabled: bool,
+    connected_devices: Sequence[int],
+    hardware_set: Sequence[int],
+    hw_sets: HardwareSetsControl,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _update_control_state() method."""
+    with patch(
+        "finesse.gui.hardware_set.hardware_sets_view"
+        ".HardwareSetsControl.current_hardware_set",
+        new_callable=PropertyMock,
+    ) as hw_set_mock:
+        hw_set_mock.return_value = _get_devices(hardware_set)
+        with patch.object(
+            hw_sets, "_connected_devices", _get_devices(connected_devices)
+        ):
+            with patch.object(
+                hw_sets._connect_btn, "setEnabled"
+            ) as connect_enable_mock:
+                with patch.object(
+                    hw_sets._disconnect_btn, "setEnabled"
+                ) as disconnect_enable_mock:
+                    hw_sets._update_control_state()
+                    connect_enable_mock.assert_called_once_with(connect_enabled)
+                    disconnect_enable_mock.assert_called_once_with(disconnect_enabled)
+
+
+@pytest.mark.parametrize(
+    "connected_devices,hardware_set,open_called",
+    (((), range(2), range(2)), (range(2), range(2), ()), ((0,), range(2), (1,))),
+)
+@patch("finesse.gui.hardware_set.hardware_set.open_device")
+def test_connect_btn(
+    open_mock: Mock,
+    connected_devices: Sequence[int],
+    hardware_set: Sequence[int],
+    open_called: Sequence[int],
+    hw_sets: HardwareSetsControl,
+    qtbot,
+) -> None:
+    """Test the connect button."""
+    with patch(
+        "finesse.gui.hardware_set.hardware_sets_view"
+        ".HardwareSetsControl.current_hardware_set",
+        new_callable=PropertyMock,
+    ) as hw_set_mock:
+        hw_set_mock.return_value = _get_devices(hardware_set)
+        with patch.object(
+            hw_sets, "_connected_devices", _get_devices(connected_devices)
+        ):
+            hw_sets._connect_btn.click()
+
+            open_mock.assert_has_calls(
+                list(
+                    call(dev.class_name, dev.instance, dev.params)
+                    for dev in _get_devices(open_called)
+                ),
+                any_order=True,
+            )
+
+
+@patch("finesse.gui.hardware_set.hardware_set.close_device")
+def test_disconnect_button(
+    close_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+) -> None:
+    """Test the disconnect button."""
+    with patch.object(hw_sets, "_update_control_state") as update_mock:
+        with patch.object(hw_sets, "_connected_devices", DEVICES):
+            hw_sets._disconnect_btn.setEnabled(True)
+            hw_sets._disconnect_btn.click()
+            close_mock.assert_has_calls([call(device.instance) for device in DEVICES])
+            update_mock.assert_called_once_with()
+
+
+def test_on_device_opened(hw_sets: HardwareSetsControl, qtbot) -> None:
+    """Test the _on_device_opened() method."""
+    device = DEVICES[0]
+    assert not hw_sets._connected_devices
+    with patch.object(hw_sets, "_update_control_state") as update_mock:
+        hw_sets._on_device_opened(
+            instance=device.instance, class_name=device.class_name, params=device.params
+        )
+        assert hw_sets._connected_devices == {device}
+        update_mock.assert_called_once_with()
+
+
+def test_on_device_closed(hw_sets: HardwareSetsControl, qtbot) -> None:
+    """Test the _on_device_closed() method."""
+    device = DEVICES[0]
+    assert not hw_sets._connected_devices
+    with patch.object(hw_sets, "_update_control_state") as update_mock:
+        hw_sets._connected_devices.add(device)
+        hw_sets._on_device_closed(device.instance)
+        assert not hw_sets._connected_devices
+        update_mock.assert_called_once_with()
+
+
+def test_on_device_closed_not_found(hw_sets: HardwareSetsControl, qtbot) -> None:
+    """Test that _on_device_closed() does not raise an error if device is not found."""
+    device = DEVICES[0]
+    assert not hw_sets._connected_devices
+    with does_not_raise():
+        hw_sets._on_device_closed(device.instance)

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -28,7 +28,7 @@ def test_init(
     timer_mock.assert_called_once()
 
     # Check timer is properly set up
-    timer.setSingleShot(True)
+    timer.setSingleShot.assert_called_once_with(True)
     timer.setInterval.assert_called_once_with(1000)
     timer.timeout.connect.assert_called_once_with(_poll_em27_status)
 

--- a/tests/gui/test_device_connection.py
+++ b/tests/gui/test_device_connection.py
@@ -1,0 +1,23 @@
+"""Test the helper functions in device_connection.py."""
+from unittest.mock import MagicMock
+
+from finesse.device_info import DeviceInstanceRef
+from finesse.gui.device_connection import close_device, open_device
+
+
+def test_open_device(sendmsg_mock: MagicMock) -> None:
+    """Test open_device()."""
+    class_name = "MyDevice"
+    instance = DeviceInstanceRef("my_base_type")
+    params = {"my_param": "my_value"}
+    open_device(class_name, instance, params)
+    sendmsg_mock.assert_called_once_with(
+        "device.open", class_name=class_name, instance=instance, params=params
+    )
+
+
+def test_close_device(sendmsg_mock: MagicMock) -> None:
+    """Test close_device()."""
+    instance = DeviceInstanceRef("my_base_type")
+    close_device(instance)
+    sendmsg_mock.assert_called_once_with("device.close", instance=instance)

--- a/tests/gui/test_serial_device_panel.py
+++ b/tests/gui/test_serial_device_panel.py
@@ -68,5 +68,5 @@ def test_on_device_opened(panel: DevicePanel) -> None:
 def test_on_device_closed(panel: DevicePanel) -> None:
     """Test the _on_device_closed() method."""
     with patch.object(panel, "set_controls_enabled") as enable_mock:
-        panel._on_device_closed()
+        panel._on_device_closed(MagicMock())
         enable_mock.assert_called_once_with(False)

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -67,7 +67,11 @@ def test_open_device(
             # Two separate messages are sent on device open
             sendmsg_mock.assert_has_calls(
                 [
-                    call(f"device.opening.{instance.topic}", params=params),
+                    call(
+                        f"device.opening.{instance.topic}",
+                        instance=instance,
+                        params=params,
+                    ),
                     call(f"device.opened.{instance.topic}"),
                 ]
             )
@@ -114,6 +118,8 @@ def test_try_close_device(
     base_type_info.name = "test"
     device_mock = MagicMock()
     device_mock.name = name
+    instance = DeviceInstanceRef("test", name)
+    device_mock.get_instance_ref.return_value = instance
 
     if not success:
         device_mock.close.side_effect = RuntimeError("Device close failed")
@@ -126,7 +132,7 @@ def test_try_close_device(
     if name:
         topic += f".{name}"
 
-    sendmsg_mock.assert_called_once_with(f"device.closed.{topic}")
+    sendmsg_mock.assert_called_once_with(f"device.closed.{topic}", instance=instance)
 
 
 def test_close_device() -> None:

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -4,6 +4,7 @@ from itertools import product
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
+from frozendict import frozendict
 from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
@@ -49,7 +50,7 @@ def test_open_device(
     module_mock.MyDevice = device_cls_mock
     import_mock.return_value = module_mock
     instance = DeviceInstanceRef("test_type", name)
-    params = {"param1": "value1", "param2": "value2"}
+    params = frozendict(param1="value1", param2="value2")
     devices_dict: dict[DeviceInstanceRef, Device] = {}
 
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
@@ -105,7 +106,9 @@ def test_open_device_replace_existing(
     old_device = MagicMock()
     devices_dict: dict[DeviceInstanceRef, Device] = {instance: old_device}
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
-        _open_device(instance=instance, class_name="some.module.MyDevice", params={})
+        _open_device(
+            instance=instance, class_name="some.module.MyDevice", params=frozendict()
+        )
         logging_mock.warn.assert_called()
         close_mock.assert_called_once_with(old_device)
         assert devices_dict == {instance: new_device}

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -53,9 +53,8 @@ def test_open_device(
     devices_dict: dict[DeviceInstanceRef, Device] = {}
 
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
-        _open_device(
-            instance=instance, class_name="some.module.MyDevice", params=params
-        )
+        class_name = "some.module.MyDevice"
+        _open_device(instance=instance, class_name=class_name, params=params)
         import_mock.assert_called_once_with("some.module")
 
         if name:
@@ -72,6 +71,7 @@ def test_open_device(
                     call(
                         f"device.opening.{instance.topic}",
                         instance=instance,
+                        class_name=class_name,
                         params=params,
                     ),
                     call(f"device.opened.{instance.topic}"),

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -53,7 +53,9 @@ def test_open_device(
     devices_dict: dict[DeviceInstanceRef, Device] = {}
 
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
-        _open_device("some.module.MyDevice", instance, params)
+        _open_device(
+            instance=instance, class_name="some.module.MyDevice", params=params
+        )
         import_mock.assert_called_once_with("some.module")
 
         if name:
@@ -103,7 +105,7 @@ def test_open_device_replace_existing(
     old_device = MagicMock()
     devices_dict: dict[DeviceInstanceRef, Device] = {instance: old_device}
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
-        _open_device("some.module.MyDevice", instance, {})
+        _open_device(instance=instance, class_name="some.module.MyDevice", params={})
         logging_mock.warn.assert_called()
         close_mock.assert_called_once_with(old_device)
         assert devices_dict == {instance: new_device}

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -67,8 +67,8 @@ def test_open_device(
             # Two separate messages are sent on device open
             sendmsg_mock.assert_has_calls(
                 [
-                    call(f"device.{name}.{instance.topic}")
-                    for name in ("opening", "opened")
+                    call(f"device.opening.{instance.topic}", params=params),
+                    call(f"device.opened.{instance.topic}"),
                 ]
             )
 

--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -1,13 +1,13 @@
 """Tests for core serial device code."""
 from unittest.mock import MagicMock, Mock, patch
 
-from finesse.hardware.serial_device import _get_usb_serial_ports, _USBSerialPortInfo
+from finesse.hardware.serial_device import _get_usb_serial_ports, _port_info_to_str
 
 
 @patch("finesse.hardware.serial_device.comports")
 def test_get_usb_serial_ports_cached(comports_mock: Mock) -> None:
     """Check that _get_usb_serial_ports() works when results have been cached."""
-    serial_ports = {_USBSerialPortInfo(1, 2, "SERIAL", 0): "COM1"}
+    serial_ports = {_port_info_to_str(1, 2, "SERIAL", 0): "COM1"}
     with patch("finesse.hardware.serial_device._serial_ports", serial_ports):
         assert _get_usb_serial_ports() == serial_ports
         comports_mock.assert_not_called()
@@ -38,6 +38,6 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
 
     with patch("finesse.hardware.serial_device._serial_ports", None):
         assert _get_usb_serial_ports() == {
-            _USBSerialPortInfo(VID, PID, SERIAL, 0): "COM1",
-            _USBSerialPortInfo(VID, PID, SERIAL, 1): "COM3",
+            _port_info_to_str(VID, PID, SERIAL, 0): "COM1",
+            _port_info_to_str(VID, PID, SERIAL, 1): "COM3",
         }

--- a/tests/test_event_counter.py
+++ b/tests/test_event_counter.py
@@ -25,7 +25,7 @@ def test_init_with_devices(subscribe_mock: MagicMock) -> None:
     counter = EventCounter(MagicMock(), MagicMock(), device_names=("my_device",))
     assert counter._target_count == 1
     subscribe_mock.assert_any_call(counter.increment, "device.opened.my_device")
-    subscribe_mock.assert_any_call(counter.decrement, "device.closed.my_device")
+    subscribe_mock.assert_any_call(counter._on_device_closed, "device.closed.my_device")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_event_counter.py
+++ b/tests/test_event_counter.py
@@ -25,7 +25,7 @@ def test_init_with_devices(subscribe_mock: MagicMock) -> None:
     counter = EventCounter(MagicMock(), MagicMock(), device_names=("my_device",))
     assert counter._target_count == 1
     subscribe_mock.assert_any_call(counter.increment, "device.opened.my_device")
-    subscribe_mock.assert_any_call(counter._on_device_closed, "device.closed.my_device")
+    subscribe_mock.assert_any_call(counter.decrement, "device.closed.my_device")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds support for managing (i.e. opening and closing) collections of devices ("hardware sets") in bulk via the GUI.

The ultimate goal of using hardware sets is:

1. To improve usability, by allowing users to connect to/disconnect from all devices with a single click
2. To allow the user to easily switch between hardware rigs (i.e. FINESSE, UNIRAS, dummy devices and others)
3. To be able to eventually move device configuration options (such as baudrate) into a separate dialog

## Design

The principle difficulty in designing this code is that, while it is easy to send the commands for connecting to and disconnecting from devices in bulk:

1. There is no guarantee that these operations will succeed (e.g. a single device may fail to initialise)
2. Even when all devices have connected successfully, they may later fail unexpectedly (e.g. because a cable comes loose)
3. We also want users to be able to manually manage connections to devices at any point
4. One or more devices may already be connected at the point where we want to connect to the hardware set

This means that the interface needs to update dynamically based on what devices' actual states are (whether they are connected or disconnected, what the device type is and what parameters were used to open it), rather than making assumptions.

This PR adds a combo box for choosing the hardware set to use, as well as "Connect" and "Disconnect all" buttons. Note that these buttons are not opposites: The "Connect" button will connect to devices belonging to the currently selected hardware set and "Disconnect all" will disconnect all devices, regardless of whether or not they belong to the set. If the user attempts to connect to a hardware set and there is already a device with the same base type open (e.g. stepper motor) but it is of the wrong type or has the wrong parameters, then it will be closed before the "right" one is opened. The buttons are only enabled when appropriate.

## Limitations

I have left the `DeviceTypeControl` in the bottom left of the GUI in place for now, although, as mentioned, the longer-term goal is to move this functionality into a separate dialog. It mostly integrates well with the `HardwareSetsControl`: you can open/close devices from either panel and the other will update its state appropriately. Currently, which device is selected for each of the base types in the `DeviceTypeControl` is not changed when the user connects to a hardware set, meaning if the open/close button was disabled beforehand, it will stay disabled, preventing the user from manually disconnecting that single device (though the "Disconnect all" button can still be used). I have left this problem for another day though, as the `DeviceTypeControl` will likely need to be modified when it is moved into the separate dialog anyway.

## Other misc changes

Other small bits of refactoring were needed to support these changes:

- Close device when replacing
- Pass device params in device.opening.* messages
- SerialDevice: Use string cf. dataclass to represent port info
- Add instance argument to various device.* messages
- _open_device: Use more logical order for args
- Also pass class_name with device.opening.* messages

Closes #365. Closes #353.