### PR TITLE
Remove deprecated VS Code settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,8 @@
 {
     "recommendations": [
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.mypy-type-checker",
         "ms-python.python"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,9 @@
 {
-    "python.formatting.provider": "black",
     "[python]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "editor.rulers": [88],
-
-    // Enable relevant linters
-    "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true,
 
     // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
     "python.testing.pytestArgs": ["--no-cov"],


### PR DESCRIPTION
VS Code now pesters me to update these settings every time I open it, so I thought I'd
fix it.

Extensions for the relevant linters have also been added to the recommended extensions.

Closes #384.
