### PR TITLE
Make all imports absolute

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,7 @@ repos:
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013", "MD041", "--"]
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+      - id: absolufy-imports

--- a/finesse/__init__.py
+++ b/finesse/__init__.py
@@ -1,5 +1,5 @@
 """The main module for the FINESSE program."""
-from .config import APP_VERSION
+from finesse.config import APP_VERSION
 
 __version__ = APP_VERSION
 
@@ -11,12 +11,12 @@ def run() -> None:
     from PySide6.QtWidgets import QApplication
 
     # This must be done before our own modules are imported
-    from .logger import initialise_logging
+    from finesse.logger import initialise_logging
 
     initialise_logging()
 
-    from . import hardware  # noqa
-    from .gui.main_window import MainWindow
+    from finesse import hardware  # noqa
+    from finesse.gui.main_window import MainWindow
 
     app = QApplication(sys.argv)
 

--- a/finesse/__main__.py
+++ b/finesse/__main__.py
@@ -1,5 +1,5 @@
 """The main entry point to FINESSE."""
-from . import run
+from finesse import run
 
 if __name__ == "__main__":
     run()

--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -14,9 +14,9 @@ from PySide6.QtWidgets import (
     QSizePolicy,
 )
 
-from ..config import DEFAULT_DATA_FILE_PATH
-from ..settings import settings
-from .path_widget import OpenDirectoryWidget
+from finesse.config import DEFAULT_DATA_FILE_PATH
+from finesse.gui.path_widget import OpenDirectoryWidget
+from finesse.settings import settings
 
 
 def _get_previous_destination_dir() -> Path:

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -3,20 +3,20 @@ from pubsub import pub
 from PySide6.QtGui import QHideEvent, QShowEvent
 from PySide6.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QMainWindow, QWidget
 
-from ..config import (
+from finesse.config import (
     APP_NAME,
     TEMPERATURE_MONITOR_COLD_BB_IDX,
     TEMPERATURE_MONITOR_HOT_BB_IDX,
 )
-from .data_file_view import DataFileControl
-from .device_view import DeviceControl
-from .em27_monitor import EM27Monitor
-from .hardware_set.hardware_sets_view import HardwareSetsControl
-from .measure_script.script_view import ScriptControl
-from .opus_view import OPUSControl
-from .stepper_motor_view import StepperMotorControl
-from .temp_control import DP9800Controls, TC4820Controls, TemperaturePlot
-from .uncaught_exceptions import set_uncaught_exception_handler
+from finesse.gui.data_file_view import DataFileControl
+from finesse.gui.device_view import DeviceControl
+from finesse.gui.em27_monitor import EM27Monitor
+from finesse.gui.hardware_set.hardware_sets_view import HardwareSetsControl
+from finesse.gui.measure_script.script_view import ScriptControl
+from finesse.gui.opus_view import OPUSControl
+from finesse.gui.stepper_motor_view import StepperMotorControl
+from finesse.gui.temp_control import DP9800Controls, TC4820Controls, TemperaturePlot
+from finesse.gui.uncaught_exceptions import set_uncaught_exception_handler
 
 
 class MainWindow(QMainWindow):

--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -15,12 +15,12 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from ...config import DEFAULT_SCRIPT_PATH
-from ..error_message import show_error_message
-from ..path_widget import SaveFileWidget
-from .count_widget import CountWidget
-from .script import Script
-from .sequence_widget import SequenceWidget
+from finesse.config import DEFAULT_SCRIPT_PATH
+from finesse.gui.error_message import show_error_message
+from finesse.gui.measure_script.count_widget import CountWidget
+from finesse.gui.measure_script.script import Script
+from finesse.gui.measure_script.sequence_widget import SequenceWidget
+from finesse.gui.path_widget import SaveFileWidget
 
 
 class ScriptEditDialog(QDialog):

--- a/finesse/gui/measure_script/script_run_dialog.py
+++ b/finesse/gui/measure_script/script_run_dialog.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from .script import Script, ScriptRunner
+from finesse.gui.measure_script.script import Script, ScriptRunner
 
 
 def get_total_steps(script: Script) -> int:

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -5,14 +5,14 @@ from typing import cast
 from pubsub import pub
 from PySide6.QtWidgets import QFileDialog, QGridLayout, QGroupBox, QPushButton
 
-from ...config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
-from ...em27_info import EM27Status
-from ...event_counter import EventCounter
-from ...settings import settings
-from ..path_widget import OpenFileWidget
-from .script import Script, ScriptRunner
-from .script_edit_dialog import ScriptEditDialog
-from .script_run_dialog import ScriptRunDialog
+from finesse.config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
+from finesse.em27_info import EM27Status
+from finesse.event_counter import EventCounter
+from finesse.gui.measure_script.script import Script, ScriptRunner
+from finesse.gui.measure_script.script_edit_dialog import ScriptEditDialog
+from finesse.gui.measure_script.script_run_dialog import ScriptRunDialog
+from finesse.gui.path_widget import OpenFileWidget
+from finesse.settings import settings
 
 
 def _get_previous_script_path() -> Path | None:

--- a/finesse/gui/measure_script/sequence_widget.py
+++ b/finesse/gui/measure_script/sequence_widget.py
@@ -15,10 +15,9 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from finesse.config import ANGLE_PRESETS
+from finesse.gui.measure_script.count_widget import CountWidget
 from finesse.gui.measure_script.script import Measurement
-
-from ...config import ANGLE_PRESETS
-from .count_widget import CountWidget
 
 
 class SequenceWidget(QWidget):

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from ..em27_info import EM27Status
+from finesse.em27_info import EM27Status
 
 
 class OPUSControl(QGroupBox):

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -2,8 +2,8 @@
 from pubsub import pub
 from PySide6.QtWidgets import QButtonGroup, QGridLayout, QPushButton, QSpinBox
 
-from ..config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
-from .device_panel import DevicePanel
+from finesse.config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
+from finesse.gui.device_panel import DevicePanel
 
 
 class StepperMotorControl(DevicePanel):

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -20,9 +20,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from finesse.device_info import DeviceInstanceRef
-
-from ..config import (
+from finesse.config import (
     NUM_TEMPERATURE_MONITOR_CHANNELS,
     TEMPERATURE_CONTROLLER_POLL_INTERVAL,
     TEMPERATURE_CONTROLLER_TOPIC,
@@ -32,8 +30,9 @@ from ..config import (
     TEMPERATURE_MONITOR_TOPIC,
     TEMPERATURE_PLOT_TIME_RANGE,
 )
-from .device_panel import DevicePanel
-from .led_icon import LEDIcon
+from finesse.device_info import DeviceInstanceRef
+from finesse.gui.device_panel import DevicePanel
+from finesse.gui.led_icon import LEDIcon
 
 
 class TemperaturePlot(QGroupBox):

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -5,17 +5,20 @@ from decimal import Decimal
 from pubsub import pub
 
 if "--dummy-em27" in sys.argv:
-    from .plugins.em27.dummy_opus_interface import DummyOPUSInterface as OPUSInterface
+    from finesse.hardware.plugins.em27.dummy_opus_interface import (
+        DummyOPUSInterface as OPUSInterface,
+    )
 else:
-    from .plugins.em27.opus_interface import OPUSInterface  # type: ignore
+    from finesse.hardware.plugins.em27.opus_interface import (  # type: ignore
+        OPUSInterface,
+    )
 
 from datetime import datetime
 
 from finesse.config import NUM_TEMPERATURE_MONITOR_CHANNELS, TEMPERATURE_MONITOR_TOPIC
-
-from . import data_file_writer  # noqa: F401
-from .device import get_device_types
-from .plugins.temperature import get_temperature_monitor_instance
+from finesse.hardware import data_file_writer  # noqa: F401
+from finesse.hardware.device import get_device_types
+from finesse.hardware.plugins.temperature import get_temperature_monitor_instance
 
 _opus: OPUSInterface
 

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -12,10 +12,9 @@ from csvy import Writer
 from pubsub import pub
 
 from finesse import config
-
-from .plugins.stepper_motor import get_stepper_motor_instance
-from .plugins.temperature import get_temperature_controller_instance
-from .pubsub_decorators import pubsub_errors
+from finesse.hardware.plugins.stepper_motor import get_stepper_motor_instance
+from finesse.hardware.plugins.temperature import get_temperature_controller_instance
+from finesse.hardware.pubsub_decorators import pubsub_errors
 
 
 def _on_error_occurred(error: BaseException) -> None:

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -22,8 +22,7 @@ from finesse.device_info import (
     DeviceParameter,
     DeviceTypeInfo,
 )
-
-from .plugins import load_all_plugins
+from finesse.hardware.plugins import load_all_plugins
 
 _base_types: set[type[Device]] = set()
 """Registry of device base types."""

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -7,8 +7,7 @@ from typing import Any, TypeVar, cast
 from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
-
-from .device import Device
+from finesse.hardware.device import Device
 
 _devices: dict[DeviceInstanceRef, Device] = {}
 

--- a/finesse/hardware/plugins/em27/dummy_em27_sensors.py
+++ b/finesse/hardware/plugins/em27/dummy_em27_sensors.py
@@ -2,7 +2,7 @@
 from importlib import resources
 from pathlib import Path
 
-from .em27_sensors import EM27SensorsBase
+from finesse.hardware.plugins.em27.em27_sensors import EM27SensorsBase
 
 
 class DummyEM27Sensors(EM27SensorsBase, description="Dummy EM27 sensors"):

--- a/finesse/hardware/plugins/em27/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/em27/dummy_opus_interface.py
@@ -10,8 +10,7 @@ from statemachine import State, StateMachine
 from statemachine.exceptions import TransitionNotAllowed
 
 from finesse.em27_info import EM27Status
-
-from .opus_interface_base import OPUSInterfaceBase
+from finesse.hardware.plugins.em27.opus_interface_base import OPUSInterfaceBase
 
 
 class OPUSError(Enum):

--- a/finesse/hardware/plugins/em27/opus_interface.py
+++ b/finesse/hardware/plugins/em27/opus_interface.py
@@ -15,8 +15,7 @@ from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequ
 
 from finesse.config import OPUS_IP
 from finesse.em27_info import EM27Status
-
-from .opus_interface_base import OPUSInterfaceBase
+from finesse.hardware.plugins.em27.opus_interface_base import OPUSInterfaceBase
 
 STATUS_FILENAME = "stat.htm"
 COMMAND_FILENAME = "cmd.htm"

--- a/finesse/hardware/plugins/stepper_motor/__init__.py
+++ b/finesse/hardware/plugins/stepper_motor/__init__.py
@@ -1,8 +1,7 @@
 """Code for interfacing with stepper motors."""
 
 from finesse.hardware.manage_devices import get_device_instance
-
-from .stepper_motor_base import StepperMotorBase
+from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 
 
 def get_stepper_motor_instance() -> StepperMotorBase | None:

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -5,8 +5,7 @@ from pubsub import pub
 from PySide6.QtCore import QTimer
 
 from finesse.config import STEPPER_MOTOR_TOPIC
-
-from .stepper_motor_base import StepperMotorBase
+from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 
 
 class DummyStepperMotor(StepperMotorBase, description="Dummy stepper motor"):

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -16,9 +16,8 @@ from PySide6.QtCore import QThread, Signal, Slot
 from serial import Serial, SerialException, SerialTimeoutException
 
 from finesse.config import STEPPER_MOTOR_TOPIC
+from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 from finesse.hardware.serial_device import SerialDevice
-
-from .stepper_motor_base import StepperMotorBase
 
 
 class ST10ControllerError(SerialException):

--- a/finesse/hardware/plugins/temperature/__init__.py
+++ b/finesse/hardware/plugins/temperature/__init__.py
@@ -1,8 +1,11 @@
 """This module contains interfaces for temperature-related hardware."""
 from finesse.hardware.manage_devices import get_device_instance
-
-from .temperature_controller_base import TemperatureControllerBase
-from .temperature_monitor_base import TemperatureMonitorBase
+from finesse.hardware.plugins.temperature.temperature_controller_base import (
+    TemperatureControllerBase,
+)
+from finesse.hardware.plugins.temperature.temperature_monitor_base import (
+    TemperatureMonitorBase,
+)
 
 
 def get_temperature_controller_instance(name: str) -> TemperatureControllerBase | None:

--- a/finesse/hardware/plugins/temperature/dp9800.py
+++ b/finesse/hardware/plugins/temperature/dp9800.py
@@ -4,9 +4,10 @@ from typing import Any
 
 from serial import SerialException
 
+from finesse.hardware.plugins.temperature.temperature_monitor_base import (
+    TemperatureMonitorBase,
+)
 from finesse.hardware.serial_device import SerialDevice
-
-from .temperature_monitor_base import TemperatureMonitorBase
 
 
 def check_data(data: bytes) -> None:

--- a/finesse/hardware/plugins/temperature/dummy_temperature_controller.py
+++ b/finesse/hardware/plugins/temperature/dummy_temperature_controller.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from decimal import Decimal
 
 from finesse.hardware.noise_producer import NoiseParameters, NoiseProducer
-
-from .temperature_controller_base import TemperatureControllerBase
+from finesse.hardware.plugins.temperature.temperature_controller_base import (
+    TemperatureControllerBase,
+)
 
 
 class DummyTemperatureController(

--- a/finesse/hardware/plugins/temperature/dummy_temperature_monitor.py
+++ b/finesse/hardware/plugins/temperature/dummy_temperature_monitor.py
@@ -4,8 +4,9 @@ from decimal import Decimal
 
 from finesse.config import NUM_TEMPERATURE_MONITOR_CHANNELS
 from finesse.hardware.noise_producer import NoiseParameters, NoiseProducer
-
-from .temperature_monitor_base import TemperatureMonitorBase
+from finesse.hardware.plugins.temperature.temperature_monitor_base import (
+    TemperatureMonitorBase,
+)
 
 _BASE_TEMPS = (19, 17, 26, 22, 24, 68, 69, 24)
 """The mean temperatures for each of the channels."""

--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -11,9 +11,10 @@ from finesse.config import (
     SENECA_MIN_MILLIVOLT,
     SENECA_MIN_TEMP,
 )
+from finesse.hardware.plugins.temperature.temperature_monitor_base import (
+    TemperatureMonitorBase,
+)
 from finesse.hardware.serial_device import SerialDevice
-
-from .temperature_monitor_base import TemperatureMonitorBase
 
 
 class SenecaK107Error(Exception):

--- a/finesse/hardware/plugins/temperature/tc4820.py
+++ b/finesse/hardware/plugins/temperature/tc4820.py
@@ -18,9 +18,10 @@ from typing import Any
 
 from serial import SerialException
 
+from finesse.hardware.plugins.temperature.temperature_controller_base import (
+    TemperatureControllerBase,
+)
 from finesse.hardware.serial_device import SerialDevice
-
-from .temperature_controller_base import TemperatureControllerBase
 
 MAX_POWER = 511
 

--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -8,8 +8,7 @@ from serial.tools.list_ports import comports
 
 from finesse.config import BAUDRATES
 from finesse.device_info import DeviceParameter
-
-from .device import AbstractDevice
+from finesse.hardware.device import AbstractDevice
 
 _serial_ports: dict[str, str] | None = None
 

--- a/finesse/logger.py
+++ b/finesse/logger.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from platformdirs import user_log_path
 
-from . import config
+from finesse import config
 
 
 def initialise_logging() -> None:

--- a/finesse/settings.py
+++ b/finesse/settings.py
@@ -1,7 +1,7 @@
 """A module with a single settings object for the program settings."""
 from PySide6.QtCore import QSettings
 
-from .config import APP_AUTHOR, APP_NAME
+from finesse.config import APP_AUTHOR, APP_NAME
 
 settings = QSettings(APP_AUTHOR, APP_NAME)
 """Contains the program settings for FINESSE."""


### PR DESCRIPTION
Convert all imports to be absolute. Closes #378.

I used this tool to do this: https://github.com/MarcoGorelli/absolufy-imports

It is also available as a pre-commit hook, so I've added it. The project is unfortunately archived but it still seems to work. We can drop the hook if it presents problems at some stage.