### PR TITLE
Added help button which opens new window showing html docs

### DIFF
--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -59,4 +59,4 @@ class DocsViewer(QAction):
 
     def _open_homepage(self):
         """Go to documentation home page."""
-        self.browser.load(QUrl(self.docs_home).as_uri())
+        self.browser.load(QUrl(f"file://{self.docs_home}"))

--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -2,6 +2,7 @@
 from importlib import resources
 from pathlib import Path
 
+from PySide6.QtCore import QObject
 from PySide6.QtGui import QAction
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QMainWindow, QToolBar, QVBoxLayout, QWidget
@@ -10,7 +11,7 @@ from PySide6.QtWidgets import QMainWindow, QToolBar, QVBoxLayout, QWidget
 class DocsViewer(QAction):
     """A window for viewing documentation."""
 
-    def __init__(self, parent) -> None:
+    def __init__(self, parent: QObject) -> None:
         """Create a menu item for opening documentation in a new window.
 
         Args:

--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -1,0 +1,62 @@
+"""Code for FINESSE's documentation viewer window."""
+from importlib import resources
+from pathlib import Path
+
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QAction
+from PySide6.QtWebEngineWidgets import QWebEngineView
+from PySide6.QtWidgets import QMainWindow, QToolBar, QVBoxLayout, QWidget
+
+
+class DocsViewer(QAction):
+    """A window for viewing documentation."""
+
+    def __init__(self, parent) -> None:
+        """Create a push button for opening documentation in a new window."""
+        super().__init__("Help", parent)
+        self.triggered.connect(self.show_docs)
+
+    def show_docs(self) -> None:
+        """Create the documentation in a new window."""
+        self.docs_window = self.create_docs_window()
+        self.docs_window.show()
+
+    def create_docs_window(self) -> QMainWindow:
+        """Create a new window displaying the documentation.
+
+        Returns:
+            A main window showing the html documentation.
+        """
+        docs_window = QMainWindow()
+        docs_window.setWindowTitle("FINESSE User Guide")
+
+        toolbar = QToolBar()
+        toolbar.setMovable(False)
+        home_btn = toolbar.addAction("Home")
+        back_btn = toolbar.addAction("Back")
+        forward_btn = toolbar.addAction("Forward")
+        docs_window.addToolBar(toolbar)
+
+        docs_path = resources.files("docs")
+        self.docs_home = Path(str(docs_path.joinpath("user_guide.html")))
+        if not self.docs_home.exists():
+            raise FileNotFoundError("User guide not found.")
+        self.browser = QWebEngineView()
+        self._open_homepage()
+        home_btn.triggered.connect(self._open_homepage)
+        back_btn.triggered.connect(self.browser.back)
+        forward_btn.triggered.connect(self.browser.forward)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.browser)
+
+        central = QWidget()
+        central.setLayout(layout)
+
+        docs_window.setCentralWidget(central)
+
+        return docs_window
+
+    def _open_homepage(self):
+        """Go to documentation home page."""
+        self.browser.load(QUrl(self.docs_home).as_uri())

--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -59,4 +59,4 @@ class DocsViewer(QAction):
 
     def _open_homepage(self):
         """Go to documentation home page."""
-        self.browser.load(QUrl(f"file://{self.docs_home}"))
+        self.browser.load(self.docs_home.as_uri())

--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -2,7 +2,6 @@
 from importlib import resources
 from pathlib import Path
 
-from PySide6.QtCore import QUrl
 from PySide6.QtGui import QAction
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import QMainWindow, QToolBar, QVBoxLayout, QWidget
@@ -12,8 +11,12 @@ class DocsViewer(QAction):
     """A window for viewing documentation."""
 
     def __init__(self, parent) -> None:
-        """Create a push button for opening documentation in a new window."""
-        super().__init__("Help", parent)
+        """Create a menu item for opening documentation in a new window.
+
+        Args:
+            parent: the menu on which to place the menu item
+        """
+        super().__init__("Open user manual", parent)
         self.triggered.connect(self.show_docs)
 
     def show_docs(self) -> None:
@@ -28,7 +31,7 @@ class DocsViewer(QAction):
             A main window showing the html documentation.
         """
         docs_window = QMainWindow()
-        docs_window.setWindowTitle("FINESSE User Guide")
+        docs_window.setWindowTitle("FINESSE User Manual")
 
         toolbar = QToolBar()
         toolbar.setMovable(False)
@@ -57,6 +60,6 @@ class DocsViewer(QAction):
 
         return docs_window
 
-    def _open_homepage(self):
+    def _open_homepage(self) -> None:
         """Go to documentation home page."""
         self.browser.load(self.docs_home.as_uri())

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -16,7 +16,6 @@ from finesse.config import (
     TEMPERATURE_MONITOR_COLD_BB_IDX,
     TEMPERATURE_MONITOR_HOT_BB_IDX,
 )
-
 from finesse.gui.data_file_view import DataFileControl
 from finesse.gui.device_view import DeviceControl
 from finesse.gui.docs_view import DocsViewer

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QMainWindow,
-    QToolBar,
+    QMenu,
     QWidget,
 )
 
@@ -39,10 +39,9 @@ class MainWindow(QMainWindow):
         set_uncaught_exception_handler(self)
 
         docs_viewer = DocsViewer(self)
-        toolbar = QToolBar()
-        toolbar.setMovable(False)
-        toolbar.addAction(docs_viewer)
-        self.addToolBar(toolbar)
+        helpmenu = QMenu("Help", self)
+        helpmenu.addAction(docs_viewer)
+        self.menuBar().addMenu(helpmenu)
 
         layout_left = QGridLayout()
 

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -1,15 +1,25 @@
 """Code for FINESSE's main GUI window."""
+
 from pubsub import pub
 from PySide6.QtGui import QHideEvent, QShowEvent
-from PySide6.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QMainWindow, QWidget
+from PySide6.QtWidgets import (
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QMainWindow,
+    QToolBar,
+    QWidget,
+)
 
 from finesse.config import (
     APP_NAME,
     TEMPERATURE_MONITOR_COLD_BB_IDX,
     TEMPERATURE_MONITOR_HOT_BB_IDX,
 )
+
 from finesse.gui.data_file_view import DataFileControl
 from finesse.gui.device_view import DeviceControl
+from finesse.gui.docs_view import DocsViewer
 from finesse.gui.em27_monitor import EM27Monitor
 from finesse.gui.hardware_set.hardware_sets_view import HardwareSetsControl
 from finesse.gui.measure_script.script_view import ScriptControl
@@ -28,6 +38,12 @@ class MainWindow(QMainWindow):
         self.setWindowTitle(APP_NAME)
 
         set_uncaught_exception_handler(self)
+
+        docs_viewer = DocsViewer(self)
+        toolbar = QToolBar()
+        toolbar.setMovable(False)
+        toolbar.addAction(docs_viewer)
+        self.addToolBar(toolbar)
 
         layout_left = QGridLayout()
 


### PR DESCRIPTION
This PR adds a mechanism for showing the user guide inside the program.

A toolbar is added to the top of the main window, containing one item - a "Help" button. Clicking it raises a new window showing the contents of `docs/user_guide.html`.
This window also contains a toolbar with a "Home" button, which takes the user to the user guide home page (currently the only page), and "Back" and "Forward" buttons for traversing browsing history.

Closes #348
