### PR TITLE
TemperatureSequence alias for temperature monitors

### DIFF
--- a/finesse/hardware/plugins/temperature/dp9800.py
+++ b/finesse/hardware/plugins/temperature/dp9800.py
@@ -6,7 +6,7 @@ from serial import SerialException
 
 from finesse.hardware.serial_device import SerialDevice
 
-from .temperature_monitor_base import TemperatureMonitorBase
+from .temperature_monitor_base import TemperatureMonitorBase, TemperatureSequence
 
 
 def check_data(data: bytes) -> None:
@@ -193,7 +193,7 @@ class DP9800(
         except Exception as e:
             raise DP9800Error(e)
 
-    def get_temperatures(self) -> list[Decimal]:
+    def get_temperatures(self) -> TemperatureSequence:
         """Get the current temperatures."""
         self.request_read()
         data = self.read_temperature_data()

--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -13,7 +13,7 @@ from finesse.config import (
 )
 from finesse.hardware.serial_device import SerialDevice
 
-from .temperature_monitor_base import TemperatureMonitorBase
+from .temperature_monitor_base import TemperatureMonitorBase, TemperatureSequence
 
 
 class SenecaK107Error(Exception):
@@ -123,7 +123,7 @@ class SenecaK107(
         ints = numpy.frombuffer(data, dt, 8, 3)
 
         vals = self.calc_temp(ints)
-        return [Decimal(val) for val in vals]
+        return vals
 
     def calc_temp(self, vals: numpy.ndarray) -> numpy.ndarray:
         """Convert data read from the SenecaK107 device into temperatures.
@@ -144,7 +144,7 @@ class SenecaK107(
         vals += self.MIN_TEMP
         return vals
 
-    def get_temperatures(self) -> list[Decimal]:
+    def get_temperatures(self) -> TemperatureSequence:
         """Get the current temperatures."""
         self.request_read()
         data = self.read()

--- a/finesse/hardware/plugins/temperature/temperature_monitor_base.py
+++ b/finesse/hardware/plugins/temperature/temperature_monitor_base.py
@@ -2,8 +2,12 @@
 from abc import abstractmethod
 from decimal import Decimal
 
+import numpy
+
 from finesse.config import TEMPERATURE_MONITOR_TOPIC
 from finesse.hardware.device import Device
+
+TemperatureSequence = list[Decimal | numpy.float64]
 
 
 class TemperatureMonitorBase(
@@ -15,5 +19,5 @@ class TemperatureMonitorBase(
     """The base class for temperature monitor devices or mock devices."""
 
     @abstractmethod
-    def get_temperatures(self) -> list[Decimal]:
+    def get_temperatures(self) -> TemperatureSequence:
         """Get the current temperatures."""


### PR DESCRIPTION
Added a typing alias called `TemperatureSequence` that is the type `list[Decimal | numpy.float64]`. This is now the return type for the `get_temperatures()` function in `temperature_monitor_base.py`, `senecak107.py` and `dp9800.py`.

Closes #401 