### PR TITLE
Use shortened module name for device classes

### DIFF
--- a/finesse/gui/hardware_set/finesse_dp9800.yaml
+++ b/finesse/gui/hardware_set/finesse_dp9800.yaml
@@ -1,24 +1,24 @@
 name: FINESSE (with DP9800)
 devices:
   stepper_motor:
-    class_name: finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller
+    class_name: stepper_motor.st10_controller.ST10Controller
     params:
       port: "0403:6011 FT1NMSVR (4)"
       baudrate: 9600
   temperature_controller.hot_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (3)"
       baudrate: 115200
   temperature_monitor:
-    class_name: finesse.hardware.plugins.temperature.dp9800.DP9800
+    class_name: temperature.dp9800.DP9800
     params:
       port: "0403:6001"
       baudrate: 38400
   em27_sensors:
-    class_name: finesse.hardware.plugins.em27.em27_sensors.EM27Sensors
+    class_name: em27.em27_sensors.EM27Sensors

--- a/finesse/gui/hardware_set/finesse_dummy.yaml
+++ b/finesse/gui/hardware_set/finesse_dummy.yaml
@@ -1,12 +1,12 @@
 name: "FINESSE (dummy devices)"
 devices:
   stepper_motor:
-    class_name: finesse.hardware.plugins.stepper_motor.dummy.DummyStepperMotor
+    class_name: stepper_motor.dummy.DummyStepperMotor
   temperature_controller.hot_bb:
-    class_name: finesse.hardware.plugins.temperature.dummy_temperature_controller.DummyTemperatureController
+    class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_controller.cold_bb:
-    class_name: finesse.hardware.plugins.temperature.dummy_temperature_controller.DummyTemperatureController
+    class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_monitor:
-    class_name: finesse.hardware.plugins.temperature.dummy_temperature_monitor.DummyTemperatureMonitor
+    class_name: temperature.dummy_temperature_monitor.DummyTemperatureMonitor
   em27_sensors:
-    class_name: finesse.hardware.plugins.em27.dummy_em27_sensors.DummyEM27Sensors
+    class_name: em27.dummy_em27_sensors.DummyEM27Sensors

--- a/finesse/gui/hardware_set/finesse_seneca.yaml
+++ b/finesse/gui/hardware_set/finesse_seneca.yaml
@@ -1,24 +1,24 @@
 name: FINESSE (with Seneca K107)
 devices:
   stepper_motor:
-    class_name: finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller
+    class_name: stepper_motor.st10_controller.ST10Controller
     params:
       port: "0403:6011 FT1NMSVR (4)"
       baudrate: 9600
   temperature_controller.hot_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (3)"
       baudrate: 115200
   temperature_monitor:
-    class_name: finesse.hardware.plugins.temperature.senecak107.SenecaK107
+    class_name: temperature.senecak107.SenecaK107
     params:
       port: "0403:6001 AB0LMVI5"
       baudrate: 57600
   em27_sensors:
-    class_name: finesse.hardware.plugins.em27.em27_sensors.EM27Sensors
+    class_name: em27.em27_sensors.EM27Sensors

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -22,6 +22,7 @@ from finesse.device_info import (
     DeviceParameter,
     DeviceTypeInfo,
 )
+from finesse.hardware.plugins import __name__ as _plugins_name
 from finesse.hardware.plugins import load_all_plugins
 
 _base_types: set[type[Device]] = set()
@@ -98,8 +99,13 @@ class AbstractDevice(ABC):
     @classmethod
     def get_device_type_info(cls) -> DeviceTypeInfo:
         """Get information about this device type."""
+        class_name_full = f"{cls.__module__}.{cls.__name__}"
+        class_name = class_name_full.removeprefix(f"{_plugins_name}.")
+        if len(class_name) == len(class_name_full):
+            raise RuntimeError(f"Plugins must be in {_plugins_name}")
+
         return DeviceTypeInfo(
-            f"{cls.__module__}.{cls.__name__}",
+            class_name,
             cls._device_description,
             cls.get_device_parameters(),
         )

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -8,6 +8,7 @@ from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
 from finesse.hardware.device import Device, get_device_types
+from finesse.hardware.plugins import __name__ as _plugins_name
 
 _devices: dict[DeviceInstanceRef, Device] = {}
 
@@ -37,7 +38,7 @@ def _open_device(
         class_name: The name of the device type's class
         params: Device parameters
     """
-    module, _, class_name_part = class_name.rpartition(".")
+    module, _, class_name_part = f"{_plugins_name}.{class_name}".rpartition(".")
 
     # Assume this is safe because the class and module will not be provided directly by
     # the user

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -105,9 +105,10 @@ def test_abstract_device_get_device_type_info() -> None:
     param = DeviceParameter("param1", ["a", "b"])
     MyDevice.add_device_parameters(param)
 
-    assert MyDevice.get_device_type_info() == DeviceTypeInfo(
-        f"{MyDevice.__module__}.MyDevice", "DESCRIPTION", [param]
-    )
+    with patch("finesse.hardware.device._plugins_name", MyDevice.__module__):
+        assert MyDevice.get_device_type_info() == DeviceTypeInfo(
+            "MyDevice", "DESCRIPTION", [param]
+        )
 
 
 def _wrapped_func_error_test(device: Device, wrapper: Callable, *args) -> None:

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -16,6 +16,7 @@ from finesse.hardware.manage_devices import (
     _open_device,
     _try_close_device,
 )
+from finesse.hardware.plugins import __name__ as _plugins_name
 
 
 def test_subscriptions():
@@ -56,7 +57,7 @@ def test_open_device(
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
         class_name = "some.module.MyDevice"
         _open_device(instance=instance, class_name=class_name, params=params)
-        import_mock.assert_called_once_with("some.module")
+        import_mock.assert_called_once_with(f"{_plugins_name}.some.module")
 
         if name:
             device_cls_mock.assert_called_once_with(**params, name=name)


### PR DESCRIPTION
This makes config files less verbose and means if/when we change the name of the main package, things won't break.

Closes #403.