### PR TITLE
Add support for typed device parameters

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -33,7 +33,10 @@ DEFAULT_SCRIPT_PATH = Path.home()
 DEFAULT_DATA_FILE_PATH = Path.home()
 """The default path to save data files."""
 
-EM27_URL = "http://10.10.0.1/diag_autom.htm"
+EM27_HOST = "10.10.0.1"
+"""The IP address or hostname of the EM27 device."""
+
+EM27_SENSORS_URL = "http://{host}/diag_autom.htm"
 """The URL of the EM27 monitoring web server."""
 
 EM27_SENSORS_POLL_INTERVAL = 60.0

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -1,8 +1,8 @@
 """Provides common dataclasses about devices for using in backend and frontend."""
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -10,10 +10,7 @@ from typing import Any
 class DeviceParameter:
     """A parameter that a device needs (e.g. baudrate)."""
 
-    name: str
-    """Name for the parameter."""
-
-    possible_values: Sequence[Any]
+    possible_values: Sequence
     """Possible values the parameter can take."""
 
     default_value: Any = None
@@ -40,7 +37,7 @@ class DeviceTypeInfo:
     """The name of the device's class including the module name."""
     description: str
     """A human-readable name for the device."""
-    parameters: Sequence[DeviceParameter]
+    parameters: Mapping[str, DeviceParameter] = field(default_factory=dict)
     """The device parameters."""
 
 

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 
-@dataclass(frozen=True)
+@dataclass
 class DeviceParameter:
     """A parameter that a device needs (e.g. baudrate)."""
 
@@ -36,7 +36,7 @@ class DeviceParameter:
             raise RuntimeError("Default value doesn't match type of possible values")
 
 
-@dataclass(frozen=True)
+@dataclass
 class DeviceTypeInfo:
     """Description of a device."""
 

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -10,9 +10,10 @@ from typing import Any
 class DeviceParameter:
     """A parameter that a device needs (e.g. baudrate)."""
 
+    description: str
+    """A human-readable description of the parameter."""
     possible_values: Sequence
     """Possible values the parameter can take."""
-
     default_value: Any = None
     """The default value for this parameter.
 

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 
 @dataclass(frozen=True)
@@ -12,8 +12,11 @@ class DeviceParameter:
 
     description: str
     """A human-readable description of the parameter."""
-    possible_values: Sequence
-    """Possible values the parameter can take."""
+    possible_values: Sequence | type
+    """Possible values the parameter can take.
+
+    This can either be a Sequence of possible values or a type (e.g. str or float).
+    """
     default_value: Any = None
     """The default value for this parameter.
 
@@ -21,13 +24,16 @@ class DeviceParameter:
 
     def __post_init__(self) -> None:
         """Check that default value is valid."""
-        if (
-            self.default_value is not None
-            and self.default_value not in self.possible_values
-        ):
-            raise RuntimeError(
-                f"Default value of {self.default_value} not in possible values"
-            )
+        if self.default_value is None:
+            return
+
+        if isinstance(self.possible_values, Sequence):
+            if self.default_value not in self.possible_values:
+                raise RuntimeError(
+                    f"Default value of {self.default_value} not in possible values"
+                )
+        elif not isinstance(self.default_value, cast(type, self.possible_values)):
+            raise RuntimeError("Default value doesn't match type of possible values")
 
 
 @dataclass(frozen=True)

--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -44,6 +44,11 @@ class DeviceParametersWidget(QWidget):
         # Make a combo box for each parameter
         self._combos: dict[str, QComboBox] = {}
         for name, param in device_type.parameters.items():
+            # The frontend currently can't deal with "typed" parameters, so ignore these
+            # for now
+            if not isinstance(param.possible_values, Sequence):
+                continue
+
             combo = QComboBox()
             combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
             combo.setToolTip(param.description)

--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -46,6 +46,7 @@ class DeviceParametersWidget(QWidget):
         for name, param in device_type.parameters.items():
             combo = QComboBox()
             combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+            combo.setToolTip(param.description)
 
             # Keep the "real" value along with its string representation, so that we can
             # pass it back to the backend on device open

--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -43,7 +43,7 @@ class DeviceParametersWidget(QWidget):
 
         # Make a combo box for each parameter
         self._combos: dict[str, QComboBox] = {}
-        for param in device_type.parameters:
+        for name, param in device_type.parameters.items():
             combo = QComboBox()
             combo.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
@@ -56,7 +56,7 @@ class DeviceParametersWidget(QWidget):
                 combo.setCurrentIndex(param.possible_values.index(param.default_value))
 
             layout.addWidget(combo)
-            self._combos[param.name] = combo
+            self._combos[name] = combo
 
         # If there are saved parameter values, load them now
         self.load_saved_parameter_values()
@@ -175,7 +175,7 @@ class DeviceTypeControl(QGroupBox):
         The "open" button should be disabled if there are no possible values for any
         of the params.
         """
-        all_params = self.current_device_type_widget.device_type.parameters
+        all_params = self.current_device_type_widget.device_type.parameters.values()
         self._open_close_btn.setEnabled(all(p.possible_values for p in all_params))
 
     def _on_device_selected(self) -> None:

--- a/finesse/gui/hardware_set/finesse_dp9800.yaml
+++ b/finesse/gui/hardware_set/finesse_dp9800.yaml
@@ -1,24 +1,24 @@
 name: FINESSE (with DP9800)
 devices:
   stepper_motor:
-    class_name: finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller
+    class_name: stepper_motor.st10_controller.ST10Controller
     params:
       port: "0403:6011 FT1NMSVR (4)"
       baudrate: 9600
   temperature_controller.hot_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (3)"
       baudrate: 115200
   temperature_monitor:
-    class_name: finesse.hardware.plugins.temperature.dp9800.DP9800
+    class_name: temperature.dp9800.DP9800
     params:
       port: "0403:6001"
       baudrate: 38400
   em27_sensors:
-    class_name: finesse.hardware.plugins.em27.em27_sensors.EM27Sensors
+    class_name: em27.em27_sensors.EM27Sensors

--- a/finesse/gui/hardware_set/finesse_dummy.yaml
+++ b/finesse/gui/hardware_set/finesse_dummy.yaml
@@ -1,12 +1,12 @@
 name: "FINESSE (dummy devices)"
 devices:
   stepper_motor:
-    class_name: finesse.hardware.plugins.stepper_motor.dummy.DummyStepperMotor
+    class_name: stepper_motor.dummy.DummyStepperMotor
   temperature_controller.hot_bb:
-    class_name: finesse.hardware.plugins.temperature.dummy_temperature_controller.DummyTemperatureController
+    class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_controller.cold_bb:
-    class_name: finesse.hardware.plugins.temperature.dummy_temperature_controller.DummyTemperatureController
+    class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_monitor:
-    class_name: finesse.hardware.plugins.temperature.dummy_temperature_monitor.DummyTemperatureMonitor
+    class_name: temperature.dummy_temperature_monitor.DummyTemperatureMonitor
   em27_sensors:
-    class_name: finesse.hardware.plugins.em27.dummy_em27_sensors.DummyEM27Sensors
+    class_name: em27.dummy_em27_sensors.DummyEM27Sensors

--- a/finesse/gui/hardware_set/finesse_seneca.yaml
+++ b/finesse/gui/hardware_set/finesse_seneca.yaml
@@ -1,24 +1,24 @@
 name: FINESSE (with Seneca K107)
 devices:
   stepper_motor:
-    class_name: finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller
+    class_name: stepper_motor.st10_controller.ST10Controller
     params:
       port: "0403:6011 FT1NMSVR (4)"
       baudrate: 9600
   temperature_controller.hot_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
-    class_name: finesse.hardware.plugins.temperature.tc4820.TC4820
+    class_name: temperature.tc4820.TC4820
     params:
       port: "0403:6011 FT1NMSVR (3)"
       baudrate: 115200
   temperature_monitor:
-    class_name: finesse.hardware.plugins.temperature.senecak107.SenecaK107
+    class_name: temperature.senecak107.SenecaK107
     params:
       port: "0403:6001 AB0LMVI5"
       baudrate: 57600
   em27_sensors:
-    class_name: finesse.hardware.plugins.em27.em27_sensors.EM27Sensors
+    class_name: em27.em27_sensors.EM27Sensors

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -68,7 +68,7 @@ class AbstractDevice(ABC):
     """Information about the device's base type."""
     _device_description: str
     """A human-readable name."""
-    _device_parameters: list[DeviceParameter] | None = None
+    _device_parameters: dict[str, DeviceParameter] = {}
     """Possible parameters that this device type accepts.
 
     The key represents the parameter name and the value is a list of possible values.
@@ -79,17 +79,14 @@ class AbstractDevice(ABC):
         """Close the connection to the device."""
 
     @classmethod
-    def add_device_parameters(cls, *parameters: DeviceParameter) -> None:
+    def add_device_parameters(cls, **parameters: DeviceParameter) -> None:
         """Add extra parameters for this device class."""
-        if cls._device_parameters is None:
-            cls._device_parameters = []
-
-        cls._device_parameters.extend(parameters)
+        cls._device_parameters = cls._device_parameters | parameters
 
     @classmethod
-    def get_device_parameters(cls) -> list[DeviceParameter]:
+    def get_device_parameters(cls) -> dict[str, DeviceParameter]:
         """Get the parameters for this device class."""
-        return cls._device_parameters or []
+        return cls._device_parameters
 
     @classmethod
     def get_device_base_type_info(cls) -> DeviceBaseTypeInfo:

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -22,6 +22,7 @@ from finesse.device_info import (
     DeviceParameter,
     DeviceTypeInfo,
 )
+from finesse.hardware.plugins import __name__ as _plugins_name
 from finesse.hardware.plugins import load_all_plugins
 
 _base_types: set[type[Device]] = set()
@@ -98,8 +99,13 @@ class AbstractDevice(ABC):
     @classmethod
     def get_device_type_info(cls) -> DeviceTypeInfo:
         """Get information about this device type."""
+        class_name_full = f"{cls.__module__}.{cls.__name__}"
+        class_name = class_name_full.removeprefix(f"{_plugins_name}.")
+        if len(class_name) == len(class_name_full):
+            raise RuntimeError(f"Plugins must be in {_plugins_name}")
+
         return DeviceTypeInfo(
-            f"{cls.__module__}.{cls.__name__}",
+            class_name,
             cls._device_description,
             cls.get_device_parameters(),
         )

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import logging
 import traceback
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
-from typing import Any
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from inspect import signature
+from typing import Any, get_type_hints
 
 from decorator import decorate
 from pubsub import pub
@@ -73,6 +75,62 @@ class AbstractDevice(ABC):
 
     The key represents the parameter name and the value is a list of possible values.
     """
+
+    def __init_subclass__(
+        cls, parameters: Mapping[str, str | tuple[str, Sequence]] = {}
+    ) -> None:
+        """Initialise a device class.
+
+        Args:
+            parameters: Extra device parameters that this class requires
+        """
+        super().__init_subclass__()
+
+        # Every time we create a new class, create a new _device_parameters attribute,
+        # so that _add_parameters() and _update_parameter_defaults() don't clobber
+        # values for the parent class.
+        cls._device_parameters = deepcopy(cls._device_parameters)
+
+        cls._add_parameters(parameters)
+        cls._update_parameter_defaults()
+
+    @classmethod
+    def _add_parameters(
+        cls,
+        parameters: Mapping[str, str | tuple[str, Sequence]],
+    ) -> None:
+        """Store extra device parameters in a class attribute."""
+        arg_types = get_type_hints(cls.__init__)
+        for name, value in parameters.items():
+            if isinstance(value, str):
+                # Only a description provided
+                try:
+                    arg_type = arg_types[name]
+                except KeyError:
+                    raise ValueError(
+                        f"The argument {name} was not found in "
+                        f"{cls.__name__}'s constructor (or no type annotation given)."
+                    )
+
+                cls._device_parameters[name] = DeviceParameter(value, arg_type)
+            elif isinstance(value, tuple):
+                # A description and possible values provided
+                cls._device_parameters[name] = DeviceParameter(value[0], value[1])
+            else:
+                # Bad type
+                raise TypeError("Invalid parameters argument")
+
+    @classmethod
+    def _update_parameter_defaults(cls) -> None:
+        """Add default values to device parameters from this class's constructor."""
+        ctor_params = signature(cls).parameters
+        for name, param in ctor_params.items():
+            if name not in cls._device_parameters:
+                continue
+
+            default_value = param.default
+            if default_value != param.empty:
+                cls._device_parameters[name].default_value = default_value
 
     @abstractmethod
     def close(self) -> None:

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -137,11 +137,6 @@ class AbstractDevice(ABC):
         """Close the connection to the device."""
 
     @classmethod
-    def add_device_parameters(cls, **parameters: DeviceParameter) -> None:
-        """Add extra parameters for this device class."""
-        cls._device_parameters = cls._device_parameters | parameters
-
-    @classmethod
     def get_device_parameters(cls) -> dict[str, DeviceParameter]:
         """Get the parameters for this device class."""
         return cls._device_parameters

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -8,6 +8,7 @@ from pubsub import pub
 
 from finesse.device_info import DeviceInstanceRef
 from finesse.hardware.device import Device, get_device_types
+from finesse.hardware.plugins import __name__ as _plugins_name
 
 _devices: dict[DeviceInstanceRef, Device] = {}
 
@@ -37,7 +38,7 @@ def _open_device(
         class_name: The name of the device type's class
         params: Device parameters
     """
-    module, _, class_name_part = class_name.rpartition(".")
+    module, _, class_name_part = f"{_plugins_name}.{class_name}".rpartition(".")
 
     # Assume this is safe because the class and module will not be provided directly by
     # the user

--- a/finesse/hardware/plugins/em27/em27_sensors.py
+++ b/finesse/hardware/plugins/em27/em27_sensors.py
@@ -102,7 +102,14 @@ class EM27SensorsBase(
         )
 
 
-class EM27Sensors(EM27SensorsBase, description="EM27 sensors"):
+class EM27Sensors(
+    EM27SensorsBase,
+    description="EM27 sensors",
+    parameters={
+        "host": "The IP address or hostname of the EM27 device",
+        "poll_interval": "How often to poll the device in seconds",
+    },
+):
     """An interface for EM27 sensors on the real device."""
 
     def __init__(

--- a/finesse/hardware/plugins/em27/em27_sensors.py
+++ b/finesse/hardware/plugins/em27/em27_sensors.py
@@ -7,7 +7,12 @@ from decimal import Decimal
 from PySide6.QtCore import QTimer, Slot
 from PySide6.QtNetwork import QNetworkReply
 
-from finesse.config import EM27_SENSORS_POLL_INTERVAL, EM27_SENSORS_TOPIC, EM27_URL
+from finesse.config import (
+    EM27_HOST,
+    EM27_SENSORS_POLL_INTERVAL,
+    EM27_SENSORS_TOPIC,
+    EM27_SENSORS_URL,
+)
 from finesse.em27_info import EM27Property
 from finesse.hardware.device import Device
 from finesse.hardware.http_requester import HTTPRequester
@@ -71,7 +76,7 @@ class EM27SensorsBase(
 ):
     """An interface for monitoring EM27 properties."""
 
-    def __init__(self, url: str = EM27_URL) -> None:
+    def __init__(self, url: str) -> None:
         """Create a new EM27 property monitor.
 
         Args:
@@ -100,13 +105,16 @@ class EM27SensorsBase(
 class EM27Sensors(EM27SensorsBase, description="EM27 sensors"):
     """An interface for EM27 sensors on the real device."""
 
-    def __init__(self, poll_interval: float = EM27_SENSORS_POLL_INTERVAL) -> None:
+    def __init__(
+        self, host: str = EM27_HOST, poll_interval: float = EM27_SENSORS_POLL_INTERVAL
+    ) -> None:
         """Create a new EM27Sensors.
 
         Args:
+            host: The IP address or hostname of the EM27 device
             poll_interval: How often to poll the sensors (seconds)
         """
-        super().__init__()
+        super().__init__(EM27_SENSORS_URL.format(host=host))
         self._poll_timer = QTimer()
         self._poll_timer.timeout.connect(self.send_data)
         self._poll_timer.start(int(poll_interval * 1000))

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -9,7 +9,6 @@ The specification is available online:
 
 import logging
 from queue import Queue
-from typing import Any
 
 from pubsub import pub
 from PySide6.QtCore import QThread, Signal, Slot
@@ -156,9 +155,7 @@ class _SerialReader(QThread):
         return response
 
 
-class ST10Controller(
-    SerialDevice, StepperMotorBase, description="ST10 controller", default_baudrate=9600
-):
+class ST10Controller(SerialDevice, StepperMotorBase, description="ST10 controller"):
     """An interface for the ST10-Q-NN stepper motor controller.
 
     This class allows for moving the mirror to arbitrary positions and retrieving its
@@ -171,22 +168,20 @@ class ST10Controller(
     ST10_MODEL_ID = "107F024"
     """The model and revision number for the ST10 controller we are using."""
 
-    def __init__(
-        self, *serial_args: Any, timeout: float = 5.0, **serial_kwargs: Any
-    ) -> None:
+    def __init__(self, port: str, baudrate: int = 9600, timeout: float = 5.0) -> None:
         """Create a new ST10Controller.
 
         Args:
-            serial_args: Arguments to pass to Serial constructor
+            port: Description of USB port (vendor ID + product ID + serial number)
+            baudrate: Baud rate of port
             timeout: Connection timeout
-            serial_kwargs: Keyword arguments to pass to Serial constructor
 
         Raises:
             SerialException: Error communicating with device
             SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
         """
-        SerialDevice.__init__(self, *serial_args, **serial_kwargs)
+        SerialDevice.__init__(self, port, baudrate)
 
         self._reader = _SerialReader(self.serial, timeout)
         self._reader.async_read_completed.connect(self._send_move_end_message)

--- a/finesse/hardware/plugins/temperature/dp9800.py
+++ b/finesse/hardware/plugins/temperature/dp9800.py
@@ -1,7 +1,6 @@
 """This module provides an interface to DP9800 temperature readers."""
 from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any
 
 from serial import SerialException
 
@@ -86,23 +85,21 @@ class DP9800Error(Exception):
     """Indicates that an error occurred while communicating with the device."""
 
 
-class DP9800(
-    SerialDevice, TemperatureMonitorBase, description="DP9800", default_baudrate=38400
-):
+class DP9800(SerialDevice, TemperatureMonitorBase, description="DP9800"):
     """An interface for DP9800 temperature readers.
 
     The manual for this device is available at:
     https://assets.omega.com/manuals/M5210.pdf
     """
 
-    def __init__(self, *serial_args: Any, **serial_kwargs: Any) -> None:
+    def __init__(self, port: str, baudrate: int = 38400) -> None:
         """Create a new DP9800.
 
         Args:
-            serial_args: Arguments to Serial constructor
-            serial_kwargs: Keyword arguments to Serial constructor
+            port: Description of USB port (vendor ID + product ID + serial number)
+            baudrate: Baud rate of port
         """
-        SerialDevice.__init__(self, *serial_args, **serial_kwargs)
+        SerialDevice.__init__(self, port, baudrate)
         TemperatureMonitorBase.__init__(self)
 
     def get_device_settings(self, sysflag: str) -> dict[str, str]:

--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -59,7 +59,7 @@ class SenecaK107(SerialDevice, TemperatureMonitorBase, description="Seneca K107"
         self.MAX_MILLIVOLT = max_millivolt
 
         # The temperature range divided by the voltage range.
-        # This figure is used when convering the raw data to temperatures.
+        # This figure is used when converting the raw data to temperatures.
         temp_range = self.MAX_TEMP - self.MIN_TEMP
         millivolt_range = self.MAX_MILLIVOLT - self.MIN_MILLIVOLT
         self.SCALING_FACTOR = temp_range / millivolt_range

--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -1,6 +1,5 @@
 """This module provides an interface to Seneca temperature readers."""
 from collections.abc import Sequence
-from typing import Any
 
 import numpy
 from serial import SerialException
@@ -21,12 +20,7 @@ class SenecaK107Error(Exception):
     """Indicates that an error occurred while communicating with the device."""
 
 
-class SenecaK107(
-    SerialDevice,
-    TemperatureMonitorBase,
-    description="Seneca K107",
-    default_baudrate=57600,
-):
+class SenecaK107(SerialDevice, TemperatureMonitorBase, description="Seneca K107"):
     """An interface for the Seneca K107USB serial converter.
 
     This device communicates through the MODBUS-RTU protocol and outputs data from
@@ -39,24 +33,24 @@ class SenecaK107(
 
     def __init__(
         self,
+        port: str,
+        baudrate: int = 57600,
         min_temp: int = SENECA_MIN_TEMP,
         max_temp: int = SENECA_MAX_TEMP,
         min_millivolt: int = SENECA_MIN_MILLIVOLT,
         max_millivolt: int = SENECA_MAX_MILLIVOLT,
-        *serial_args: Any,
-        **serial_kwargs: Any,
     ) -> None:
         """Create a new SenecaK107.
 
         Args:
+            port: Description of USB port (vendor ID + product ID + serial number)
+            baudrate: Baud rate of port
             min_temp: The minimum temperature limit of the device.
             max_temp: The maximum temperature limit of the device.
             min_millivolt: The minimum voltage output (millivolts) of the device.
             max_millivolt: The maximum voltage output (millivolts) of the device.
-            serial_args: Arguments to Serial constructor
-            serial_kwargs: Keyword arguments to Serial constructor
         """
-        SerialDevice.__init__(self, *serial_args, **serial_kwargs)
+        SerialDevice.__init__(self, port, baudrate)
         TemperatureMonitorBase.__init__(self)
 
         self.MIN_TEMP = min_temp

--- a/finesse/hardware/plugins/temperature/tc4820.py
+++ b/finesse/hardware/plugins/temperature/tc4820.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 from decimal import Decimal
-from typing import Any
 
 from serial import SerialException
 
@@ -30,31 +29,26 @@ class MalformedMessageError(Exception):
     """Raised when a message sent or received was malformed."""
 
 
-class TC4820(
-    SerialDevice,
-    TemperatureControllerBase,
-    description="TC4820",
-    default_baudrate=115200,
-):
+class TC4820(SerialDevice, TemperatureControllerBase, description="TC4820"):
     """An interface for TC4820 temperature controllers."""
 
     def __init__(
-        self, name: str, *serial_args: Any, max_attempts: int = 3, **serial_kwargs: Any
+        self, name: str, port: str, baudrate: int = 115200, max_attempts: int = 3
     ) -> None:
         """Create a new TC4820 from an existing serial device.
 
         Args:
             name: The name of the device, to distinguish it from others
-            serial_args: Arguments to pass to Serial constructor
+            port: Description of USB port (vendor ID + product ID + serial number)
+            baudrate: Baud rate of port
             max_attempts: Maximum number of attempts for requests
-            serial_kwargs: Keyword arguments to pass to Serial constructor
         """
         if max_attempts < 1:
             raise ValueError("max_attempts must be at least 1")
 
         self.max_attempts = max_attempts
 
-        SerialDevice.__init__(self, *serial_args, **serial_kwargs)
+        SerialDevice.__init__(self, port, baudrate)
         TemperatureControllerBase.__init__(self, name)
 
     def close(self) -> None:

--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -83,8 +83,8 @@ class SerialDevice(AbstractDevice):
 
         # Extra, serial-specific parameters
         cls.add_device_parameters(
-            DeviceParameter("port", list(_get_usb_serial_ports().keys())),
-            DeviceParameter("baudrate", BAUDRATES, default_baudrate),
+            port=DeviceParameter(tuple(_get_usb_serial_ports().keys())),
+            baudrate=DeviceParameter(BAUDRATES, default_baudrate),
         )
 
     def __init__(self, port: str, baudrate: int) -> None:

--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -1,13 +1,10 @@
 """Provides a base class for USB serial devices."""
 from __future__ import annotations
 
-from typing import Any
-
 from serial import Serial, SerialException
 from serial.tools.list_ports import comports
 
 from finesse.config import BAUDRATES
-from finesse.device_info import DeviceParameter
 from finesse.hardware.device import AbstractDevice
 
 _serial_ports: dict[str, str] | None = None
@@ -64,7 +61,16 @@ def _get_usb_serial_ports() -> dict[str, str]:
     return _serial_ports
 
 
-class SerialDevice(AbstractDevice):
+class SerialDevice(
+    AbstractDevice,
+    parameters={
+        "port": (
+            "USB port, including vendor ID, product ID and serial number",
+            tuple(_get_usb_serial_ports().keys()),
+        ),
+        "baudrate": ("Baud rate", BAUDRATES),
+    },
+):
     """A base class for USB serial devices.
 
     Note that it is not sufficient for a device type class to inherit from this class
@@ -77,22 +83,13 @@ class SerialDevice(AbstractDevice):
     serial: Serial
     """Underlying serial device."""
 
-    def __init_subclass__(cls, default_baudrate: int, **kwargs: Any) -> None:
-        """Add serial-specific device parameters to the class."""
-        super().__init_subclass__(**kwargs)
-
-        # Extra, serial-specific parameters
-        cls.add_device_parameters(
-            port=DeviceParameter(
-                "USB port, including vendor ID, product ID and serial number "
-                "(if available)",
-                tuple(_get_usb_serial_ports().keys()),
-            ),
-            baudrate=DeviceParameter("Baud rate", BAUDRATES, default_baudrate),
-        )
-
     def __init__(self, port: str, baudrate: int) -> None:
-        """Create a new serial device."""
+        """Create a new serial device.
+
+        Args:
+            port: Description of USB port (vendor ID + product ID + serial number)
+            baudrate: Baud rate of port
+        """
         try:
             device = _serial_ports[port]  # type: ignore[index]
         except KeyError:

--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -83,8 +83,12 @@ class SerialDevice(AbstractDevice):
 
         # Extra, serial-specific parameters
         cls.add_device_parameters(
-            port=DeviceParameter(tuple(_get_usb_serial_ports().keys())),
-            baudrate=DeviceParameter(BAUDRATES, default_baudrate),
+            port=DeviceParameter(
+                "USB port, including vendor ID, product ID and serial number "
+                "(if available)",
+                tuple(_get_usb_serial_ports().keys()),
+            ),
+            baudrate=DeviceParameter("Baud rate", BAUDRATES, default_baudrate),
         )
 
     def __init__(self, port: str, baudrate: int) -> None:

--- a/tests/gui/hardware_set/test_device_control.py
+++ b/tests/gui/hardware_set/test_device_control.py
@@ -56,8 +56,8 @@ def test_on_device_list(widget_mock: Mock, widget: DeviceControl, qtbot) -> None
     """Test the _on_device_list() method."""
     base_type = DeviceBaseTypeInfo("base_type", "Base type", (), ())
     device_types = [
-        DeviceTypeInfo("my_class1", "Device 1", []),
-        DeviceTypeInfo("my_class2", "Device 2", []),
+        DeviceTypeInfo("my_class1", "Device 1"),
+        DeviceTypeInfo("my_class2", "Device 2"),
     ]
 
     with patch.object(widget, "layout"):

--- a/tests/gui/hardware_set/test_device_parameters_widget.py
+++ b/tests/gui/hardware_set/test_device_parameters_widget.py
@@ -1,5 +1,5 @@
 """Tests for the DeviceParametersWidget class."""
-from collections.abc import Sequence
+from collections.abc import Mapping
 from unittest.mock import Mock, patch
 
 import pytest
@@ -12,7 +12,7 @@ from finesse.gui.hardware_set.device_view import DeviceParametersWidget
 def widget(qtbot) -> DeviceParametersWidget:
     """A fixture providing a DeviceParametersWidget."""
     return DeviceParametersWidget(
-        DeviceTypeInfo("my_class", "My Device", [DeviceParameter("my_param", range(2))])
+        DeviceTypeInfo("my_class", "My Device", {"my_param": DeviceParameter(range(2))})
     )
 
 
@@ -20,17 +20,17 @@ def widget(qtbot) -> DeviceParametersWidget:
     "params",
     (
         # no params
-        (),
+        {},
         # one param
-        (DeviceParameter("my_param", ("value1", "value2")),),
+        {"my_param": DeviceParameter(("value1", "value2"))},
         # two params
-        (
-            DeviceParameter("my_param", ("value1", "value2")),
-            DeviceParameter("param2", range(3), 1),
-        ),
+        {
+            "my_param": DeviceParameter(("value1", "value2")),
+            "param2": DeviceParameter(range(3), 1),
+        },
     ),
 )
-def test_init(params: Sequence[DeviceParameter], qtbot) -> None:
+def test_init(params: Mapping[str, DeviceParameter], qtbot) -> None:
     """Test the constructor."""
     device_type = DeviceTypeInfo("my_class", "My Device", params)
 
@@ -39,11 +39,11 @@ def test_init(params: Sequence[DeviceParameter], qtbot) -> None:
     ) as load_params_mock:
         widget = DeviceParametersWidget(device_type)
         assert widget.device_type is device_type
-        assert list(widget._combos.keys()) == [p.name for p in params]
+        assert widget._combos.keys() == params.keys()
         load_params_mock.assert_called_once_with()
 
-        for param in params:
-            combo = widget._combos[param.name]
+        for name, param in params.items():
+            combo = widget._combos[name]
             items = [combo.itemText(i) for i in range(combo.count())]
             assert items == list(map(str, param.possible_values))
             assert (

--- a/tests/gui/hardware_set/test_device_parameters_widget.py
+++ b/tests/gui/hardware_set/test_device_parameters_widget.py
@@ -1,5 +1,6 @@
 """Tests for the DeviceParametersWidget class."""
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from typing import cast
 from unittest.mock import Mock, patch
 
 import pytest
@@ -47,11 +48,14 @@ def test_init(params: Mapping[str, DeviceParameter], qtbot) -> None:
         for name, param in params.items():
             combo = widget._combos[name]
             items = [combo.itemText(i) for i in range(combo.count())]
-            assert items == list(map(str, param.possible_values))
+
+            # Non-Sequence values are not currently supported
+            poss_values = cast(Sequence, param.possible_values)
+            assert items == list(map(str, poss_values))
             assert (
                 combo.currentData() == param.default_value
                 if param.default_value
-                else param.possible_values[0]
+                else poss_values[0]
             )
 
 

--- a/tests/gui/hardware_set/test_device_parameters_widget.py
+++ b/tests/gui/hardware_set/test_device_parameters_widget.py
@@ -12,7 +12,9 @@ from finesse.gui.hardware_set.device_view import DeviceParametersWidget
 def widget(qtbot) -> DeviceParametersWidget:
     """A fixture providing a DeviceParametersWidget."""
     return DeviceParametersWidget(
-        DeviceTypeInfo("my_class", "My Device", {"my_param": DeviceParameter(range(2))})
+        DeviceTypeInfo(
+            "my_class", "My Device", {"my_param": DeviceParameter("", range(2))}
+        )
     )
 
 
@@ -22,11 +24,11 @@ def widget(qtbot) -> DeviceParametersWidget:
         # no params
         {},
         # one param
-        {"my_param": DeviceParameter(("value1", "value2"))},
+        {"my_param": DeviceParameter("", ("value1", "value2"))},
         # two params
         {
-            "my_param": DeviceParameter(("value1", "value2")),
-            "param2": DeviceParameter(range(3), 1),
+            "my_param": DeviceParameter("", ("value1", "value2")),
+            "param2": DeviceParameter("", range(3), 1),
         },
     ),
 )

--- a/tests/gui/hardware_set/test_device_type_control.py
+++ b/tests/gui/hardware_set/test_device_type_control.py
@@ -11,8 +11,8 @@ from finesse.gui.hardware_set.device_view import (
 )
 
 DEVICE_TYPES = [
-    DeviceTypeInfo("my_class1", "Device 1", []),
-    DeviceTypeInfo("my_class2", "Device 2", []),
+    DeviceTypeInfo("my_class1", "Device 1"),
+    DeviceTypeInfo("my_class2", "Device 2"),
 ]
 
 
@@ -104,37 +104,23 @@ def test_init_no_device_types(qtbot) -> None:
 @pytest.mark.parametrize(
     "params,expected_enabled",
     (
-        ((DeviceParameter("param_not_poss", ()),), False),
+        ({"param_not_poss": DeviceParameter(())}, False),
         (
-            (
-                DeviceParameter(
-                    "param_poss",
-                    range(2),
-                ),
-            ),
+            {"param_poss": DeviceParameter(range(2))},
             True,
         ),
         (
-            (
-                DeviceParameter("param_not_poss", ()),
-                DeviceParameter(
-                    "param_poss",
-                    range(2),
-                ),
-            ),
+            {
+                "param_not_poss": DeviceParameter(()),
+                "param_poss": DeviceParameter(range(2)),
+            },
             False,
         ),
         (
-            (
-                DeviceParameter(
-                    "param_poss1",
-                    range(2),
-                ),
-                DeviceParameter(
-                    "param_poss2",
-                    range(2),
-                ),
-            ),
+            {
+                "param_poss1": DeviceParameter(range(2)),
+                "param_poss2": DeviceParameter(range(2)),
+            },
             True,
         ),
     ),

--- a/tests/gui/hardware_set/test_device_type_control.py
+++ b/tests/gui/hardware_set/test_device_type_control.py
@@ -208,6 +208,21 @@ def test_open_device(open_device_mock: Mock, widget: DeviceTypeControl, qtbot) -
     )
 
 
+@patch("finesse.gui.hardware_set.device_view.show_error_message")
+@patch(
+    "finesse.gui.hardware_set.device_view"
+    ".DeviceParametersWidget.current_parameter_values",
+    new_callable=PropertyMock,
+)
+def test_open_device_bad_params(
+    get_params_mock: Mock, error_message_mock: Mock, widget: DeviceTypeControl, qtbot
+) -> None:
+    """Test that a dialog is shown when parameter values are invalid."""
+    get_params_mock.side_effect = ValueError
+    widget._open_device()
+    error_message_mock.assert_called_once()
+
+
 @patch("finesse.gui.hardware_set.device_view.close_device")
 def test_close_device(
     close_device_mock: Mock, widget: DeviceTypeControl, qtbot

--- a/tests/gui/hardware_set/test_device_type_control.py
+++ b/tests/gui/hardware_set/test_device_type_control.py
@@ -104,22 +104,22 @@ def test_init_no_device_types(qtbot) -> None:
 @pytest.mark.parametrize(
     "params,expected_enabled",
     (
-        ({"param_not_poss": DeviceParameter(())}, False),
+        ({"param_not_poss": DeviceParameter("", ())}, False),
         (
-            {"param_poss": DeviceParameter(range(2))},
+            {"param_poss": DeviceParameter("", range(2))},
             True,
         ),
         (
             {
-                "param_not_poss": DeviceParameter(()),
-                "param_poss": DeviceParameter(range(2)),
+                "param_not_poss": DeviceParameter("", ()),
+                "param_poss": DeviceParameter("", range(2)),
             },
             False,
         ),
         (
             {
-                "param_poss1": DeviceParameter(range(2)),
-                "param_poss2": DeviceParameter(range(2)),
+                "param_poss1": DeviceParameter("", range(2)),
+                "param_poss2": DeviceParameter("", range(2)),
             },
             True,
         ),

--- a/tests/hardware/plugins/em27/test_em27_sensors.py
+++ b/tests/hardware/plugins/em27/test_em27_sensors.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from PySide6.QtNetwork import QNetworkReply
 
-from finesse.config import EM27_URL
+from finesse.config import EM27_SENSORS_URL
 from finesse.hardware.plugins.em27.em27_sensors import (
     EM27Error,
     EM27Property,
@@ -43,8 +43,8 @@ def test_init() -> None:
     with patch("finesse.hardware.plugins.em27.em27_sensors.QTimer") as qtimer_mock:
         qtimer = MagicMock()
         qtimer_mock.return_value = qtimer
-        sensors = EM27Sensors(2.0)
-        assert sensors._url == EM27_URL
+        sensors = EM27Sensors("1.2.3.4", 2.0)
+        assert sensors._url == EM27_SENSORS_URL.format(host="1.2.3.4")
         qtimer.timeout.connect.assert_called_once_with(sensors.send_data)
         qtimer.start.assert_called_once_with(2000)
 

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -105,9 +105,10 @@ def test_abstract_device_get_device_type_info() -> None:
     param = DeviceParameter("param1", ["a", "b"])
     MyDevice.add_device_parameters(param)
 
-    assert MyDevice.get_device_type_info() == DeviceTypeInfo(
-        f"{MyDevice.__module__}.MyDevice", "DESCRIPTION", [param]
-    )
+    with patch("finesse.hardware.device._plugins_name", MyDevice.__module__):
+        assert MyDevice.get_device_type_info() == DeviceTypeInfo(
+            "MyDevice", "DESCRIPTION", [param]
+        )
 
 
 def _wrapped_func_error_test(device: Device, wrapper: Callable, *args) -> None:

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -75,6 +75,69 @@ def test_get_device_types(load_plugins_mock: Mock) -> None:
             assert get_names(1) == ["Device0", "Device2"]
 
 
+def test_abstract_device_add_parameters_description_only() -> None:
+    """Test adding a device parameter with only a description provided."""
+
+    class MyDevice(AbstractDevice, parameters={"my_param": "My parameter"}):
+        def __init__(self, my_param: int) -> None:
+            pass
+
+    assert MyDevice.get_device_parameters() == {
+        "my_param": DeviceParameter("My parameter", int)
+    }
+
+
+def test_abstract_device_add_parameters_possible_values() -> None:
+    """Test adding a device parameter with description and possible values provided."""
+
+    class MyDevice(AbstractDevice, parameters={"my_param": ("My parameter", range(2))}):
+        def __init__(self, my_param: int) -> None:
+            pass
+
+    assert MyDevice.get_device_parameters() == {
+        "my_param": DeviceParameter("My parameter", range(2))
+    }
+
+
+def test_abstract_device_add_parameters_missing_arg() -> None:
+    """Test that an error is raised for a missing parameter."""
+    with pytest.raises(ValueError):
+
+        class MyDevice(AbstractDevice, parameters={"my_param": "My parameter"}):
+            pass
+
+
+def test_abstract_device_add_parameters_bad_type() -> None:
+    """Test that a TypeError is raised for a bad parameter type."""
+    with pytest.raises(TypeError):
+
+        class MyDevice(AbstractDevice, parameters={"my_param": 42}):  # type: ignore
+            def __init__(self, my_param: int) -> None:
+                pass
+
+
+def test_abstract_device_default_value() -> None:
+    """Test that default values for parameters are set correctly."""
+
+    class MyDevice(AbstractDevice, parameters={"my_param": "My parameter"}):
+        def __init__(self, my_param: int = 42) -> None:
+            pass
+
+    # Default value (and type) should be set from __init__'s signature
+    assert MyDevice.get_device_parameters() == {
+        "my_param": DeviceParameter("My parameter", int, 42)
+    }
+
+    class MyDeviceSubclass(MyDevice):
+        def __init__(self, my_param: int = 43) -> None:
+            pass
+
+    # Default value should be different for this subclass
+    assert MyDeviceSubclass.get_device_parameters() == {
+        "my_param": DeviceParameter("My parameter", int, 43)
+    }
+
+
 def test_abstract_device_device_parameters() -> None:
     """Test AbstractDevice's device parameter classmethods."""
 

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -81,10 +81,10 @@ def test_abstract_device_device_parameters() -> None:
     class MyDevice(AbstractDevice):
         pass
 
-    assert MyDevice.get_device_parameters() == []
-    param = DeviceParameter("param1", ["a", "b"])
-    MyDevice.add_device_parameters(param)
-    assert MyDevice.get_device_parameters() == [param]
+    assert not MyDevice.get_device_parameters()
+    param = DeviceParameter(("a", "b"))
+    MyDevice.add_device_parameters(my_param=param)
+    assert MyDevice.get_device_parameters() == {"my_param": param}
 
 
 def test_abstract_device_get_device_base_type_info() -> None:
@@ -102,12 +102,12 @@ def test_abstract_device_get_device_type_info() -> None:
     class MyDevice(AbstractDevice):
         _device_description = "DESCRIPTION"
 
-    param = DeviceParameter("param1", ["a", "b"])
-    MyDevice.add_device_parameters(param)
+    param = DeviceParameter(["a", "b"])
+    MyDevice.add_device_parameters(my_param=param)
 
     with patch("finesse.hardware.device._plugins_name", MyDevice.__module__):
         assert MyDevice.get_device_type_info() == DeviceTypeInfo(
-            "MyDevice", "DESCRIPTION", [param]
+            "MyDevice", "DESCRIPTION", {"my_param": param}
         )
 
 

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from finesse.device_info import DeviceParameter, DeviceTypeInfo
+from finesse.device_info import DeviceParameter
 from finesse.hardware.device import AbstractDevice, Device, get_device_types
 
 
@@ -138,18 +138,6 @@ def test_abstract_device_default_value() -> None:
     }
 
 
-def test_abstract_device_device_parameters() -> None:
-    """Test AbstractDevice's device parameter classmethods."""
-
-    class MyDevice(AbstractDevice):
-        pass
-
-    assert not MyDevice.get_device_parameters()
-    param = DeviceParameter("", ("a", "b"))
-    MyDevice.add_device_parameters(my_param=param)
-    assert MyDevice.get_device_parameters() == {"my_param": param}
-
-
 def test_abstract_device_get_device_base_type_info() -> None:
     """Test the get_device_base_type_info() classmethod."""
 
@@ -157,21 +145,6 @@ def test_abstract_device_get_device_base_type_info() -> None:
         _device_base_type_info = "INFO"  # type: ignore
 
     assert MyDevice.get_device_base_type_info() == "INFO"
-
-
-def test_abstract_device_get_device_type_info() -> None:
-    """Test the get_device_type_info() classmethod."""
-
-    class MyDevice(AbstractDevice):
-        _device_description = "DESCRIPTION"
-
-    param = DeviceParameter("", ("a", "b"))
-    MyDevice.add_device_parameters(my_param=param)
-
-    with patch("finesse.hardware.device._plugins_name", MyDevice.__module__):
-        assert MyDevice.get_device_type_info() == DeviceTypeInfo(
-            "MyDevice", "DESCRIPTION", {"my_param": param}
-        )
 
 
 def _wrapped_func_error_test(device: Device, wrapper: Callable, *args) -> None:

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -82,7 +82,7 @@ def test_abstract_device_device_parameters() -> None:
         pass
 
     assert not MyDevice.get_device_parameters()
-    param = DeviceParameter(("a", "b"))
+    param = DeviceParameter("", ("a", "b"))
     MyDevice.add_device_parameters(my_param=param)
     assert MyDevice.get_device_parameters() == {"my_param": param}
 
@@ -102,7 +102,7 @@ def test_abstract_device_get_device_type_info() -> None:
     class MyDevice(AbstractDevice):
         _device_description = "DESCRIPTION"
 
-    param = DeviceParameter(["a", "b"])
+    param = DeviceParameter("", ("a", "b"))
     MyDevice.add_device_parameters(my_param=param)
 
     with patch("finesse.hardware.device._plugins_name", MyDevice.__module__):

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -16,6 +16,7 @@ from finesse.hardware.manage_devices import (
     _open_device,
     _try_close_device,
 )
+from finesse.hardware.plugins import __name__ as _plugins_name
 
 
 def test_subscriptions():
@@ -56,7 +57,7 @@ def test_open_device(
     with patch("finesse.hardware.manage_devices._devices", devices_dict):
         class_name = "some.module.MyDevice"
         _open_device(instance=instance, class_name=class_name, params=params)
-        import_mock.assert_called_once_with("some.module")
+        import_mock.assert_called_once_with(f"{_plugins_name}.some.module")
 
         if name:
             device_cls_mock.assert_called_once_with(**params, name=name)


### PR DESCRIPTION
This PR adds support for specifying arbitrary device parameters via a text box, rather than having to choose from a set list in a combo box (#377).

The changes to the frontend are fairly minimal. The device management dialog will now display text boxes or combo boxes for each of the parameters, depending on which is appropriate. While there are no labels saying what each parameter is, a description is provided in a tooltip so the user can find out by hovering.

The backend changes were a bit more invasive. I refactored the device plugin code, so now the user just has to specify the names of the parameters along with a description and, optionally, the list of possible values.

For example, the signature for the `EM27Sensors` class now looks like this:

```py
class EM27Sensors(
    EM27SensorsBase,
    description="EM27 sensors",
    parameters={
        "host": "The IP address or hostname of the EM27 device",
        "poll_interval": "How often to poll the device in seconds",
    },
):
```

(Both of these are typed device params, i.e. their values can be arbitrary.)

The types and default values are automatically worked out from the constructor's signature:

```py
    def __init__(
        self, host: str = EM27_HOST, poll_interval: float = EM27_SENSORS_POLL_INTERVAL
    ) -> None:
```

If a child class changes/adds a default value for these params in its own constructor, then these will be used instead. This feature was added with `SerialDevice`s in mind: it now means that devices can specify a default baudrate in their constructors, without having to provide an extra `default_baudrate` class argument, as it was before.

(I also implemented #403 at the same time.)

Closes #377. Closes #403.