### PR TITLE
Add support for importing hardware sets

### DIFF
--- a/docs/hardware_sets.md
+++ b/docs/hardware_sets.md
@@ -1,0 +1,50 @@
+# Hardware sets
+
+Hardware sets are collections of hardware device types along with their associated
+parameters. They are used in FINESSE to represent a particular hardware rig (e.g.
+FINESSE or UNIRAS), so that users can easily swap between them. FINESSE comes with some
+built in configurations, but users can also define their own, either for convenience
+during testing or to build on FINESSE's functionality.
+
+Hardware sets are represented in a [YAML](https://yaml.org) format. Custom hardware sets
+can be created and imported into FINESSE. Here is an example:
+
+```yaml
+name: My hardware set
+devices:
+  stepper_motor:
+    class_name: stepper_motor.st10_controller.ST10Controller
+    params:
+      port: "0403:6011 FT1NMSVR (4)"
+      baudrate: 9600
+  temperature_controller.hot_bb:
+    class_name: temperature.tc4820.TC4820
+    params:
+      port: "0403:6011 FT1NMSVR (2)"
+      baudrate: 115200
+  temperature_controller.cold_bb:
+    class_name: temperature.tc4820.TC4820
+    params:
+      port: "0403:6011 FT1NMSVR (3)"
+      baudrate: 115200
+  temperature_monitor:
+    class_name: temperature.dp9800.DP9800
+    params:
+      port: "0403:6001"
+      baudrate: 38400
+  em27_sensors:
+    class_name: em27.em27_sensors.EM27Sensors
+```
+
+The `name` property defines a human-readable name for the hardware set, to be displayed
+in the GUI and the `devices` property contains informations about the devices in this
+hardware set. The `devices` array consists of key-value pairs, with the keys
+corresponding to device base types (see [Hardware]). The values are YAML objects with a
+`class_name` property and (optionally) a `params` property. `class_name` is a string
+corresponding to the Python class name, along with the last part of the module name (all
+plugins are in the `finesse.hardware.plugins` module, so this part is omitted). `params`
+is also a YAML object, containing key-value pairs for each of the device parameters (see
+[Hardware] again). If any of the parameters are omitted, their default values will be
+used.
+
+[Hardware]: ./hardware.md

--- a/docs/hardware_sets.md
+++ b/docs/hardware_sets.md
@@ -47,4 +47,11 @@ is also a YAML object, containing key-value pairs for each of the device paramet
 [Hardware] again). If any of the parameters are omitted, their default values will be
 used.
 
+Note that the port names are in a FINESSE-specific format. The string is composed of the
+USB vendor and product IDs, followed by the serial number (if present) and (optionally)
+a number to distinguish ports which share all these properties (as happens with
+USB-to-serial devices with multiple ports, for example). The easiest way to figure out
+these strings is to run FINESSE and click on "Manage devices". The available USB ports
+will be listed in the dialog.
+
 [Hardware]: ./hardware.md

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -2,6 +2,8 @@
 from importlib.metadata import version
 from pathlib import Path
 
+from platformdirs import user_config_path
+
 APP_NAME = "FINESSE"
 """A human-readable name for the app."""
 
@@ -10,6 +12,12 @@ APP_AUTHOR = "Imperial College London"
 
 APP_VERSION = version("finesse")
 """The current version of the app."""
+
+APP_CONFIG_PATH = user_config_path(APP_NAME, APP_AUTHOR, ensure_exists=True)
+"""Path where config files will be saved."""
+
+HARDWARE_SET_USER_PATH = APP_CONFIG_PATH / "hardware_sets"
+"""Path where user-added hardware set config files will be saved."""
 
 ANGLE_PRESETS = {
     "zenith": 180.0,

--- a/finesse/device_info.py
+++ b/finesse/device_info.py
@@ -88,16 +88,15 @@ class DeviceInstanceRef:
     Used for disambiguating devices where there can be multiple instances.
     """
 
+    def __str__(self) -> str:
+        """Get the short string representation of this device."""
+        s = self.base_type
+        if self.name:
+            s += f".{self.name}"
+        return s
+
     @staticmethod
     def from_str(s: str) -> DeviceInstanceRef:
         """Convert from a string in the format "base_type.name" or "base_type"."""
         base_type, _, name = s.partition(".")
         return DeviceInstanceRef(base_type, name or None)
-
-    @property
-    def topic(self) -> str:
-        """Get the partial pubsub topic for this device."""
-        topic = self.base_type
-        if self.name:
-            topic += f".{self.name}"
-        return topic

--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -186,10 +186,7 @@ class DeviceTypeControl(QGroupBox):
             self._device_widgets.append(widget)
 
         # Select the last device that was successfully opened, if there is one
-        topic = instance.topic
-        previous_device = cast(
-            str | None, settings.value(f"device/type/{instance.topic}")
-        )
+        previous_device = cast(str | None, settings.value(f"device/type/{instance!s}"))
         if previous_device:
             self._select_device(previous_device)
 
@@ -217,9 +214,9 @@ class DeviceTypeControl(QGroupBox):
         self._device_combo.currentIndexChanged.connect(self._on_device_selected)
 
         # pubsub subscriptions
-        pub.subscribe(self._on_device_opened, f"device.opening.{topic}")
-        pub.subscribe(self._set_device_closed, f"device.closed.{topic}")
-        pub.subscribe(self._show_error_message, f"device.error.{topic}")
+        pub.subscribe(self._on_device_opened, f"device.opening.{instance!s}")
+        pub.subscribe(self._set_device_closed, f"device.closed.{instance!s}")
+        pub.subscribe(self._show_error_message, f"device.error.{instance!s}")
 
     def _update_open_btn_enabled_state(self) -> None:
         """Enable button depending on whether there are options for all params.
@@ -318,7 +315,7 @@ class DeviceTypeControl(QGroupBox):
         """
         show_error_message(
             self,
-            f"A fatal error has occurred with the {instance.topic} device: {error!s}",
+            f"A fatal error has occurred with the {instance!s} device: {error!s}",
             title="Device error",
         )
 

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -46,10 +46,10 @@ class HardwareSet:
     name: str
     devices: frozenset[OpenDeviceArgs]
     file_path: Path
-    read_only: bool
+    built_in: bool
 
     @classmethod
-    def load(cls, file_path: Path, read_only: bool = False) -> HardwareSet:
+    def load(cls, file_path: Path, built_in: bool = False) -> HardwareSet:
         """Load a HardwareSet from a YAML file."""
         logging.info(f"Loading hardware set from {file_path}")
 
@@ -61,11 +61,11 @@ class HardwareSet:
             for k, v in plain_data.get("devices", {}).items()
         )
 
-        return cls(plain_data["name"], devices, file_path, read_only)
+        return cls(plain_data["name"], devices, file_path, built_in)
 
 
 def load_builtin_hardware_sets() -> Generator[HardwareSet, None, None]:
     """Load all the default hardware sets included with FINESSE."""
     pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
     for filepath in Path(pkg_path).glob("*.yaml"):
-        yield HardwareSet.load(filepath, read_only=True)
+        yield HardwareSet.load(filepath, built_in=True)

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -225,12 +225,14 @@ def _load_user_hardware_sets() -> Iterable[HardwareSet]:
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
         )
         ret = msg_box.exec()
-        if ret == QMessageBox.StandardButton.Ok:
-            for path in error.file_paths:
-                if QFile.moveToTrash(str(path)):
-                    logging.info(f"Trashed {path}")
-                else:
-                    logging.error(f"Failed to trash {path}")
+        if ret != QMessageBox.StandardButton.Ok:
+            return
+            
+        for path in error.file_paths:
+            if QFile.moveToTrash(str(path)):
+                logging.info(f"Trashed {path}")
+            else:
+                logging.error(f"Failed to trash {path}")
 
 
 def _load_all_hardware_sets() -> None:

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import bisect
 import logging
-from collections.abc import Generator, Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
@@ -141,7 +141,7 @@ def _save_hardware_set(hw_set: HardwareSet) -> None:
         pub.sendMessage("hardware_set.added", hw_set=new_hw_set)
 
 
-def _load_builtin_hardware_sets() -> Generator[HardwareSet, None, None]:
+def _load_builtin_hardware_sets() -> Iterable[HardwareSet]:
     """Load all the default hardware sets included with FINESSE."""
     pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
     for filepath in Path(pkg_path).glob("*.yaml"):
@@ -155,7 +155,7 @@ def _load_hardware_sets() -> None:
     _hw_sets.sort()
 
 
-def get_hardware_sets() -> Generator[HardwareSet, None, None]:
+def get_hardware_sets() -> Iterable[HardwareSet]:
     """Get all hardware sets in the store, sorted.
 
     This function is a generator as we do not want to expose the underlying list, which

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -227,7 +227,7 @@ def _load_user_hardware_sets() -> Iterable[HardwareSet]:
         ret = msg_box.exec()
         if ret != QMessageBox.StandardButton.Ok:
             return
-            
+
         for path in error.file_paths:
             if QFile.moveToTrash(str(path)):
                 logging.info(f"Trashed {path}")

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -63,9 +63,37 @@ class HardwareSet:
 
         return cls(plain_data["name"], devices, file_path, built_in)
 
+    def __lt__(self, other: HardwareSet) -> bool:
+        """For comparing HardwareSets."""
+        return (not self.built_in, self.name, self.file_path) < (
+            not other.built_in,
+            other.name,
+            other.file_path,
+        )
 
-def load_builtin_hardware_sets() -> Generator[HardwareSet, None, None]:
+
+def _load_builtin_hardware_sets() -> Generator[HardwareSet, None, None]:
     """Load all the default hardware sets included with FINESSE."""
     pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
     for filepath in Path(pkg_path).glob("*.yaml"):
         yield HardwareSet.load(filepath, built_in=True)
+
+
+def _load_hardware_sets() -> None:
+    """Load all known hardware sets from disk."""
+    global _hw_sets
+    _hw_sets = sorted(_load_builtin_hardware_sets())
+
+
+def get_hardware_sets() -> Generator[HardwareSet, None, None]:
+    """Get all hardware sets in the store, sorted.
+
+    This function is a generator as we do not want to expose the underlying list, which
+    should only be modified in this module.
+    """
+    yield from _hw_sets
+
+
+_hw_sets: list[HardwareSet]
+
+_load_hardware_sets()

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -106,7 +106,17 @@ class HardwareSet:
     built_in: bool
 
     def __lt__(self, other: HardwareSet) -> bool:
-        """For comparing HardwareSets."""
+        """Used for sorting HardwareSets.
+
+        Built-in hardware sets come before custom ones, then the hardware sets are
+        sorted by name. In the case that two hardware sets have the same name, they will
+        be distinguished by file path (which should be unique).
+
+        The GUI appends numbers to distinguish hardware sets with the same names. The
+        reason for also using the file path for sorting is because it is not guaranteed
+        that hardware set config files will always be loaded in the same order and we
+        don't want the name + number pairs to change between runs of FINESSE.
+        """
         return (not self.built_in, self.name, self.file_path) < (
             not other.built_in,
             other.name,

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -21,7 +21,7 @@ from finesse.gui.hardware_set.device_view import DeviceControl
 from finesse.gui.hardware_set.hardware_set import (
     HardwareSet,
     OpenDeviceArgs,
-    load_builtin_hardware_sets,
+    get_hardware_sets,
 )
 from finesse.settings import settings
 
@@ -64,7 +64,7 @@ class HardwareSetsControl(QGroupBox):
         )
 
         # Populate combo box
-        for hw_set in load_builtin_hardware_sets():
+        for hw_set in get_hardware_sets():
             self._add_hardware_set(hw_set)
 
         # Remember which hardware set was in use the last time the program was run

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -1,15 +1,16 @@
 """Provides a panel for choosing between hardware sets and (dis)connecting."""
 from collections.abc import Mapping
+from pathlib import Path
 from typing import AbstractSet, Any, cast
 
 from frozendict import frozendict
 from pubsub import pub
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
-    QGridLayout,
+    QFileDialog,
     QGroupBox,
+    QHBoxLayout,
     QPushButton,
     QSizePolicy,
     QVBoxLayout,
@@ -17,6 +18,7 @@ from PySide6.QtWidgets import (
 )
 
 from finesse.device_info import DeviceInstanceRef
+from finesse.gui.error_message import show_error_message
 from finesse.gui.hardware_set.device_view import DeviceControl
 from finesse.gui.hardware_set.hardware_set import (
     HardwareSet,
@@ -62,19 +64,8 @@ class HardwareSetsControl(QGroupBox):
         self._hardware_sets_combo.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
         )
-
-        # Populate combo box
-        for hw_set in get_hardware_sets():
-            self._add_hardware_set(hw_set)
-
-        # Remember which hardware set was in use the last time the program was run
-        last_selected = cast(str | None, settings.value("hardware_set/selected"))
-        if last_selected:
-            self._hardware_sets_combo.setCurrentText(last_selected)
-
-        self._hardware_sets_combo.currentIndexChanged.connect(
-            self._update_control_state
-        )
+        self._load_hardware_set_list()
+        self._load_last_selected_hardware_set()
 
         self._connect_btn = QPushButton("Connect")
         self._connect_btn.setSizePolicy(
@@ -87,22 +78,68 @@ class HardwareSetsControl(QGroupBox):
         )
         self._disconnect_btn.pressed.connect(self._on_disconnect_btn_pressed)
 
+        import_hw_set_btn = QPushButton("Import config")
+        import_hw_set_btn.pressed.connect(self._import_hardware_set)
+
         manage_devices_btn = QPushButton("Manage devices")
         manage_devices_btn.pressed.connect(self._show_manage_devices_dialog)
         self._manage_devices_dialog: ManageDevicesDialog
 
-        # Enable/disable controls
-        self._update_control_state()
+        row1 = QHBoxLayout()
+        row1.addWidget(self._hardware_sets_combo)
+        row1.addWidget(self._connect_btn)
+        row1.addWidget(self._disconnect_btn)
+        row2 = QHBoxLayout()
+        row2.addWidget(import_hw_set_btn)
+        row2.addWidget(manage_devices_btn)
 
-        layout = QGridLayout()
-        layout.addWidget(self._hardware_sets_combo, 0, 0)
-        layout.addWidget(self._connect_btn, 0, 1)
-        layout.addWidget(self._disconnect_btn, 0, 2)
-        layout.addWidget(manage_devices_btn, 1, 0, 1, 3, Qt.AlignmentFlag.AlignHCenter)
+        layout = QVBoxLayout()
+        layout.addLayout(row1)
+        layout.addLayout(row2)
         self.setLayout(layout)
 
+        pub.subscribe(self._on_hardware_set_added, "hardware_set.added")
+
+        self._update_control_state()
+
+        self._hardware_sets_combo.currentIndexChanged.connect(
+            self._update_control_state
+        )
+
+    def _load_last_selected_hardware_set(self) -> None:
+        """Select the hardware set last selected when the program was run before."""
+        if last_selected := cast(str | None, settings.value("hardware_set/selected")):
+            self._hardware_sets_combo.setCurrentText(last_selected)
+
+    def _load_hardware_set_list(self) -> None:
+        """Populate the combo box with hardware sets."""
+        for hw_set in get_hardware_sets():
+            self._add_hardware_set(hw_set)
+
+    def _import_hardware_set(self) -> None:
+        """Import a hardware set from a file."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self, "Import hardware set config file", filter="*.yaml"
+        )
+        if not file_path:
+            return
+
+        try:
+            hw_set = HardwareSet.load(Path(file_path))
+        except Exception:
+            show_error_message(
+                self,
+                "Could not load hardware set config file. Is it in the correct format?",
+                "Could not load config file",
+            )
+        else:
+            pub.sendMessage("hardware_set.add", hw_set=hw_set)
+
     def _show_manage_devices_dialog(self) -> None:
-        # Create dialog lazily
+        """Show a dialog for managing devices manually.
+
+        The dialog is created lazily.
+        """
         if not hasattr(self, "_manage_devices_dialog"):
             self._manage_devices_dialog = ManageDevicesDialog(
                 self.window(), self._connected_devices
@@ -134,10 +171,32 @@ class HardwareSetsControl(QGroupBox):
                 return
             i += 1
 
+    def _on_hardware_set_added(self, hw_set: HardwareSet) -> None:
+        """Clear the combo box and refill it, then select hw_set.
+
+        The reason for clearing the combo box and refilling it is so that we can keep
+        the entries sorted.
+        """
+        self._hardware_sets_combo.clear()
+        self._load_hardware_set_list()
+
+        # Select the just-added hardware set
+        idx = next(
+            i
+            for i in range(self._hardware_sets_combo.count())
+            if self._hardware_sets_combo.itemData(i) is hw_set
+        )
+        self._hardware_sets_combo.setCurrentIndex(idx)
+
     @property
     def current_hardware_set(self) -> frozenset[OpenDeviceArgs]:
-        """Return the currently selected hardware set."""
-        return self._hardware_sets_combo.currentData().devices
+        """Return the currently selected hardware set.
+
+        If the combo box is empty and, therefore, no hardware set is selected, an empty
+        set is returned.
+        """
+        hw_set = cast(HardwareSet | None, self._hardware_sets_combo.currentData())
+        return hw_set.devices if hw_set else frozenset()
 
     def _update_control_state(self) -> None:
         """Enable or disable the connect and disconnect buttons as appropriate."""

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -116,14 +116,19 @@ class HardwareSetsControl(QGroupBox):
             self._hardware_sets_combo.itemText(i)
             for i in range(self._hardware_sets_combo.count())
         }
-        if hw_set.name not in labels:
-            self._hardware_sets_combo.addItem(hw_set.name, hw_set)
+
+        name_root = hw_set.name
+        if hw_set.built_in:
+            name_root += " (built in)"
+
+        if name_root not in labels:
+            self._hardware_sets_combo.addItem(name_root, hw_set)
             return
 
         # If there is already a hardware set by that name, append a number
         i = 2
         while True:
-            name = f"{hw_set.name} ({i})"
+            name = f"{name_root} ({i})"
             if name not in labels:
                 self._hardware_sets_combo.addItem(name, hw_set)
                 return

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -184,7 +184,7 @@ class HardwareSetsControl(QGroupBox):
         )
 
         # Remember last opened device
-        settings.setValue(f"device/type/{instance.topic}", class_name)
+        settings.setValue(f"device/type/{instance!s}", class_name)
         if params:
             settings.setValue(f"device/params/{class_name}", params)
 

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -268,7 +268,7 @@ class Device(AbstractDevice):
         # Send pubsub message
         instance = self.get_instance_ref()
         pub.sendMessage(
-            f"device.error.{instance.topic}",
+            f"device.error.{instance!s}",
             instance=instance,
             error=error,
         )

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -47,7 +47,7 @@ def _open_device(
     logging.info(f"Opening device of type {instance.base_type}: {class_name_part}")
 
     if device := _devices.get(instance):
-        logging.warn(f"Replacing existing instance of device of type {instance.topic}")
+        logging.warn(f"Replacing existing instance of device of type {instance!s}")
         _try_close_device(device)
 
     # If this instance also has a name (e.g. "hot_bb") then we also need to pass this as
@@ -59,10 +59,8 @@ def _open_device(
     try:
         _devices[instance] = cls(**params_with_name)
     except Exception as error:
-        logging.error(f"Failed to open {instance.topic} device: {str(error)}")
-        pub.sendMessage(
-            f"device.error.{instance.topic}", instance=instance, error=error
-        )
+        logging.error(f"Failed to open {instance!s} device: {str(error)}")
+        pub.sendMessage(f"device.error.{instance!s}", instance=instance, error=error)
     else:
         logging.info("Opened device")
 
@@ -70,12 +68,12 @@ def _open_device(
         # because we want to ensure that some listeners always run before others, in
         # case an error occurs and we have to undo the work.
         pub.sendMessage(
-            f"device.opening.{instance.topic}",
+            f"device.opening.{instance!s}",
             instance=instance,
             class_name=class_name,
             params=params,
         )
-        pub.sendMessage(f"device.opened.{instance.topic}")
+        pub.sendMessage(f"device.opened.{instance!s}")
 
 
 def _try_close_device(device: Device) -> None:
@@ -91,7 +89,7 @@ def _try_close_device(device: Device) -> None:
         logging.warn(f"Error while closing {device.__class__.__name__}: {ex!s}")
 
     instance = device.get_instance_ref()
-    pub.sendMessage(f"device.closed.{instance.topic}", instance=instance)
+    pub.sendMessage(f"device.closed.{instance!s}", instance=instance)
 
 
 def _close_device(instance: DeviceInstanceRef) -> None:

--- a/finesse/settings.py
+++ b/finesse/settings.py
@@ -5,5 +5,5 @@ from finesse.config import APP_CONFIG_PATH
 
 # We use platformdirs to choose the path for config file because Qt seems to use a
 # slightly different scheme (at least on Linux)
-settings = QSettings(str(APP_CONFIG_PATH / "settings.conf"))
+settings = QSettings(str(APP_CONFIG_PATH / "settings.ini"), QSettings.Format.IniFormat)
 """Contains the program settings for FINESSE."""

--- a/finesse/settings.py
+++ b/finesse/settings.py
@@ -1,11 +1,9 @@
 """A module with a single settings object for the program settings."""
-from platformdirs import user_config_path
 from PySide6.QtCore import QSettings
 
-from finesse.config import APP_AUTHOR, APP_NAME
+from finesse.config import APP_CONFIG_PATH
 
 # We use platformdirs to choose the path for config file because Qt seems to use a
 # slightly different scheme (at least on Linux)
-_config_dir = user_config_path(APP_NAME, APP_AUTHOR, ensure_exists=True)
-settings = QSettings(str(_config_dir / "settings.conf"))
+settings = QSettings(str(APP_CONFIG_PATH / "settings.conf"))
 """Contains the program settings for FINESSE."""

--- a/finesse/settings.py
+++ b/finesse/settings.py
@@ -1,7 +1,11 @@
 """A module with a single settings object for the program settings."""
+from platformdirs import user_config_path
 from PySide6.QtCore import QSettings
 
 from finesse.config import APP_AUTHOR, APP_NAME
 
-settings = QSettings(APP_AUTHOR, APP_NAME)
+# We use platformdirs to choose the path for config file because Qt seems to use a
+# slightly different scheme (at least on Linux)
+_config_dir = user_config_path(APP_NAME, APP_AUTHOR, ensure_exists=True)
+settings = QSettings(str(_config_dir / "settings.conf"))
 """Contains the program settings for FINESSE."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ plugins:
 nav:
 - FINESSE documentation: index.md
 - Hardware: hardware.md
+- Hardware sets: hardware_sets.md
 - Measure scripts: measure_scripts.md
 # defer to gen-files + literate-nav
 - Code Reference: reference/

--- a/tests/gui/hardware_set/test_device_type_control.py
+++ b/tests/gui/hardware_set/test_device_type_control.py
@@ -86,9 +86,9 @@ def test_init(
 
     subscribe_mock.assert_has_calls(
         [
-            call(widget._on_device_opened, f"device.opening.{instance.topic}"),
-            call(widget._set_device_closed, f"device.closed.{instance.topic}"),
-            call(widget._show_error_message, f"device.error.{instance.topic}"),
+            call(widget._on_device_opened, f"device.opening.{instance!s}"),
+            call(widget._set_device_closed, f"device.closed.{instance!s}"),
+            call(widget._show_error_message, f"device.error.{instance!s}"),
         ]
     )
 

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -11,7 +11,8 @@ from finesse.gui.hardware_set import hardware_set
 from finesse.gui.hardware_set.hardware_set import (
     HardwareSet,
     OpenDeviceArgs,
-    load_builtin_hardware_sets,
+    _load_builtin_hardware_sets,
+    get_hardware_sets,
 )
 
 FILE_PATH = Path("test/file.yaml")
@@ -81,5 +82,12 @@ def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
     """Test the load_builtin_hardware_sets() function."""
     pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
     yaml_files = Path(pkg_path).glob("*.yaml")
-    list(load_builtin_hardware_sets())  # assume return value is correct
+    list(_load_builtin_hardware_sets())  # assume return value is correct
     load_mock.assert_has_calls([call(file, built_in=True) for file in yaml_files])
+
+
+def test_get_hardware_sets() -> None:
+    """Test the get_hardware_sets() method."""
+    hw_sets = list(range(2))
+    with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
+        assert list(get_hardware_sets()) == hw_sets

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -1,22 +1,85 @@
 """Tests for the HardwareSet class and associated helper functions."""
+from collections.abc import Sequence
 from importlib import resources
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock, call, mock_open, patch
+from unittest.mock import MagicMock, Mock, call, mock_open, patch
 
 import pytest
 import yaml
+from frozendict import frozendict
+from pubsub import pub
 
+from finesse.device_info import DeviceInstanceRef
 from finesse.gui.hardware_set import hardware_set
 from finesse.gui.hardware_set.hardware_set import (
     HardwareSet,
     OpenDeviceArgs,
+    _device_to_plain_data,
+    _get_new_hardware_set_path,
     _load_builtin_hardware_sets,
+    _load_hardware_sets,
+    _save_hardware_set,
     get_hardware_sets,
 )
 
 FILE_PATH = Path("test/file.yaml")
 NAME = "Test hardware set"
+
+
+def test_subscriptions() -> None:
+    """Check the module-level subscriptions."""
+    assert pub.isSubscribed(_save_hardware_set, "hardware_set.add")
+
+
+@pytest.mark.parametrize(
+    "device,expected",
+    (
+        (
+            OpenDeviceArgs(DeviceInstanceRef("base_type"), "my_class"),
+            ("base_type", {"class_name": "my_class"}),
+        ),
+        (
+            OpenDeviceArgs(
+                DeviceInstanceRef("base_type"), "my_class", frozendict(a=1, b="hello")
+            ),
+            ("base_type", {"class_name": "my_class", "params": {"a": 1, "b": "hello"}}),
+        ),
+    ),
+)
+def test_device_to_plain_data(device: OpenDeviceArgs, expected: dict[str, Any]) -> None:
+    """Test _device_to_plain_data()."""
+    assert _device_to_plain_data(device) == expected
+
+
+@patch("finesse.gui.hardware_set.hardware_set._device_to_plain_data")
+@patch("finesse.gui.hardware_set.hardware_set.yaml.dump")
+def test_hardware_set_save(dump_mock: Mock, to_plain_mock: Mock) -> None:
+    """Test HardwareSet's save() method."""
+    file_path = MagicMock()
+    devices = (
+        OpenDeviceArgs(DeviceInstanceRef(f"base_type{i}"), f"my_class{i}")
+        for i in range(2)
+    )
+    to_plain_mock.side_effect = ((f"key{i}", i) for i in range(2))
+    hw_set = HardwareSet(NAME, frozenset(devices), FILE_PATH, False)
+    hw_set.save(file_path)
+    expected = {"name": NAME, "devices": {"key0": 0, "key1": 1}}
+    assert dump_mock.call_count == 1
+    assert dump_mock.mock_calls[0].args[0] == expected
+
+
+def test_hardware_set_save_and_load(tmp_path: Path) -> None:
+    """Test that saved files are loadable."""
+    devices = (
+        OpenDeviceArgs(DeviceInstanceRef(f"base_type{i}"), f"my_class{i}")
+        for i in range(2)
+    )
+    save_path = tmp_path / "file.yaml"
+    hw_set1 = HardwareSet(NAME, frozenset(devices), save_path, False)
+    hw_set1.save(save_path)
+    hw_set2 = HardwareSet.load(save_path, False)
+    assert hw_set1 == hw_set2
 
 
 @pytest.mark.parametrize(
@@ -77,6 +140,84 @@ def test_load(data: dict[str, Any], expected: HardwareSet) -> None:
         assert result == expected
 
 
+@pytest.mark.parametrize(
+    "to_create,expected_file_name",
+    (
+        ((), "file.yaml"),
+        (("file.yaml",), "file_2.yaml"),
+        (("file.yaml", "file_2.yaml"), ("file_3.yaml")),
+    ),
+)
+def test_get_new_hardware_set_path(
+    to_create: Sequence[str], expected_file_name: str, tmp_path: Path
+) -> None:
+    """Test _get_new_hardware_set_path()."""
+    output_dir = tmp_path / "sub"
+
+    # Create files
+    output_dir.mkdir()
+    for file_name in to_create:
+        open(output_dir / file_name, "w").close()
+
+    assert (
+        _get_new_hardware_set_path("file", output_dir)
+        == output_dir / expected_file_name
+    )
+
+
+def test_get_new_hardware_set_path_creates_dir(tmp_path: Path) -> None:
+    """Test that _get_new_hardware_set_path() creates the target directory."""
+    output_dir = tmp_path / "sub"
+    _get_new_hardware_set_path("file", output_dir)
+    assert output_dir.exists()
+
+
+@patch("finesse.gui.hardware_set.hardware_set._get_new_hardware_set_path")
+@patch("finesse.gui.hardware_set.hardware_set.show_error_message")
+def test_save_hardware_set_success(
+    error_message_mock: Mock, get_path_mock: Mock, sendmsg_mock: MagicMock
+) -> None:
+    """Test _save_hardware_set()."""
+    in_path = Path("dir1/file.yaml")
+    out_path = Path("dir2/file.yaml")
+    hw_set = MagicMock()
+    hw_set.name = NAME
+    hw_set.file_path = in_path
+    hw_set.devices = HW_SETS[0].devices
+    hw_set.built_in = False
+    get_path_mock.return_value = out_path
+    hw_sets: list = []
+    with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
+        hw_set_new = HardwareSet(NAME, HW_SETS[0].devices, out_path, built_in=False)
+        _save_hardware_set(hw_set)
+        get_path_mock.assert_called_once_with(in_path.stem)
+        hw_set.save.assert_called_once_with(out_path)
+        error_message_mock.assert_not_called()
+        assert hw_sets == [hw_set_new]  # NB: Should be sorted but we don't check this
+        sendmsg_mock.assert_called_once_with("hardware_set.added", hw_set=hw_set_new)
+
+
+@patch("finesse.gui.hardware_set.hardware_set._get_new_hardware_set_path")
+@patch("finesse.gui.hardware_set.hardware_set.show_error_message")
+def test_save_hardware_set_fail(
+    error_message_mock: Mock, get_path_mock: Mock, sendmsg_mock: MagicMock
+) -> None:
+    """Test _save_hardware_set()."""
+    in_path = Path("dir1/file.yaml")
+    out_path = Path("dir2/file.yaml")
+    hw_set = MagicMock()
+    hw_set.file_path = in_path
+    hw_set.save.side_effect = RuntimeError
+    get_path_mock.return_value = out_path
+    hw_sets: list = []
+    with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
+        _save_hardware_set(hw_set)
+        get_path_mock.assert_called_once_with(in_path.stem)
+        hw_set.save.assert_called_once_with(out_path)
+        error_message_mock.assert_called_once()
+        sendmsg_mock.assert_not_called()
+
+
 @patch.object(HardwareSet, "load")
 def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
     """Test the load_builtin_hardware_sets() function."""
@@ -84,6 +225,16 @@ def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
     yaml_files = Path(pkg_path).glob("*.yaml")
     list(_load_builtin_hardware_sets())  # assume return value is correct
     load_mock.assert_has_calls([call(file, built_in=True) for file in yaml_files])
+
+
+@patch("finesse.gui.hardware_set.hardware_set._load_builtin_hardware_sets")
+def test_load_hardware_sets(load_builtin_mock: Mock) -> None:
+    """Test _load_hardware_sets()."""
+    hw_sets: list[int] = []
+    with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
+        load_builtin_mock.return_value = (1, 0)  # deliberately unsorted
+        _load_hardware_sets()
+        assert hw_sets == [0, 1]
 
 
 def test_get_hardware_sets() -> None:

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -1,6 +1,8 @@
 """Tests for the HardwareSet class and associated helper functions."""
 from collections.abc import Sequence
+from contextlib import nullcontext as does_not_raise
 from importlib import resources
+from itertools import product
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, call, mock_open, patch
@@ -9,22 +11,56 @@ import pytest
 import yaml
 from frozendict import frozendict
 from pubsub import pub
+from PySide6.QtWidgets import QMessageBox
 
+from finesse.config import HARDWARE_SET_USER_PATH
 from finesse.device_info import DeviceInstanceRef
 from finesse.gui.hardware_set import hardware_set
 from finesse.gui.hardware_set.hardware_set import (
     HardwareSet,
+    HardwareSetLoadError,
     OpenDeviceArgs,
     _device_to_plain_data,
     _get_new_hardware_set_path,
+    _load_all_hardware_sets,
     _load_builtin_hardware_sets,
     _load_hardware_sets,
+    _load_user_hardware_sets,
     _save_hardware_set,
     get_hardware_sets,
 )
 
 FILE_PATH = Path("test/file.yaml")
 NAME = "Test hardware set"
+
+HW_SETS = [
+    HardwareSet(
+        "Test 1",
+        frozenset(
+            (
+                OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
+                OpenDeviceArgs.create(
+                    "temperature_monitor",
+                    "MyTemperatureMonitor",
+                    {"param1": "value1"},
+                ),
+            )
+        ),
+        Path("path/test.yaml"),
+        False,
+    ),
+    HardwareSet(
+        "Test 2",
+        frozenset(
+            (
+                OpenDeviceArgs.create("stepper_motor", "OtherStepperMotor"),
+                OpenDeviceArgs.create("temperature_monitor", "OtherTemperatureMonitor"),
+            )
+        ),
+        Path("path/test2.yaml"),
+        False,
+    ),
+]
 
 
 def test_subscriptions() -> None:
@@ -80,6 +116,33 @@ def test_hardware_set_save_and_load(tmp_path: Path) -> None:
     hw_set1.save(save_path)
     hw_set2 = HardwareSet.load(save_path, False)
     assert hw_set1 == hw_set2
+
+
+@pytest.mark.parametrize(
+    "hw_set1,hw_set2",
+    (
+        # Built-in HardwareSets come before user ones
+        (
+            HardwareSet("B", frozenset(), Path("b.yaml"), True),
+            HardwareSet("A", frozenset(), Path("a.yaml"), False),
+        ),
+        # Then sort by name
+        (
+            HardwareSet("A", frozenset(), Path("2.yaml"), True),
+            HardwareSet("B", frozenset(), Path("1.yaml"), True),
+        ),
+        # Lastly, sort by file name
+        (
+            HardwareSet(NAME, frozenset(), Path("a.yaml"), True),
+            HardwareSet(NAME, frozenset(), Path("b.yaml"), True),
+        ),
+    ),
+)
+def test_hardware_set_lt(hw_set1: HardwareSet, hw_set2: HardwareSet) -> None:
+    """Test HardwareSet's magic __lt__ method()."""
+    assert hw_set1 < hw_set2
+    assert hw_set2 > hw_set1
+    assert hw_set1 != hw_set2
 
 
 @pytest.mark.parametrize(
@@ -218,27 +281,131 @@ def test_save_hardware_set_fail(
         sendmsg_mock.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "raise_error,raises",
+    (
+        (
+            errors,
+            pytest.raises(HardwareSetLoadError) if any(errors) else does_not_raise(),
+        )
+        for errors in product((False, True), repeat=len(HW_SETS))
+    ),
+)
+@patch.object(HardwareSet, "load")
+def test_load_hardware_sets(
+    load_mock: Mock, tmp_path: Path, raise_error: Sequence[bool], raises: Any
+) -> None:
+    """Test _load_hardware_sets()."""
+    # Create n empty files in tmp_path
+    for i in range(len(HW_SETS)):
+        path = tmp_path / f"file{i}.yaml"
+        path.open("w").close()
+
+    i = -1
+
+    def mock_load(*args, **kwargs):
+        nonlocal i
+        i += 1
+        if raise_error[i]:
+            raise RuntimeError()
+        return HW_SETS[i]
+
+    load_mock.side_effect = mock_load
+    out: list[HardwareSet] = []
+    with raises:
+        for hw_set in _load_hardware_sets(tmp_path, built_in=False):
+            out.append(hw_set)
+
+
 @patch.object(HardwareSet, "load")
 def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
-    """Test the load_builtin_hardware_sets() function."""
+    """Test the _load_builtin_hardware_sets() function."""
     pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
     yaml_files = Path(pkg_path).glob("*.yaml")
     list(_load_builtin_hardware_sets())  # assume return value is correct
     load_mock.assert_has_calls([call(file, built_in=True) for file in yaml_files])
 
 
-@patch("finesse.gui.hardware_set.hardware_set._load_builtin_hardware_sets")
-def test_load_hardware_sets(load_builtin_mock: Mock) -> None:
-    """Test _load_hardware_sets()."""
+@patch("finesse.gui.hardware_set.hardware_set._load_hardware_sets")
+def test_load_all_hardware_sets(load_mock: Mock) -> None:
+    """Test _load_all_hardware_sets()."""
     hw_sets: list[int] = []
     with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
-        load_builtin_mock.return_value = (1, 0)  # deliberately unsorted
-        _load_hardware_sets()
-        assert hw_sets == [0, 1]
+        load_mock.side_effect = ((1, 0), (3, 2))  # deliberately unsorted
+        _load_all_hardware_sets()
+        assert hw_sets == [0, 1, 2, 3]
 
 
-def test_get_hardware_sets() -> None:
+@patch("finesse.gui.hardware_set.hardware_set._load_hardware_sets")
+def test_load_user_hardware_sets_success(load_mock: Mock) -> None:
+    """Test _load_user_hardware_sets() when it succeeds."""
+    list(_load_user_hardware_sets())  # assume return value is correct
+    load_mock.assert_called_once_with(HARDWARE_SET_USER_PATH, built_in=False)
+
+
+@patch("finesse.gui.hardware_set.hardware_set.QFile.moveToTrash")
+@patch("finesse.gui.hardware_set.hardware_set.QMessageBox")
+@patch("finesse.gui.hardware_set.hardware_set._load_hardware_sets")
+def test_load_user_hardware_sets_no_trash(
+    load_mock: Mock, msgbox_mock: Mock, trash_mock: Mock
+) -> None:
+    """Test _load_user_hardware_sets() when an error occurs and the user cancels."""
+    msgbox = MagicMock()
+    msgbox_mock.return_value = msgbox
+    msgbox_mock.StandardButton = QMessageBox.StandardButton
+    msgbox.exec.return_value = QMessageBox.StandardButton.Cancel
+    paths = (Path("a.yaml"), Path("b.yaml"))
+    load_mock.side_effect = HardwareSetLoadError(paths)
+    list(_load_user_hardware_sets())  # assume return value is correct
+    load_mock.assert_called_once_with(HARDWARE_SET_USER_PATH, built_in=False)
+    trash_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("trash_succeeded", (True, False))
+@patch("finesse.gui.hardware_set.hardware_set.logging.error")
+@patch("finesse.gui.hardware_set.hardware_set.QFile.moveToTrash")
+@patch("finesse.gui.hardware_set.hardware_set.QMessageBox")
+@patch("finesse.gui.hardware_set.hardware_set._load_hardware_sets")
+def test_load_user_hardware_sets_trash(
+    load_mock: Mock,
+    msgbox_mock: Mock,
+    trash_mock: Mock,
+    error_mock: Mock,
+    trash_succeeded: bool,
+) -> None:
+    """Test _load_user_hardware_sets() when an error occurs and the user clicks OK."""
+    msgbox = MagicMock()
+    msgbox.exec.return_value = QMessageBox.StandardButton.Ok
+    msgbox_mock.return_value = msgbox
+    msgbox_mock.StandardButton = QMessageBox.StandardButton
+    paths = (Path("a.yaml"), Path("b.yaml"))
+    load_mock.side_effect = HardwareSetLoadError(paths)
+    trash_mock.return_value = trash_succeeded
+    list(_load_user_hardware_sets())  # assume return value is correct
+    load_mock.assert_called_once_with(HARDWARE_SET_USER_PATH, built_in=False)
+    trash_mock.assert_has_calls(tuple(map(call, map(str, paths))))
+
+    # An error message should be printed if trashing files fails
+    if trash_succeeded:
+        error_mock.assert_not_called()
+    else:
+        assert error_mock.call_count == len(paths)
+
+
+@patch("finesse.gui.hardware_set.hardware_set._load_all_hardware_sets")
+def test_get_hardware_sets(load_mock: Mock) -> None:
     """Test the get_hardware_sets() method."""
+    # Check that _load_hardware_sets() will not be called if hardware sets are already
+    # loaded
     hw_sets = list(range(2))
     with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
-        assert list(get_hardware_sets()) == hw_sets
+        ret = list(get_hardware_sets())
+        load_mock.assert_not_called()
+        assert ret == hw_sets
+
+    # Check that hardware sets will be loaded if not loaded already
+    hw_sets.clear()
+    with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_sets):
+        ret = list(get_hardware_sets())
+        load_mock.assert_called_once_with()
+        assert ret == hw_sets

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -82,4 +82,4 @@ def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
     pkg_path = str(resources.files("finesse.gui.hardware_set").joinpath())
     yaml_files = Path(pkg_path).glob("*.yaml")
     list(load_builtin_hardware_sets())  # assume return value is correct
-    load_mock.assert_has_calls([call(file, read_only=True) for file in yaml_files])
+    load_mock.assert_has_calls([call(file, built_in=True) for file in yaml_files])

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -40,24 +40,24 @@ HW_SETS = [
 
 
 @pytest.fixture
-@patch("finesse.gui.hardware_set.hardware_sets_view.load_builtin_hardware_sets")
+@patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
 def hw_sets(
-    load_hw_sets_mock: Mock, sendmsg_mock: MagicMock, subscribe_mock: MagicMock, qtbot
+    get_hw_sets_mock: Mock, sendmsg_mock: MagicMock, subscribe_mock: MagicMock, qtbot
 ) -> HardwareSetsControl:
     """A fixture for the control."""
-    load_hw_sets_mock.return_value = HW_SETS
+    get_hw_sets_mock.return_value = HW_SETS
     return HardwareSetsControl()
 
 
 @pytest.mark.parametrize("selected_hw_set", (hw_set.name for hw_set in HW_SETS))
-@patch("finesse.gui.hardware_set.hardware_sets_view.load_builtin_hardware_sets")
+@patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
 def test_init(
-    load_hw_sets_mock: Mock, selected_hw_set: str, subscribe_mock: MagicMock, qtbot
+    get_hw_sets_mock: Mock, selected_hw_set: str, subscribe_mock: MagicMock, qtbot
 ) -> None:
     """Test the constructor."""
     with patch("finesse.gui.hardware_set.hardware_sets_view.settings") as settings_mock:
         settings_mock.value.return_value = selected_hw_set
-        load_hw_sets_mock.return_value = HW_SETS
+        get_hw_sets_mock.return_value = HW_SETS
         hw_sets = HardwareSetsControl()
         settings_mock.value.assert_called_once_with("hardware_set/selected")
         assert hw_sets._hardware_sets_combo.count() == 2

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -230,7 +230,7 @@ def test_on_device_opened(
         update_mock.assert_called_once_with()
         settings_mock.setValue.assert_has_calls(
             [
-                call(f"device/type/{device.instance.topic}", device.class_name),
+                call(f"device/type/{device.instance!s}", device.class_name),
                 call(f"device/params/{device.class_name}", device.params),
             ]
         )

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -40,37 +40,137 @@ HW_SETS = [
 
 
 @pytest.fixture
+@patch.object(HardwareSetsControl, "_update_control_state")
+@patch.object(HardwareSetsControl, "_load_last_selected_hardware_set")
 @patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
 def hw_sets(
-    get_hw_sets_mock: Mock, sendmsg_mock: MagicMock, subscribe_mock: MagicMock, qtbot
+    get_hw_sets_mock: Mock,
+    update_mock: Mock,
+    load_mock: Mock,
+    sendmsg_mock: MagicMock,
+    subscribe_mock: MagicMock,
+    qtbot,
 ) -> HardwareSetsControl:
     """A fixture for the control."""
-    get_hw_sets_mock.return_value = HW_SETS
+    get_hw_sets_mock.return_value = iter(HW_SETS)
     return HardwareSetsControl()
 
 
-@pytest.mark.parametrize("selected_hw_set", (hw_set.name for hw_set in HW_SETS))
-@patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
+@patch.object(HardwareSetsControl, "_load_hardware_set_list")
+@patch.object(HardwareSetsControl, "_update_control_state")
+@patch.object(HardwareSetsControl, "_load_last_selected_hardware_set")
 def test_init(
-    get_hw_sets_mock: Mock, selected_hw_set: str, subscribe_mock: MagicMock, qtbot
+    load_last_mock: Mock,
+    update_mock: Mock,
+    load_mock: Mock,
+    subscribe_mock: MagicMock,
+    qtbot,
 ) -> None:
     """Test the constructor."""
-    with patch("finesse.gui.hardware_set.hardware_sets_view.settings") as settings_mock:
-        settings_mock.value.return_value = selected_hw_set
-        get_hw_sets_mock.return_value = HW_SETS
-        hw_sets = HardwareSetsControl()
-        settings_mock.value.assert_called_once_with("hardware_set/selected")
-        assert hw_sets._hardware_sets_combo.count() == 2
-        assert hw_sets._hardware_sets_combo.currentText() == selected_hw_set
-        assert hw_sets._connect_btn.isEnabled()
-        assert not hw_sets._disconnect_btn.isEnabled()
+    hw_sets = HardwareSetsControl()
+    load_mock.assert_called_once_with()
+    load_last_mock.assert_called_once_with()
+    update_mock.assert_called_once_with()
 
-        subscribe_mock.assert_has_calls(
-            [
-                call(hw_sets._on_device_opened, "device.opening"),
-                call(hw_sets._on_device_closed, "device.closed"),
-            ]
-        )
+    subscribe_mock.assert_has_calls(
+        [
+            call(hw_sets._on_device_opened, "device.opening"),
+            call(hw_sets._on_device_closed, "device.closed"),
+            call(hw_sets._on_hardware_set_added, "hardware_set.added"),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "selected_hw_set,expected_selection",
+    ((None, "Test 1"), ("Test 1", "Test 1"), ("Test 2", "Test 2")),
+)
+@patch("finesse.gui.hardware_set.hardware_sets_view.settings")
+def test_load_last_selected_hardware_set(
+    settings_mock: Mock,
+    selected_hw_set: str,
+    expected_selection: str | None,
+    hw_sets: HardwareSetsControl,
+    qtbot,
+) -> None:
+    """Test the _load_last_selected_hardware_set() method."""
+    settings_mock.value.return_value = selected_hw_set
+    hw_sets._load_last_selected_hardware_set()
+    settings_mock.value.assert_called_once_with("hardware_set/selected")
+    assert hw_sets._hardware_sets_combo.currentText() == expected_selection
+
+
+@patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
+def test_load_hardware_set_list(
+    get_hw_sets_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+) -> None:
+    """Test the _load_hardware_set_list() method."""
+    get_hw_sets_mock.return_value = range(2)
+    with patch.object(hw_sets, "_add_hardware_set") as add_mock:
+        hw_sets._load_hardware_set_list()
+        add_mock.assert_has_calls((call(0), call(1)))
+
+
+@patch.object(HardwareSet, "load")
+@patch("finesse.gui.hardware_set.hardware_sets_view.show_error_message")
+@patch("finesse.gui.hardware_set.hardware_sets_view.QFileDialog.getOpenFileName")
+def test_import_hardware_set_success(
+    open_file_mock: Mock,
+    error_message_mock: Mock,
+    load_mock: Mock,
+    hw_sets: HardwareSetsControl,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _import_hardware_set() method when a file is loaded successfully."""
+    path = Path("dir/file.txt")
+    hw_set = MagicMock()
+    load_mock.return_value = hw_set
+    open_file_mock.return_value = (str(path), None)
+    hw_sets._import_hardware_set()
+    load_mock.assert_called_once_with(path)
+    sendmsg_mock.assert_called_once_with("hardware_set.add", hw_set=hw_set)
+    error_message_mock.assert_not_called()
+
+
+@patch.object(HardwareSet, "load")
+@patch("finesse.gui.hardware_set.hardware_sets_view.show_error_message")
+@patch("finesse.gui.hardware_set.hardware_sets_view.QFileDialog.getOpenFileName")
+def test_import_hardware_set_cancelled(
+    open_file_mock: Mock,
+    error_message_mock: Mock,
+    load_mock: Mock,
+    hw_sets: HardwareSetsControl,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _import_hardware_set() method when the dialog is closed."""
+    open_file_mock.return_value = (None, None)
+    hw_sets._import_hardware_set()
+    sendmsg_mock.assert_not_called()
+    error_message_mock.assert_not_called()
+    load_mock.assert_not_called()
+
+
+@patch.object(HardwareSet, "load")
+@patch("finesse.gui.hardware_set.hardware_sets_view.show_error_message")
+@patch("finesse.gui.hardware_set.hardware_sets_view.QFileDialog.getOpenFileName")
+def test_import_hardware_set_error(
+    open_file_mock: Mock,
+    error_message_mock: Mock,
+    load_mock: Mock,
+    hw_sets: HardwareSetsControl,
+    sendmsg_mock: MagicMock,
+    qtbot,
+) -> None:
+    """Test the _import_hardware_set() method when a file fails to load."""
+    path = Path("dir/file.txt")
+    load_mock.side_effect = RuntimeError
+    open_file_mock.return_value = (str(path), None)
+    hw_sets._import_hardware_set()
+    load_mock.assert_called_once_with(path)
+    sendmsg_mock.assert_not_called()
+    error_message_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -111,6 +211,32 @@ def test_add_hardware_set(
             hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
             hw_sets._add_hardware_set(hw_set)
             add_mock.assert_called_once_with(expected_name, hw_set)
+
+
+@patch.object(HardwareSetsControl, "_load_hardware_set_list")
+def test_on_hardware_set_added(
+    load_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+) -> None:
+    """Test the _on_hardware_set_added() method."""
+    with patch.object(hw_sets, "_hardware_sets_combo") as combo_mock:
+        combo_mock.itemData = lambda idx: HW_SETS[idx]
+        combo_mock.count.return_value = len(HW_SETS)
+        hw_sets._on_hardware_set_added(HW_SETS[1])
+        combo_mock.clear.assert_called_once_with()
+        load_mock.assert_called_once_with()
+        combo_mock.setCurrentIndex.assert_called_once_with(1)
+
+
+def test_current_hardware_set(hw_sets: HardwareSetsControl, qtbot) -> None:
+    """Test the current_hardware_set property."""
+    with patch.object(hw_sets._hardware_sets_combo, "currentData") as data_mock:
+        hw_set = MagicMock()
+        data_mock.return_value = hw_set
+        assert hw_sets.current_hardware_set is hw_set.devices
+
+        # Should also work if no hardware set is selected
+        data_mock.return_value = None
+        assert hw_sets.current_hardware_set == frozenset()
 
 
 DEVICES = [

--- a/tests/hardware/test_manage_devices.py
+++ b/tests/hardware/test_manage_devices.py
@@ -71,12 +71,12 @@ def test_open_device(
             sendmsg_mock.assert_has_calls(
                 [
                     call(
-                        f"device.opening.{instance.topic}",
+                        f"device.opening.{instance!s}",
                         instance=instance,
                         class_name=class_name,
                         params=params,
                     ),
-                    call(f"device.opened.{instance.topic}"),
+                    call(f"device.opened.{instance!s}"),
                 ]
             )
 
@@ -85,7 +85,7 @@ def test_open_device(
         else:
             assert not devices_dict
             sendmsg_mock.assert_called_once_with(
-                f"device.error.{instance.topic}", instance=instance, error=error
+                f"device.error.{instance!s}", instance=instance, error=error
             )
             logging_mock.error.assert_called()
 


### PR DESCRIPTION
This PR adds support for importing additional hardware set config files by clicking a button (#430). While a user could in theory write one of these config files by hand, the longer-term goal is to allow for creating and editing these files via a dialog (#393).

This required some extra functionality:

- A store for user hardware sets on disk and in memory, separate from the representation in the GUI
- The ability to load these imported config files automatically on program launch

I've also tried to be careful about validating the files; I added a schema to do this (#414). If a file fails to load, the program will notify the user, give them the option of moving it to the recycle bin and continue as normal. The reason for being so careful is that the format of these files may change between versions of FINESSE and it would suck if one of these old files caused the GUI to crash every time it was launched.

This PR is on the long side, I'm afraid, but two thirds of the change is added tests, so I hope that's ok!

Closes #430. Closes #414.

I think it closes #426 too, but that may be debatable :wink: 