### PR TITLE
Show fallback html page if user guide has not been generated

### DIFF
--- a/FINESSE.spec
+++ b/FINESSE.spec
@@ -15,6 +15,7 @@ a = Analysis(
         ("finesse/gui/images/*.png", "finesse/gui/images"),
         ("finesse/hardware/plugins/em27/diag_autom.htm", "finesse/hardware/plugins/em27"),
         ("docs/user_guide.html", "docs"),
+        ("docs/fallback.html", "docs"),
     ],
     hiddenimports=["finesse.gui.images", *load_all_plugins()],
     hookspath=[],

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ To get started:
 
 1. Build the user guide:
 
-   ```bash
-   python docs/gen_user_guide.py
-   ```
+   1. Install [pandoc](https://pandoc.org/installing.html)
+
+   1. ```bash
+      python docs/gen_user_guide.py
+      ```

--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ To get started:
    ```bash
    pytest
    ```
+
+1. Build the user guide:
+
+    ```bash
+    python docs/gen_user_guide.py
+    ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ To get started:
 
 1. Build the user guide:
 
-    ```bash
-    python docs/gen_user_guide.py
-    ```
+   ```bash
+   python docs/gen_user_guide.py
+   ```

--- a/docs/fallback.html
+++ b/docs/fallback.html
@@ -2,8 +2,7 @@
 <html>
   <body>
     <h1>FINESSE/UNIRAS User Guide</h1>
-    The user guide could not be located. Please run
-    <p><code>python docs/gen_user_guide.py</code></p>
-    to generate the user guide and try again.
+    The user guide could not be located. Please consult the developer documentation
+    on how to generate the user guide.
   </body>
 </html>

--- a/docs/fallback.html
+++ b/docs/fallback.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <body>
-    <h1 id="finesseuniras-user-guide">FINESSE/UNIRAS User Guide</h1>
+    <h1>FINESSE/UNIRAS User Guide</h1>
     The user guide could not be located. Please run
     <p><code>python docs/gen_user_guide.py</code></p>
     to generate the user guide and try again.

--- a/docs/fallback.html
+++ b/docs/fallback.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <h1 id="finesseuniras-user-guide">FINESSE/UNIRAS User Guide</h1>
+    The user guide could not be located. Please run
+    <p><code>python docs/gen_user_guide.py</code></p>
+    to generate the user guide and try again.
+  </body>
+</html>

--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -17,7 +17,7 @@ class DocsViewer(QAction):
         Args:
             parent: the menu on which to place the menu item
         """
-        super().__init__("Open user manual", parent)
+        super().__init__("Open user guide", parent)
         self.triggered.connect(self.show_docs)
 
     def show_docs(self) -> None:
@@ -32,7 +32,7 @@ class DocsViewer(QAction):
             A main window showing the html documentation.
         """
         docs_window = QMainWindow()
-        docs_window.setWindowTitle("FINESSE User Manual")
+        docs_window.setWindowTitle("User Guide")
 
         toolbar = QToolBar()
         toolbar.setMovable(False)

--- a/finesse/gui/docs_view.py
+++ b/finesse/gui/docs_view.py
@@ -44,7 +44,7 @@ class DocsViewer(QAction):
         docs_path = resources.files("docs")
         self.docs_home = Path(str(docs_path.joinpath("user_guide.html")))
         if not self.docs_home.exists():
-            raise FileNotFoundError("User guide not found.")
+            self.docs_home = Path(str(docs_path.joinpath("fallback.html")))
         self.browser = QWebEngineView()
         self._open_homepage()
         home_btn.triggered.connect(self._open_homepage)


### PR DESCRIPTION
This PR adds a new html document, `docs/fallback.html` to be shown if `docs/user_guide.html` cannot be found - the most likely scenario being that it hasn't been generated.

I thought this might be a nicer approach than opening a popup dialog, but that's just me. Happy to go down the dialog route if others prefer.

Closes #435 