### PR TITLE
Split combo box code out from `HardwareSetsControl`

### DIFF
--- a/finesse/gui/hardware_set/hardware_sets_combo_box.py
+++ b/finesse/gui/hardware_set/hardware_sets_combo_box.py
@@ -1,0 +1,86 @@
+"""Provides a combo box for choosing between hardware sets."""
+from pubsub import pub
+from PySide6.QtWidgets import QComboBox
+
+from finesse.gui.hardware_set.hardware_set import (
+    HardwareSet,
+    OpenDeviceArgs,
+    get_hardware_sets,
+)
+
+
+class HardwareSetsComboBox(QComboBox):
+    """A combo box for choosing between hardware sets."""
+
+    def __init__(self) -> None:
+        """Create a new HardwareSetsComboBox."""
+        super().__init__()
+        self._load_hardware_set_list()
+
+        pub.subscribe(self._on_hardware_set_added, "hardware_set.added")
+        pub.subscribe(self._load_hardware_set_list, "hardware_set.removed")
+
+    def _load_hardware_set_list(self) -> None:
+        """Populate the combo box with hardware sets."""
+        self.clear()
+        for hw_set in get_hardware_sets():
+            self._add_hardware_set(hw_set)
+
+    def _add_hardware_set(self, hw_set: HardwareSet) -> None:
+        """Add a new hardware set to the combo box."""
+        labels = {self.itemText(i) for i in range(self.count())}
+
+        name_root = hw_set.name
+        if hw_set.built_in:
+            name_root += " (built in)"
+
+        if name_root not in labels:
+            self.addItem(name_root, hw_set)
+            return
+
+        # If there is already a hardware set by that name, append a number
+        i = 2
+        while True:
+            name = f"{name_root} ({i})"
+            if name not in labels:
+                self.addItem(name, hw_set)
+                return
+            i += 1
+
+    def _on_hardware_set_added(self, hw_set: HardwareSet) -> None:
+        """Clear the combo box and refill it, then select hw_set.
+
+        The reason for clearing the combo box and refilling it is so that we can keep
+        the entries sorted.
+        """
+        self._load_hardware_set_list()
+
+        # Select the just-added hardware set
+        self.current_hardware_set = hw_set
+
+    @property
+    def current_hardware_set(self) -> HardwareSet | None:
+        """Return the currently selected hardware set.
+
+        Returns None if no item is selected.
+        """
+        return self.currentData()
+
+    @current_hardware_set.setter
+    def current_hardware_set(self, hw_set: HardwareSet) -> None:
+        try:
+            idx = next(i for i in range(self.count()) if self.itemData(i) is hw_set)
+        except StopIteration:
+            raise ValueError(f'Hardware set "{hw_set.name}" not found')
+        else:
+            self.setCurrentIndex(idx)
+
+    @property
+    def current_hardware_set_devices(self) -> frozenset[OpenDeviceArgs]:
+        """Return the currently selected hardware set's devices.
+
+        If the combo box is empty and, therefore, no hardware set is selected, an empty
+        set is returned.
+        """
+        hw_set = self.current_hardware_set
+        return hw_set.devices if hw_set else frozenset()

--- a/tests/gui/hardware_set/conftest.py
+++ b/tests/gui/hardware_set/conftest.py
@@ -1,0 +1,42 @@
+"""Configuration for hardware set tests."""
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
+
+_HW_SETS = (
+    HardwareSet(
+        "Test 1",
+        frozenset(
+            (
+                OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
+                OpenDeviceArgs.create(
+                    "temperature_monitor",
+                    "MyTemperatureMonitor",
+                    {"param1": "value1"},
+                ),
+            )
+        ),
+        Path("path/test.yaml"),
+        False,
+    ),
+    HardwareSet(
+        "Test 2",
+        frozenset(
+            (
+                OpenDeviceArgs.create("stepper_motor", "OtherStepperMotor"),
+                OpenDeviceArgs.create("temperature_monitor", "OtherTemperatureMonitor"),
+            )
+        ),
+        Path("path/test2.yaml"),
+        False,
+    ),
+)
+
+
+@pytest.fixture
+def hw_sets() -> Sequence[HardwareSet]:
+    """A fixture providing some HardwareSets."""
+    return _HW_SETS

--- a/tests/gui/hardware_set/test_hardware_sets_combo_box.py
+++ b/tests/gui/hardware_set/test_hardware_sets_combo_box.py
@@ -1,0 +1,136 @@
+"""Tests for the HardwareSetsComboBox class."""
+from collections.abc import Sequence
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
+
+import pytest
+
+from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
+from finesse.gui.hardware_set.hardware_sets_combo_box import HardwareSetsComboBox
+
+
+@pytest.fixture
+@patch("finesse.gui.hardware_set.hardware_sets_combo_box.get_hardware_sets")
+def combo(
+    get_hw_sets_mock: Mock, hw_sets: Sequence[HardwareSet], qtbot
+) -> HardwareSetsComboBox:
+    """A fixture for a combo box containing multiple hardware sets."""
+    get_hw_sets_mock.return_value = hw_sets
+    return HardwareSetsComboBox()
+
+
+@patch.object(HardwareSetsComboBox, "current_hardware_set", new_callable=PropertyMock)
+def test_on_hardware_set_added(
+    cur_hw_set_mock: PropertyMock,
+    combo: HardwareSetsComboBox,
+    hw_sets: Sequence[HardwareSet],
+    qtbot,
+) -> None:
+    """Test the _on_hardware_set_added() method."""
+    # combo = HardwareSetsComboBox()
+    with patch.object(combo, "_load_hardware_set_list") as load_mock:
+        combo._on_hardware_set_added(hw_sets[1])
+        load_mock.assert_called_once_with()
+        cur_hw_set_mock.assert_called_once_with(hw_sets[1])
+
+
+@patch("finesse.gui.hardware_set.hardware_sets_combo_box.get_hardware_sets")
+def test_load_hardware_set_list(
+    get_hw_sets_mock: Mock, combo: HardwareSetsComboBox, qtbot
+) -> None:
+    """Test the _load_hardware_set_list() method."""
+    get_hw_sets_mock.return_value = range(2)
+    with patch.object(combo, "_add_hardware_set") as add_mock:
+        combo._load_hardware_set_list()
+        add_mock.assert_has_calls((call(0), call(1)))
+
+
+_HW_SET = HardwareSet(
+    "Test 1",
+    frozenset(
+        (
+            OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
+            OpenDeviceArgs.create(
+                "temperature_monitor",
+                "MyTemperatureMonitor",
+                {"param1": "value1"},
+            ),
+        )
+    ),
+    Path("path/test.yaml"),
+    False,
+)
+
+
+@pytest.mark.parametrize(
+    "existing_hw_sets,hw_set_name,expected_name,built_in",
+    (
+        ((), _HW_SET.name, _HW_SET.name, False),
+        ((_HW_SET,), _HW_SET.name, f"{_HW_SET.name} (2)", False),
+        ((_HW_SET, _HW_SET), _HW_SET.name, f"{_HW_SET.name} (3)", False),
+        ((), _HW_SET.name, f"{_HW_SET.name} (built in)", True),
+        ((_HW_SET,), _HW_SET.name, f"{_HW_SET.name} (built in) (2)", True),
+        (
+            (_HW_SET, _HW_SET),
+            _HW_SET.name,
+            f"{_HW_SET.name} (built in) (3)",
+            True,
+        ),
+    ),
+)
+def test_add_hardware_set(
+    existing_hw_sets: Sequence[HardwareSet],
+    hw_set_name: str,
+    expected_name: str,
+    built_in: bool,
+    combo: HardwareSetsComboBox,
+    qtbot,
+) -> None:
+    """Test the _add_hardware_set() method."""
+    combo.clear()
+    for hw_set in existing_hw_sets:
+        hw_set = HardwareSet(hw_set.name, hw_set.devices, hw_set.file_path, built_in)
+        combo._add_hardware_set(hw_set)
+
+    with patch.object(combo, "addItem") as add_mock:
+        hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
+        combo._add_hardware_set(hw_set)
+        add_mock.assert_called_once_with(expected_name, hw_set)
+
+
+def test_get_current_hardware_set(combo: HardwareSetsComboBox, qtbot) -> None:
+    """Test getting the current_hardware_set property."""
+    hw_set = MagicMock()
+    with patch.object(combo, "currentData", return_value=hw_set):
+        assert combo.current_hardware_set == hw_set
+
+
+def test_set_current_hardware_set(
+    combo: HardwareSetsComboBox, hw_sets: Sequence[HardwareSet], qtbot
+) -> None:
+    """Test setting the current_hardware_set property."""
+    assert combo.currentIndex() == 0
+    combo.current_hardware_set = hw_sets[1]
+    assert combo.currentIndex() == 1
+
+
+def test_set_current_hardware_set_error(combo: HardwareSetsComboBox, qtbot) -> None:
+    """Test that current_hardware_set's setter raises an error if does not exist."""
+    with pytest.raises(ValueError):
+        combo.current_hardware_set = MagicMock()
+
+
+@patch.object(HardwareSetsComboBox, "current_hardware_set", new_callable=PropertyMock)
+def test_get_current_hardware_set_devices(
+    cur_hw_set_mock: PropertyMock, combo: HardwareSetsComboBox, qtbot
+) -> None:
+    """Test the current_hardware_set_devices property."""
+    # Check that it returns hw_set.devices for a valid hardware set
+    hw_set = MagicMock()
+    cur_hw_set_mock.return_value = hw_set
+    assert combo.current_hardware_set_devices == hw_set.devices
+
+    # Check that it returns an empty frozenset if no hardware set is selected
+    cur_hw_set_mock.reset_mock()
+    cur_hw_set_mock.return_value = None
+    assert combo.current_hardware_set_devices == frozenset()

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -9,50 +9,22 @@ import pytest
 from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
 from finesse.gui.hardware_set.hardware_sets_view import HardwareSetsControl
 
-HW_SETS = [
-    HardwareSet(
-        "Test 1",
-        frozenset(
-            (
-                OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
-                OpenDeviceArgs.create(
-                    "temperature_monitor",
-                    "MyTemperatureMonitor",
-                    {"param1": "value1"},
-                ),
-            )
-        ),
-        Path("path/test.yaml"),
-        False,
-    ),
-    HardwareSet(
-        "Test 2",
-        frozenset(
-            (
-                OpenDeviceArgs.create("stepper_motor", "OtherStepperMotor"),
-                OpenDeviceArgs.create("temperature_monitor", "OtherTemperatureMonitor"),
-            )
-        ),
-        Path("path/test2.yaml"),
-        False,
-    ),
-]
-
 
 @pytest.fixture
 @patch.object(HardwareSetsControl, "_update_control_state")
 @patch.object(HardwareSetsControl, "_load_last_selected_hardware_set")
 @patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
-def hw_sets(
+def hw_control(
     get_hw_sets_mock: Mock,
     update_mock: Mock,
     load_mock: Mock,
+    hw_sets: Sequence[HardwareSet],
     sendmsg_mock: MagicMock,
     subscribe_mock: MagicMock,
     qtbot,
 ) -> HardwareSetsControl:
     """A fixture for the control."""
-    get_hw_sets_mock.return_value = iter(HW_SETS)
+    get_hw_sets_mock.return_value = iter(hw_sets)
     return HardwareSetsControl()
 
 
@@ -92,24 +64,24 @@ def test_load_last_selected_hardware_set(
     settings_mock: Mock,
     selected_hw_set: str,
     expected_selection: str | None,
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     qtbot,
 ) -> None:
     """Test the _load_last_selected_hardware_set() method."""
     settings_mock.value.return_value = selected_hw_set
-    hw_sets._load_last_selected_hardware_set()
+    hw_control._load_last_selected_hardware_set()
     settings_mock.value.assert_called_once_with("hardware_set/selected")
-    assert hw_sets._hardware_sets_combo.currentText() == expected_selection
+    assert hw_control._hardware_sets_combo.currentText() == expected_selection
 
 
 @patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
 def test_load_hardware_set_list(
-    get_hw_sets_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+    get_hw_sets_mock: Mock, hw_control: HardwareSetsControl, qtbot
 ) -> None:
     """Test the _load_hardware_set_list() method."""
     get_hw_sets_mock.return_value = range(2)
-    with patch.object(hw_sets, "_add_hardware_set") as add_mock:
-        hw_sets._load_hardware_set_list()
+    with patch.object(hw_control, "_add_hardware_set") as add_mock:
+        hw_control._load_hardware_set_list()
         add_mock.assert_has_calls((call(0), call(1)))
 
 
@@ -120,7 +92,7 @@ def test_import_hardware_set_success(
     open_file_mock: Mock,
     error_message_mock: Mock,
     load_mock: Mock,
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     sendmsg_mock: MagicMock,
     qtbot,
 ) -> None:
@@ -129,7 +101,7 @@ def test_import_hardware_set_success(
     hw_set = MagicMock()
     load_mock.return_value = hw_set
     open_file_mock.return_value = (str(path), None)
-    hw_sets._import_hardware_set()
+    hw_control._import_hardware_set()
     load_mock.assert_called_once_with(path)
     sendmsg_mock.assert_called_once_with("hardware_set.add", hw_set=hw_set)
     error_message_mock.assert_not_called()
@@ -142,13 +114,13 @@ def test_import_hardware_set_cancelled(
     open_file_mock: Mock,
     error_message_mock: Mock,
     load_mock: Mock,
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     sendmsg_mock: MagicMock,
     qtbot,
 ) -> None:
     """Test the _import_hardware_set() method when the dialog is closed."""
     open_file_mock.return_value = (None, None)
-    hw_sets._import_hardware_set()
+    hw_control._import_hardware_set()
     sendmsg_mock.assert_not_called()
     error_message_mock.assert_not_called()
     load_mock.assert_not_called()
@@ -161,7 +133,7 @@ def test_import_hardware_set_error(
     open_file_mock: Mock,
     error_message_mock: Mock,
     load_mock: Mock,
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     sendmsg_mock: MagicMock,
     qtbot,
 ) -> None:
@@ -169,24 +141,41 @@ def test_import_hardware_set_error(
     path = Path("dir/file.txt")
     load_mock.side_effect = RuntimeError
     open_file_mock.return_value = (str(path), None)
-    hw_sets._import_hardware_set()
+    hw_control._import_hardware_set()
     load_mock.assert_called_once_with(path)
     sendmsg_mock.assert_not_called()
     error_message_mock.assert_called_once()
 
 
+_HW_SET = HardwareSet(
+    "Test 1",
+    frozenset(
+        (
+            OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
+            OpenDeviceArgs.create(
+                "temperature_monitor",
+                "MyTemperatureMonitor",
+                {"param1": "value1"},
+            ),
+        )
+    ),
+    Path("path/test.yaml"),
+    False,
+)
+
+
 @pytest.mark.parametrize(
     "existing_hw_sets,hw_set_name,expected_name,built_in",
     (
-        ((), HW_SETS[0].name, HW_SETS[0].name, False),
-        ((HW_SETS[0],), HW_SETS[0].name, f"{HW_SETS[0].name} (2)", False),
-        ((HW_SETS[0], HW_SETS[0]), HW_SETS[0].name, f"{HW_SETS[0].name} (3)", False),
-        ((), HW_SETS[0].name, f"{HW_SETS[0].name} (built in)", True),
-        ((HW_SETS[0],), HW_SETS[0].name, f"{HW_SETS[0].name} (built in) (2)", True),
+        ((), _HW_SET.name, _HW_SET.name, False),
+        ((_HW_SET,), _HW_SET.name, f"{_HW_SET.name} (2)", False),
+        ((_HW_SET, _HW_SET), _HW_SET.name, f"{_HW_SET.name} (3)", False),
+        ((), _HW_SET.name, f"{_HW_SET.name} (built in)", True),
+        ((_HW_SET,), _HW_SET.name, f"{_HW_SET.name} (built in) (2)", True),
         (
-            (HW_SETS[0], HW_SETS[0]),
-            HW_SETS[0].name,
-            f"{HW_SETS[0].name} (built in) (3)",
+            (_HW_SET, _HW_SET),
+            _HW_SET.name,
+            f"{_HW_SET.name} (built in) (3)",
             True,
         ),
     ),
@@ -196,48 +185,51 @@ def test_add_hardware_set(
     hw_set_name: str,
     expected_name: str,
     built_in: bool,
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     qtbot,
 ) -> None:
     """Test the _add_hardware_set() method."""
     # Patch this function, because it'll break if the combo box is empty
-    with patch.object(hw_sets, "_update_control_state"):
-        hw_sets._hardware_sets_combo.clear()
+    with patch.object(hw_control, "_update_control_state"):
+        hw_control._hardware_sets_combo.clear()
         for hw_set in existing_hw_sets:
             hw_set = HardwareSet(
                 hw_set.name, hw_set.devices, hw_set.file_path, built_in
             )
-            hw_sets._add_hardware_set(hw_set)
+            hw_control._add_hardware_set(hw_set)
 
-        with patch.object(hw_sets._hardware_sets_combo, "addItem") as add_mock:
+        with patch.object(hw_control._hardware_sets_combo, "addItem") as add_mock:
             hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
-            hw_sets._add_hardware_set(hw_set)
+            hw_control._add_hardware_set(hw_set)
             add_mock.assert_called_once_with(expected_name, hw_set)
 
 
 @patch.object(HardwareSetsControl, "_load_hardware_set_list")
 def test_on_hardware_set_added(
-    load_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+    load_mock: Mock,
+    hw_control: HardwareSetsControl,
+    hw_sets: Sequence[HardwareSet],
+    qtbot,
 ) -> None:
     """Test the _on_hardware_set_added() method."""
-    with patch.object(hw_sets, "_hardware_sets_combo") as combo_mock:
-        combo_mock.itemData = lambda idx: HW_SETS[idx]
-        combo_mock.count.return_value = len(HW_SETS)
-        hw_sets._on_hardware_set_added(HW_SETS[1])
+    with patch.object(hw_control, "_hardware_sets_combo") as combo_mock:
+        combo_mock.itemData = lambda idx: hw_sets[idx]
+        combo_mock.count.return_value = len(hw_sets)
+        hw_control._on_hardware_set_added(hw_sets[1])
         load_mock.assert_called_once_with()
         combo_mock.setCurrentIndex.assert_called_once_with(1)
 
 
-def test_current_hardware_set(hw_sets: HardwareSetsControl, qtbot) -> None:
+def test_current_hardware_set(hw_control: HardwareSetsControl, qtbot) -> None:
     """Test the current_hardware_set property."""
-    with patch.object(hw_sets._hardware_sets_combo, "currentData") as data_mock:
+    with patch.object(hw_control._hardware_sets_combo, "currentData") as data_mock:
         hw_set = MagicMock()
         data_mock.return_value = hw_set
-        assert hw_sets.current_hardware_set is hw_set.devices
+        assert hw_control.current_hardware_set is hw_set.devices
 
         # Should also work if no hardware set is selected
         data_mock.return_value = None
-        assert hw_sets.current_hardware_set == frozenset()
+        assert hw_control.current_hardware_set == frozenset()
 
 
 DEVICES = [
@@ -264,7 +256,7 @@ def test_update_control_state(
     disconnect_enabled: bool,
     connected_devices: Sequence[int],
     hardware_set: Sequence[int],
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     sendmsg_mock: MagicMock,
     qtbot,
 ) -> None:
@@ -276,15 +268,15 @@ def test_update_control_state(
     ) as hw_set_mock:
         hw_set_mock.return_value = _get_devices(hardware_set)
         with patch.object(
-            hw_sets, "_connected_devices", _get_devices(connected_devices)
+            hw_control, "_connected_devices", _get_devices(connected_devices)
         ):
             with patch.object(
-                hw_sets._connect_btn, "setEnabled"
+                hw_control._connect_btn, "setEnabled"
             ) as connect_enable_mock:
                 with patch.object(
-                    hw_sets._disconnect_btn, "setEnabled"
+                    hw_control._disconnect_btn, "setEnabled"
                 ) as disconnect_enable_mock:
-                    hw_sets._update_control_state()
+                    hw_control._update_control_state()
                     connect_enable_mock.assert_called_once_with(connect_enabled)
                     disconnect_enable_mock.assert_called_once_with(disconnect_enabled)
 
@@ -301,7 +293,7 @@ def test_connect_btn(
     connected_devices: Sequence[int],
     hardware_set: Sequence[int],
     open_called: Sequence[int],
-    hw_sets: HardwareSetsControl,
+    hw_control: HardwareSetsControl,
     qtbot,
 ) -> None:
     """Test the connect button."""
@@ -312,9 +304,9 @@ def test_connect_btn(
     ) as hw_set_mock:
         hw_set_mock.return_value = _get_devices(hardware_set)
         with patch.object(
-            hw_sets, "_connected_devices", _get_devices(connected_devices)
+            hw_control, "_connected_devices", _get_devices(connected_devices)
         ):
-            hw_sets._connect_btn.click()
+            hw_control._connect_btn.click()
 
             open_mock.assert_has_calls(
                 list(
@@ -331,29 +323,29 @@ def test_connect_btn(
 
 @patch("finesse.gui.hardware_set.hardware_set.close_device")
 def test_disconnect_button(
-    close_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+    close_mock: Mock, hw_control: HardwareSetsControl, qtbot
 ) -> None:
     """Test the disconnect button."""
-    with patch.object(hw_sets, "_update_control_state") as update_mock:
-        with patch.object(hw_sets, "_connected_devices", DEVICES):
-            hw_sets._disconnect_btn.setEnabled(True)
-            hw_sets._disconnect_btn.click()
+    with patch.object(hw_control, "_update_control_state") as update_mock:
+        with patch.object(hw_control, "_connected_devices", DEVICES):
+            hw_control._disconnect_btn.setEnabled(True)
+            hw_control._disconnect_btn.click()
             close_mock.assert_has_calls([call(device.instance) for device in DEVICES])
             update_mock.assert_called_once_with()
 
 
 @patch("finesse.gui.hardware_set.hardware_sets_view.settings")
 def test_on_device_opened(
-    settings_mock: Mock, hw_sets: HardwareSetsControl, qtbot
+    settings_mock: Mock, hw_control: HardwareSetsControl, qtbot
 ) -> None:
     """Test the _on_device_opened() method."""
     device = DEVICES[0]
-    assert not hw_sets._connected_devices
-    with patch.object(hw_sets, "_update_control_state") as update_mock:
-        hw_sets._on_device_opened(
+    assert not hw_control._connected_devices
+    with patch.object(hw_control, "_update_control_state") as update_mock:
+        hw_control._on_device_opened(
             instance=device.instance, class_name=device.class_name, params=device.params
         )
-        assert hw_sets._connected_devices == {device}
+        assert hw_control._connected_devices == {device}
         update_mock.assert_called_once_with()
         settings_mock.setValue.assert_has_calls(
             [
@@ -363,46 +355,46 @@ def test_on_device_opened(
         )
 
 
-def test_on_device_closed(hw_sets: HardwareSetsControl, qtbot) -> None:
+def test_on_device_closed(hw_control: HardwareSetsControl, qtbot) -> None:
     """Test the _on_device_closed() method."""
     device = DEVICES[0]
-    assert not hw_sets._connected_devices
-    with patch.object(hw_sets, "_update_control_state") as update_mock:
-        hw_sets._connected_devices.add(device)
-        hw_sets._on_device_closed(device.instance)
-        assert not hw_sets._connected_devices
+    assert not hw_control._connected_devices
+    with patch.object(hw_control, "_update_control_state") as update_mock:
+        hw_control._connected_devices.add(device)
+        hw_control._on_device_closed(device.instance)
+        assert not hw_control._connected_devices
         update_mock.assert_called_once_with()
 
 
-def test_on_device_closed_not_found(hw_sets: HardwareSetsControl, qtbot) -> None:
+def test_on_device_closed_not_found(hw_control: HardwareSetsControl, qtbot) -> None:
     """Test that _on_device_closed() does not raise an error if device is not found."""
     device = DEVICES[0]
-    assert not hw_sets._connected_devices
+    assert not hw_control._connected_devices
     with does_not_raise():
-        hw_sets._on_device_closed(device.instance)
+        hw_control._on_device_closed(device.instance)
 
 
-def test_show_manage_devices_dialog(hw_sets: HardwareSetsControl, qtbot) -> None:
+def test_show_manage_devices_dialog(hw_control: HardwareSetsControl, qtbot) -> None:
     """Test the _show_manage_devices_dialog() method."""
     # Check that the dialog is created if it doesn't exist
-    assert not hasattr(hw_sets, "_manage_devices_dialog")
-    hw_sets._show_manage_devices_dialog()
-    dialog = hw_sets._manage_devices_dialog
+    assert not hasattr(hw_control, "_manage_devices_dialog")
+    hw_control._show_manage_devices_dialog()
+    dialog = hw_control._manage_devices_dialog
     assert not dialog.isHidden()
 
     # If it already exists, check it is shown
     dialog.hide()
-    hw_sets._show_manage_devices_dialog()
+    hw_control._show_manage_devices_dialog()
     assert not dialog.isHidden()
-    assert hw_sets._manage_devices_dialog is dialog
+    assert hw_control._manage_devices_dialog is dialog
 
 
 def test_remove_hw_set_btn(
-    hw_sets: HardwareSetsControl, sendmsg_mock: Mock, qtbot
+    hw_control: HardwareSetsControl, sendmsg_mock: Mock, qtbot
 ) -> None:
     """Test that _remove_hw_set_btn works."""
-    with patch.object(hw_sets._hardware_sets_combo, "currentData") as data_mock:
+    with patch.object(hw_control._hardware_sets_combo, "currentData") as data_mock:
         hw_set = MagicMock()
         data_mock.return_value = hw_set
-        hw_sets._remove_hw_set_btn.click()
+        hw_control._remove_hw_set_btn.click()
         sendmsg_mock.assert_called_once_with("hardware_set.remove", hw_set=hw_set)

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -189,19 +189,15 @@ def test_add_hardware_set(
     qtbot,
 ) -> None:
     """Test the _add_hardware_set() method."""
-    # Patch this function, because it'll break if the combo box is empty
-    with patch.object(hw_control, "_update_control_state"):
-        hw_control._hardware_sets_combo.clear()
-        for hw_set in existing_hw_sets:
-            hw_set = HardwareSet(
-                hw_set.name, hw_set.devices, hw_set.file_path, built_in
-            )
-            hw_control._add_hardware_set(hw_set)
+    hw_control._hardware_sets_combo.clear()
+    for hw_set in existing_hw_sets:
+        hw_set = HardwareSet(hw_set.name, hw_set.devices, hw_set.file_path, built_in)
+        hw_control._add_hardware_set(hw_set)
 
-        with patch.object(hw_control._hardware_sets_combo, "addItem") as add_mock:
-            hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
-            hw_control._add_hardware_set(hw_set)
-            add_mock.assert_called_once_with(expected_name, hw_set)
+    with patch.object(hw_control._hardware_sets_combo, "addItem") as add_mock:
+        hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
+        hw_control._add_hardware_set(hw_set)
+        add_mock.assert_called_once_with(expected_name, hw_set)
 
 
 @patch.object(HardwareSetsControl, "_load_hardware_set_list")

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -7,82 +7,92 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 import pytest
 
 from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
-from finesse.gui.hardware_set.hardware_sets_view import HardwareSetsControl
+from finesse.gui.hardware_set.hardware_sets_view import (
+    HardwareSetsControl,
+    _get_last_selected_hardware_set,
+)
 
 
 @pytest.fixture
 @patch.object(HardwareSetsControl, "_update_control_state")
-@patch.object(HardwareSetsControl, "_load_last_selected_hardware_set")
+@patch("finesse.gui.hardware_set.hardware_sets_view._get_last_selected_hardware_set")
 @patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
 def hw_control(
     get_hw_sets_mock: Mock,
+    last_selected_mock: Mock,
     update_mock: Mock,
-    load_mock: Mock,
     hw_sets: Sequence[HardwareSet],
     sendmsg_mock: MagicMock,
     subscribe_mock: MagicMock,
     qtbot,
 ) -> HardwareSetsControl:
     """A fixture for the control."""
-    get_hw_sets_mock.return_value = iter(hw_sets)
+    last_selected_mock.return_value = None
+    get_hw_sets_mock.return_value = hw_sets
     return HardwareSetsControl()
 
 
-@patch.object(HardwareSetsControl, "_load_hardware_set_list")
+@pytest.mark.parametrize("last_selected", (None, "some/path.yaml"))
+@patch(
+    "finesse.gui.hardware_set.hardware_sets_view"
+    ".HardwareSetsComboBox.current_hardware_set",
+    new_callable=PropertyMock,
+)
 @patch.object(HardwareSetsControl, "_update_control_state")
-@patch.object(HardwareSetsControl, "_load_last_selected_hardware_set")
+@patch("finesse.gui.hardware_set.hardware_sets_view._get_last_selected_hardware_set")
 def test_init(
     load_last_mock: Mock,
     update_mock: Mock,
-    load_mock: Mock,
+    cur_hw_set_mock: PropertyMock,
+    last_selected: str | None,
     subscribe_mock: MagicMock,
     qtbot,
 ) -> None:
     """Test the constructor."""
+    load_last_mock.return_value = last_selected
     hw_sets = HardwareSetsControl()
-    load_mock.assert_called_once_with()
     load_last_mock.assert_called_once_with()
     update_mock.assert_called_once_with()
+    if last_selected:
+        cur_hw_set_mock.assert_called_once()
+    else:
+        cur_hw_set_mock.assert_not_called()
 
-    subscribe_mock.assert_has_calls(
-        (
-            call(hw_sets._on_device_opened, "device.opening"),
-            call(hw_sets._on_device_closed, "device.closed"),
-            call(hw_sets._on_hardware_set_added, "hardware_set.added"),
-            call(hw_sets._load_hardware_set_list, "hardware_set.removed"),
-        ),
-        any_order=True,
-    )
-
-
-@pytest.mark.parametrize(
-    "selected_hw_set,expected_selection",
-    ((None, "Test 1"), ("Test 1", "Test 1"), ("Test 2", "Test 2")),
-)
-@patch("finesse.gui.hardware_set.hardware_sets_view.settings")
-def test_load_last_selected_hardware_set(
-    settings_mock: Mock,
-    selected_hw_set: str,
-    expected_selection: str | None,
-    hw_control: HardwareSetsControl,
-    qtbot,
-) -> None:
-    """Test the _load_last_selected_hardware_set() method."""
-    settings_mock.value.return_value = selected_hw_set
-    hw_control._load_last_selected_hardware_set()
-    settings_mock.value.assert_called_once_with("hardware_set/selected")
-    assert hw_control._combo.currentText() == expected_selection
+    # HardwareSetsComboBox's constructor will also call pub.subscribe
+    subscribe_mock.assert_any_call(hw_sets._on_device_opened, "device.opening")
+    subscribe_mock.assert_any_call(hw_sets._on_device_closed, "device.closed")
 
 
 @patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
-def test_load_hardware_set_list(
-    get_hw_sets_mock: Mock, hw_control: HardwareSetsControl, qtbot
+@patch("finesse.gui.hardware_set.hardware_sets_view.settings")
+def test_get_last_selected_hardware_set_cached_success(
+    settings_mock: Mock, get_hw_sets_mock: Mock, hw_sets: Sequence[HardwareSet], qtbot
 ) -> None:
-    """Test the _load_hardware_set_list() method."""
-    get_hw_sets_mock.return_value = range(2)
-    with patch.object(hw_control, "_add_hardware_set") as add_mock:
-        hw_control._load_hardware_set_list()
-        add_mock.assert_has_calls((call(0), call(1)))
+    """Test _get_last_selected_hardware_set() when there is a valid value cached."""
+    get_hw_sets_mock.return_value = hw_sets[0:1]
+    settings_mock.value.return_value = str(hw_sets[0].file_path)
+    assert _get_last_selected_hardware_set() is hw_sets[0]
+    settings_mock.value.assert_called_once_with("hardware_set/selected")
+
+
+@patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
+@patch("finesse.gui.hardware_set.hardware_sets_view.settings")
+def test_get_last_selected_hardware_set_cached_fail(
+    settings_mock: Mock, get_hw_sets_mock: Mock, hw_sets: Sequence[HardwareSet], qtbot
+) -> None:
+    """Test _get_last_selected_hardware_set() with an unknown path cached."""
+    get_hw_sets_mock.return_value = hw_sets[0:1]
+    settings_mock.value.return_value = str(hw_sets[1].file_path)
+    assert _get_last_selected_hardware_set() is None
+    settings_mock.value.assert_called_once_with("hardware_set/selected")
+
+
+@patch("finesse.gui.hardware_set.hardware_sets_view.settings")
+def test_get_last_selected_hardware_set_no_cached(settings_mock: Mock, qtbot) -> None:
+    """Test _get_last_selected_hardware_set() when no value is cached."""
+    settings_mock.value.return_value = None
+    assert _get_last_selected_hardware_set() is None
+    settings_mock.value.assert_called_once_with("hardware_set/selected")
 
 
 @patch.object(HardwareSet, "load")
@@ -147,87 +157,6 @@ def test_import_hardware_set_error(
     error_message_mock.assert_called_once()
 
 
-_HW_SET = HardwareSet(
-    "Test 1",
-    frozenset(
-        (
-            OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),
-            OpenDeviceArgs.create(
-                "temperature_monitor",
-                "MyTemperatureMonitor",
-                {"param1": "value1"},
-            ),
-        )
-    ),
-    Path("path/test.yaml"),
-    False,
-)
-
-
-@pytest.mark.parametrize(
-    "existing_hw_sets,hw_set_name,expected_name,built_in",
-    (
-        ((), _HW_SET.name, _HW_SET.name, False),
-        ((_HW_SET,), _HW_SET.name, f"{_HW_SET.name} (2)", False),
-        ((_HW_SET, _HW_SET), _HW_SET.name, f"{_HW_SET.name} (3)", False),
-        ((), _HW_SET.name, f"{_HW_SET.name} (built in)", True),
-        ((_HW_SET,), _HW_SET.name, f"{_HW_SET.name} (built in) (2)", True),
-        (
-            (_HW_SET, _HW_SET),
-            _HW_SET.name,
-            f"{_HW_SET.name} (built in) (3)",
-            True,
-        ),
-    ),
-)
-def test_add_hardware_set(
-    existing_hw_sets: Sequence[HardwareSet],
-    hw_set_name: str,
-    expected_name: str,
-    built_in: bool,
-    hw_control: HardwareSetsControl,
-    qtbot,
-) -> None:
-    """Test the _add_hardware_set() method."""
-    hw_control._combo.clear()
-    for hw_set in existing_hw_sets:
-        hw_set = HardwareSet(hw_set.name, hw_set.devices, hw_set.file_path, built_in)
-        hw_control._add_hardware_set(hw_set)
-
-    with patch.object(hw_control._combo, "addItem") as add_mock:
-        hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
-        hw_control._add_hardware_set(hw_set)
-        add_mock.assert_called_once_with(expected_name, hw_set)
-
-
-@patch.object(HardwareSetsControl, "_load_hardware_set_list")
-def test_on_hardware_set_added(
-    load_mock: Mock,
-    hw_control: HardwareSetsControl,
-    hw_sets: Sequence[HardwareSet],
-    qtbot,
-) -> None:
-    """Test the _on_hardware_set_added() method."""
-    with patch.object(hw_control, "_combo") as combo_mock:
-        combo_mock.itemData = lambda idx: hw_sets[idx]
-        combo_mock.count.return_value = len(hw_sets)
-        hw_control._on_hardware_set_added(hw_sets[1])
-        load_mock.assert_called_once_with()
-        combo_mock.setCurrentIndex.assert_called_once_with(1)
-
-
-def test_current_hardware_set(hw_control: HardwareSetsControl, qtbot) -> None:
-    """Test the current_hardware_set property."""
-    with patch.object(hw_control._combo, "currentData") as data_mock:
-        hw_set = MagicMock()
-        data_mock.return_value = hw_set
-        assert hw_control.current_hardware_set is hw_set.devices
-
-        # Should also work if no hardware set is selected
-        data_mock.return_value = None
-        assert hw_control.current_hardware_set == frozenset()
-
-
 DEVICES = [
     OpenDeviceArgs.create(f"type{i}", f"class{i}", {"my_param": "my_value"})
     for i in range(2)
@@ -259,7 +188,7 @@ def test_update_control_state(
     """Test the _update_control_state() method."""
     with patch(
         "finesse.gui.hardware_set.hardware_sets_view"
-        ".HardwareSetsControl.current_hardware_set",
+        ".HardwareSetsComboBox.current_hardware_set_devices",
         new_callable=PropertyMock,
     ) as hw_set_mock:
         hw_set_mock.return_value = _get_devices(hardware_set)
@@ -293,27 +222,25 @@ def test_connect_btn(
     qtbot,
 ) -> None:
     """Test the connect button."""
-    with patch(
-        "finesse.gui.hardware_set.hardware_sets_view"
-        ".HardwareSetsControl.current_hardware_set",
-        new_callable=PropertyMock,
-    ) as hw_set_mock:
-        hw_set_mock.return_value = _get_devices(hardware_set)
+    file_path = Path("path/test.yaml")
+    with patch.object(hw_control, "_combo") as combo_mock:
+        combo_mock.current_hardware_set_devices = _get_devices(hardware_set)
+        combo_mock.current_hardware_set.file_path = file_path
         with patch.object(
             hw_control, "_connected_devices", _get_devices(connected_devices)
         ):
             hw_control._connect_btn.click()
 
             open_mock.assert_has_calls(
-                list(
+                [
                     call(dev.class_name, dev.instance, dev.params)
                     for dev in _get_devices(open_called)
-                ),
+                ],
                 any_order=True,
             )
 
             settings_mock.setValue.assert_called_once_with(
-                "hardware_set/selected", "Test 1"
+                "hardware_set/selected", str(file_path)
             )
 
 

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -71,7 +71,7 @@ def test_load_last_selected_hardware_set(
     settings_mock.value.return_value = selected_hw_set
     hw_control._load_last_selected_hardware_set()
     settings_mock.value.assert_called_once_with("hardware_set/selected")
-    assert hw_control._hardware_sets_combo.currentText() == expected_selection
+    assert hw_control._combo.currentText() == expected_selection
 
 
 @patch("finesse.gui.hardware_set.hardware_sets_view.get_hardware_sets")
@@ -189,12 +189,12 @@ def test_add_hardware_set(
     qtbot,
 ) -> None:
     """Test the _add_hardware_set() method."""
-    hw_control._hardware_sets_combo.clear()
+    hw_control._combo.clear()
     for hw_set in existing_hw_sets:
         hw_set = HardwareSet(hw_set.name, hw_set.devices, hw_set.file_path, built_in)
         hw_control._add_hardware_set(hw_set)
 
-    with patch.object(hw_control._hardware_sets_combo, "addItem") as add_mock:
+    with patch.object(hw_control._combo, "addItem") as add_mock:
         hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
         hw_control._add_hardware_set(hw_set)
         add_mock.assert_called_once_with(expected_name, hw_set)
@@ -208,7 +208,7 @@ def test_on_hardware_set_added(
     qtbot,
 ) -> None:
     """Test the _on_hardware_set_added() method."""
-    with patch.object(hw_control, "_hardware_sets_combo") as combo_mock:
+    with patch.object(hw_control, "_combo") as combo_mock:
         combo_mock.itemData = lambda idx: hw_sets[idx]
         combo_mock.count.return_value = len(hw_sets)
         hw_control._on_hardware_set_added(hw_sets[1])
@@ -218,7 +218,7 @@ def test_on_hardware_set_added(
 
 def test_current_hardware_set(hw_control: HardwareSetsControl, qtbot) -> None:
     """Test the current_hardware_set property."""
-    with patch.object(hw_control._hardware_sets_combo, "currentData") as data_mock:
+    with patch.object(hw_control._combo, "currentData") as data_mock:
         hw_set = MagicMock()
         data_mock.return_value = hw_set
         assert hw_control.current_hardware_set is hw_set.devices
@@ -389,7 +389,7 @@ def test_remove_hw_set_btn(
     hw_control: HardwareSetsControl, sendmsg_mock: Mock, qtbot
 ) -> None:
     """Test that _remove_hw_set_btn works."""
-    with patch.object(hw_control._hardware_sets_combo, "currentData") as data_mock:
+    with patch.object(hw_control._combo, "currentData") as data_mock:
         hw_set = MagicMock()
         data_mock.return_value = hw_set
         hw_control._remove_hw_set_btn.click()


### PR DESCRIPTION
This PR contains some refactoring I did as a precursor to #393. Although we've decided to park that issue for now, I think this refactoring makes sense by itself and didn't want to lose the work already done on it.