### PR TITLE
Unify opus message types

### DIFF
--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -127,9 +127,7 @@ class ScriptControl(QGroupBox):
         self.run_dialog.hide()
         del self.run_dialog
 
-    def _on_opus_message(
-        self, status: EM27Status, text: str, error: tuple[int, str] | None
-    ) -> None:
+    def _on_opus_message(self, status: EM27Status, text: str) -> None:
         """Increase/decrease the enable counter when the EM27 connects/disconnects."""
         if status.is_connected == self._opus_connected:
             # The connection status hasn't changed

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -113,10 +113,6 @@ class OPUSControl(QGroupBox):
         """
         pub.sendMessage("opus.request", command=command)
 
-    def _request_status(self) -> None:
-        self.logger.info("Requesting status")
-        pub.sendMessage("opus.request", command="status")
-
 
 class OPUSLogHandler(logging.Handler):
     """Specific logger for the errors related to OPUS.

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -96,11 +96,8 @@ class OPUSControl(QGroupBox):
         self,
         status: EM27Status,
         text: str,
-        error: tuple[int, str] | None,
     ) -> None:
         self.logger.info(f"Response ({status.value}): {text}")
-        if error:
-            self.logger.error(f"Error ({error[0]}): {error[1]}")
 
     def _log_error(self, error: BaseException) -> None:
         self.logger.error(f"Error during request: {str(error)}")

--- a/finesse/hardware/plugins/em27/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/em27/dummy_opus_interface.py
@@ -13,7 +13,7 @@ from finesse.em27_info import EM27Status
 from finesse.hardware.plugins.em27.opus_interface_base import OPUSInterfaceBase
 
 
-class OPUSError(Enum):
+class OPUSErrorInfo(Enum):
     """Represents an error code and description for OPUS errors.
 
     The codes and descriptions are taken from the manual.
@@ -33,7 +33,7 @@ class OPUSError(Enum):
 
     def to_tuple(self) -> tuple[int, str] | None:
         """Convert to a (code, message) tuple or None if no error."""
-        if self == OPUSError.NO_ERROR:
+        if self == OPUSErrorInfo.NO_ERROR:
             return None
         return self.value
 
@@ -111,10 +111,10 @@ class DummyOPUSInterface(OPUSInterfaceBase):
     """A mock version of the OPUS API for testing purposes."""
 
     _COMMAND_ERRORS = {
-        "cancel": OPUSError.NOT_RUNNING,
-        "stop": OPUSError.NOT_RUNNING_OR_FINISHING,
-        "start": OPUSError.NOT_CONNECTED,
-        "connect": OPUSError.NOT_IDLE,
+        "cancel": OPUSErrorInfo.NOT_RUNNING,
+        "stop": OPUSErrorInfo.NOT_RUNNING_OR_FINISHING,
+        "start": OPUSErrorInfo.NOT_CONNECTED,
+        "connect": OPUSErrorInfo.NOT_IDLE,
     }
     """The error thrown by each command when in an invalid state."""
 
@@ -126,7 +126,7 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         """
         super().__init__()
 
-        self.last_error = OPUSError.NO_ERROR
+        self.last_error = OPUSErrorInfo.NO_ERROR
         """The last error which occurred."""
         self.state_machine = OPUSStateMachine(
             measure_duration, self._measuring_finished
@@ -143,7 +143,7 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         """
         fun = getattr(self.state_machine, command)
 
-        self.last_error = OPUSError.NO_ERROR
+        self.last_error = OPUSErrorInfo.NO_ERROR
         try:
             fun()
         except TransitionNotAllowed:
@@ -160,11 +160,11 @@ class DummyOPUSInterface(OPUSInterfaceBase):
         """
         if command == "status":
             if self.state_machine.current_state == OPUSStateMachine.idle:
-                self.last_error = OPUSError.NOT_CONNECTED
+                self.last_error = OPUSErrorInfo.NOT_CONNECTED
         elif command in self._COMMAND_ERRORS:
             self._run_command(command)
         else:
-            self.last_error = OPUSError.UNKNOWN_COMMAND
+            self.last_error = OPUSErrorInfo.UNKNOWN_COMMAND
 
         # Broadcast the response for the command
         state = self.state_machine.current_state
@@ -177,5 +177,5 @@ class DummyOPUSInterface(OPUSInterfaceBase):
 
     def _measuring_finished(self) -> None:
         """Finish measurement successfully."""
-        self.last_error = OPUSError.NO_ERROR
+        self.last_error = OPUSErrorInfo.NO_ERROR
         logging.info("Measurement complete")

--- a/finesse/hardware/plugins/em27/opus_interface_base.py
+++ b/finesse/hardware/plugins/em27/opus_interface_base.py
@@ -1,9 +1,22 @@
 """Provides a base class for interfacing with the OPUS program."""
+from __future__ import annotations
+
 import logging
 import traceback
 from abc import ABC, abstractmethod
 
 from pubsub import pub
+
+from finesse.em27_info import EM27Status
+
+
+class OPUSError(Exception):
+    """Indicates that an error occurred with an OPUS device."""
+
+    @classmethod
+    def from_response(cls, errcode: int, errtext: str) -> OPUSError:
+        """Create an OPUSError from the information given in the device response."""
+        return cls(f"Error {errcode}: {errtext}")
 
 
 class OPUSInterfaceBase(ABC):
@@ -24,6 +37,11 @@ class OPUSInterfaceBase(ABC):
         Args:
             command: Name of command to run
         """
+
+    @staticmethod
+    def send_response(command: str, status: EM27Status, text: str) -> None:
+        """Broadcast the device's response via pubsub."""
+        pub.sendMessage(f"opus.response.{command}", status=status, text=text)
 
     @staticmethod
     def error_occurred(error: BaseException) -> None:

--- a/tests/gui/measure_script/test_script_view.py
+++ b/tests/gui/measure_script/test_script_view.py
@@ -281,7 +281,7 @@ def test_on_opus_message_connect(
     script_control._opus_connected = already_connected
 
     with patch.object(script_control, "_enable_counter") as counter_mock:
-        script_control._on_opus_message(status, "", None)
+        script_control._on_opus_message(status, "")
         if already_connected:
             counter_mock.increment.assert_not_called()
         else:
@@ -304,7 +304,7 @@ def test_on_opus_message_disconnect(
     script_control._opus_connected = already_connected
 
     with patch.object(script_control, "_enable_counter") as counter_mock:
-        script_control._on_opus_message(status, "", None)
+        script_control._on_opus_message(status, "")
         if not already_connected:
             counter_mock.decrement.assert_not_called()
         else:

--- a/tests/hardware/plugins/em27/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/em27/test_dummy_opus_interface.py
@@ -1,6 +1,5 @@
 """Tests for DummyOPUSInterface."""
 
-from itertools import product
 from typing import cast
 from unittest.mock import MagicMock, Mock, patch
 
@@ -38,43 +37,40 @@ def test_finish_measuring(dev: DummyOPUSInterface) -> None:
     assert dev.last_error == OPUSErrorInfo.NO_ERROR
 
 
-@pytest.mark.parametrize("state,error", product(OPUSStateMachine.states, OPUSErrorInfo))
-def test_request_status(
-    state: State,
-    error: OPUSErrorInfo,
-    dev: DummyOPUSInterface,
-    sendmsg_mock: MagicMock,
-) -> None:
+@pytest.mark.parametrize(
+    "state",
+    (state for state in OPUSStateMachine.states if state != OPUSStateMachine.idle),
+)
+def test_request_status(state: State, dev: DummyOPUSInterface) -> None:
     """Test the request_status() method."""
-    dev.last_error = error
     dev.state_machine.current_state = state
 
-    dev.request_command("status")
-    sendmsg_mock.assert_called_once_with(
-        "opus.response.status",
-        status=state.value,
-        text=state.name,
-        error=OPUSErrorInfo.NOT_CONNECTED.to_tuple()
-        if state == OPUSStateMachine.idle
-        else error.to_tuple(),
-    )
+    with patch.object(dev, "send_response") as response_mock:
+        dev.request_command("status")
+        response_mock.assert_called_once_with(
+            "status", status=state.value, text=state.name
+        )
+
+
+def test_request_status_idle(dev: DummyOPUSInterface) -> None:
+    """Test the request_status() method raises an error if device not connected."""
+    dev.state_machine.current_state = OPUSStateMachine.idle
+
+    with patch.object(dev, "error_occurred") as error_mock:
+        dev.request_command("status")
+        error_mock.assert_called_once()
 
 
 _COMMANDS = (
-    ("cancel", OPUSStateMachine.measuring, OPUSErrorInfo.NOT_RUNNING, "stop"),
-    (
-        "stop",
-        OPUSStateMachine.measuring,
-        OPUSErrorInfo.NOT_RUNNING_OR_FINISHING,
-        "stop",
-    ),
-    ("start", OPUSStateMachine.connected, OPUSErrorInfo.NOT_CONNECTED, "start"),
-    ("connect", OPUSStateMachine.idle, OPUSErrorInfo.NOT_IDLE, None),
+    ("cancel", OPUSStateMachine.measuring, "stop"),
+    ("stop", OPUSStateMachine.measuring, "stop"),
+    ("start", OPUSStateMachine.connected, "start"),
+    ("connect", OPUSStateMachine.idle, None),
 )
 
 
 @pytest.mark.parametrize(
-    "command,required_state,error,timer_command,initial_state",
+    "command,required_state,timer_command,initial_state",
     (
         (
             *command,
@@ -87,48 +83,37 @@ _COMMANDS = (
 def test_request_command(
     command: str,
     required_state: State,
-    error: OPUSErrorInfo,
     timer_command: str | None,
     initial_state: State,
     dev: DummyOPUSInterface,
-    sendmsg_mock: MagicMock,
 ) -> None:
     """Test the request_command() method."""
     with patch.object(dev.state_machine, "measure_timer") as timer_mock:
-        dev.state_machine.current_state = initial_state
+        with patch.object(dev, "send_response") as response_mock:
+            with patch.object(dev, "error_occurred") as error_mock:
+                dev.state_machine.current_state = initial_state
+                dev.request_command(command)
 
-        dev.request_command(command)
+    if initial_state != required_state:
+        # Check the error was broadcast
+        error_mock.assert_called_once()
+        response_mock.assert_not_called()
+        return
 
-        if initial_state == required_state:
-            # If we're in the required state, no error should occur
-            assert dev.last_error == OPUSErrorInfo.NO_ERROR
+    # Check that no error was thrown
+    error_mock.assert_not_called()
 
-            # Check that the right thing has been done to the timer
-            if timer_command:
-                getattr(timer_mock, timer_command).assert_called_once()
-        else:
-            assert dev.last_error == error
-
-        # Check that the right response message was sent
-        state = dev.state_machine.current_state
-        sendmsg_mock.assert_called_once_with(
-            f"opus.response.{command}",
-            status=state.value,
-            text=state.name,
-            error=dev.last_error.to_tuple(),
-        )
-
-
-def test_request_command_bad_command(
-    dev: DummyOPUSInterface, sendmsg_mock: MagicMock
-) -> None:
-    """Check that request_command() handles non-existent commands correctly."""
-    dev.request_command("non_existent_command")
-
+    # Check that the right response message was sent
     state = dev.state_machine.current_state
-    sendmsg_mock.assert_called_once_with(
-        "opus.response.non_existent_command",
-        status=state.value,
-        text=state.name,
-        error=OPUSErrorInfo.UNKNOWN_COMMAND.to_tuple(),
-    )
+    response_mock.assert_called_once_with(command, status=state.value, text=state.name)
+
+    # Check that the right thing has been done to the timer
+    if timer_command:
+        getattr(timer_mock, timer_command).assert_called_once()
+
+
+def test_request_command_bad_command(dev: DummyOPUSInterface) -> None:
+    """Check that request_command() handles non-existent commands correctly."""
+    with patch.object(dev, "error_occurred") as error_mock:
+        dev.request_command("non_existent_command")
+        error_mock.assert_called_once()


### PR DESCRIPTION
This PR removes the `error` arg from `opus.response` messages. Instead, all errors are now broadcast via the `opus.error` topic. This is a preliminary step towards making the spectrometer interface more generic.

I think the fact that this PR removes lines shows that this is a cleaner approach!

Closes #147.