### PR TITLE
Convert OPUS devices to plugins

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,14 +10,6 @@
             "request": "launch",
             "module": "finesse",
             "justMyCode": true
-        },
-        {
-            "name": "FINESSE (dummy EM27)",
-            "type": "python",
-            "request": "launch",
-            "module": "finesse",
-            "args": ["--dummy-em27"],
-            "justMyCode": true
         }
     ]
 }

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -68,6 +68,9 @@ TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
 OPUS_IP = "10.10.0.2"
 """The IP address of the machine running the OPUS software."""
 
+OPUS_TOPIC = "opus"
+"""The topic name to use for OPUS-related messages."""
+
 TEMPERATURE_CONTROLLER_POLL_INTERVAL = 2
 """Number of seconds between temperature controller device reads."""
 

--- a/finesse/gui/device_panel.py
+++ b/finesse/gui/device_panel.py
@@ -23,7 +23,7 @@ class DevicePanel(QGroupBox):
         cls.__init__ = init_decorator(cls.__init__)
 
     def __init__(self, name: str, title: str, *args: Any, **kwargs: Any) -> None:
-        """Create a new SerialDevicePanel.
+        """Create a new DevicePanel.
 
         The controls will be disabled initially.
 

--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -215,7 +215,7 @@ class DeviceTypeControl(QGroupBox):
 
         # pubsub subscriptions
         pub.subscribe(self._on_device_opened, f"device.opening.{instance!s}")
-        pub.subscribe(self._set_device_closed, f"device.closed.{instance!s}")
+        pub.subscribe(self._on_device_closed, f"device.closed.{instance!s}")
 
     def _update_open_btn_enabled_state(self) -> None:
         """Enable button depending on whether there are options for all params.
@@ -274,7 +274,7 @@ class DeviceTypeControl(QGroupBox):
             # Reload saved parameter values
             self._device_widgets[idx].load_saved_parameter_values()
 
-    def _set_device_closed(self, **kwargs) -> None:
+    def _set_device_closed(self) -> None:
         """Update the GUI for when the device is opened."""
         self._set_combos_enabled(True)
         self._open_close_btn.setText("Open")
@@ -299,6 +299,10 @@ class DeviceTypeControl(QGroupBox):
     ) -> None:
         """Update the GUI on device open."""
         self._set_device_opened(class_name)
+
+    def _on_device_closed(self, instance: DeviceInstanceRef) -> None:
+        """Update the GUI on device close."""
+        self._set_device_closed()
 
     def _close_device(self) -> None:
         """Close the device."""

--- a/finesse/gui/hardware_set/finesse_dp9800.yaml
+++ b/finesse/gui/hardware_set/finesse_dp9800.yaml
@@ -22,3 +22,5 @@ devices:
       baudrate: 38400
   em27_sensors:
     class_name: em27.em27_sensors.EM27Sensors
+  opus:
+    class_name: em27.opus_interface.OPUSInterface

--- a/finesse/gui/hardware_set/finesse_dummy.yaml
+++ b/finesse/gui/hardware_set/finesse_dummy.yaml
@@ -10,3 +10,5 @@ devices:
     class_name: temperature.dummy_temperature_monitor.DummyTemperatureMonitor
   em27_sensors:
     class_name: em27.dummy_em27_sensors.DummyEM27Sensors
+  opus:
+    class_name: em27.dummy_opus_interface.DummyOPUSInterface

--- a/finesse/gui/hardware_set/finesse_seneca.yaml
+++ b/finesse/gui/hardware_set/finesse_seneca.yaml
@@ -22,3 +22,5 @@ devices:
       baudrate: 57600
   em27_sensors:
     class_name: em27.em27_sensors.EM27Sensors
+  opus:
+    class_name: em27.opus_interface.OPUSInterface

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import QWidget
 from schema import And, Or, Schema, SchemaError
 from statemachine import State, StateMachine
 
-from finesse.config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
+from finesse.config import ANGLE_PRESETS, OPUS_TOPIC, STEPPER_MOTOR_TOPIC
 from finesse.device_info import DeviceInstanceRef
 from finesse.em27_info import EM27Status
 from finesse.gui.error_message import show_error_message
@@ -127,7 +127,7 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
 
 def _poll_em27_status() -> None:
     """Request the EM27's status from OPUS."""
-    pub.sendMessage("opus.request", command="status")
+    pub.sendMessage(f"device.{OPUS_TOPIC}.request", command="status")
 
 
 class ScriptIterator:
@@ -278,9 +278,9 @@ class ScriptRunner(StateMachine):
         )
 
         # EM27 messages
-        pub.unsubscribe(self._on_em27_error, "opus.error")
-        pub.unsubscribe(self._measuring_started, "opus.response.start")
-        pub.unsubscribe(self._status_received, "opus.response.status")
+        pub.unsubscribe(self._on_em27_error, f"device.error.{OPUS_TOPIC}")
+        pub.unsubscribe(self._measuring_started, f"device.{OPUS_TOPIC}.response.start")
+        pub.unsubscribe(self._status_received, f"device.{OPUS_TOPIC}.response.status")
 
         # Send message signalling that the measure script is no longer running
         pub.sendMessage("measure_script.end")
@@ -294,9 +294,9 @@ class ScriptRunner(StateMachine):
         )
 
         # Listen for EM27 messages
-        pub.subscribe(self._on_em27_error, "opus.error")
-        pub.subscribe(self._measuring_started, "opus.response.start")
-        pub.subscribe(self._status_received, "opus.response.status")
+        pub.subscribe(self._on_em27_error, f"device.error.{OPUS_TOPIC}")
+        pub.subscribe(self._measuring_started, f"device.{OPUS_TOPIC}.response.start")
+        pub.subscribe(self._status_received, f"device.{OPUS_TOPIC}.response.status")
 
     def _load_next_measurement(self) -> bool:
         """Load the next measurement in the sequence.
@@ -338,7 +338,7 @@ class ScriptRunner(StateMachine):
         NB: This is also invoked on repeat measurements
         """
         pub.sendMessage("measure_script.start_measuring", script_runner=self)
-        pub.sendMessage("opus.request", command="start")
+        pub.sendMessage(f"device.{OPUS_TOPIC}.request", command="start")
 
     def on_exit_measuring(self) -> None:
         """Ensure that the polling timer is stopped."""
@@ -406,7 +406,7 @@ class ScriptRunner(StateMachine):
         """Call abort()."""
         self.abort()
 
-    def _on_em27_error(self, error: Exception) -> None:
+    def _on_em27_error(self, instance: DeviceInstanceRef, error: Exception) -> None:
         """Cancel current measurement and show an error message to the user."""
         self.abort()
 

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -5,7 +5,7 @@ from typing import cast
 from pubsub import pub
 from PySide6.QtWidgets import QFileDialog, QGridLayout, QGroupBox, QPushButton
 
-from finesse.config import DEFAULT_SCRIPT_PATH, STEPPER_MOTOR_TOPIC
+from finesse.config import DEFAULT_SCRIPT_PATH, OPUS_TOPIC, STEPPER_MOTOR_TOPIC
 from finesse.em27_info import EM27Status
 from finesse.event_counter import EventCounter
 from finesse.gui.measure_script.script import Script, ScriptRunner
@@ -62,7 +62,7 @@ class ScriptControl(QGroupBox):
 
         # Monitor OPUS messages to enable/disable run button on connect/disconnect
         self._opus_connected = False
-        pub.subscribe(self._on_opus_message, "opus.response")
+        pub.subscribe(self._on_opus_message, f"device.{OPUS_TOPIC}.response")
 
         # Show/hide self.run_dialog on measure script begin/end
         pub.subscribe(self._show_run_dialog, "measure_script.begin")

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -1,6 +1,7 @@
 """Panel and widgets related to the control of the OPUS interferometer."""
 import logging
 import weakref
+from collections.abc import Sequence
 from functools import partial
 
 from pubsub import pub
@@ -23,10 +24,10 @@ from finesse.gui.device_panel import DevicePanel
 class OPUSControl(DevicePanel):
     """Class that monitors and controls the OPUS interferometer."""
 
-    COMMANDS = ["status", "cancel", "stop", "start", "connect"]
+    COMMANDS = ("status", "cancel", "stop", "start", "connect")
     """The default commands shown for interacting with OPUS."""
 
-    def __init__(self, commands: list[str] = COMMANDS) -> None:
+    def __init__(self, commands: Sequence[str] = COMMANDS) -> None:
         """Create the widgets to monitor and control the OPUS interferometer."""
         super().__init__(OPUS_TOPIC, "OPUS client view")
 

--- a/finesse/gui/opus_view.py
+++ b/finesse/gui/opus_view.py
@@ -14,10 +14,13 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
+from finesse.config import OPUS_TOPIC
+from finesse.device_info import DeviceInstanceRef
 from finesse.em27_info import EM27Status
+from finesse.gui.device_panel import DevicePanel
 
 
-class OPUSControl(QGroupBox):
+class OPUSControl(DevicePanel):
     """Class that monitors and controls the OPUS interferometer."""
 
     COMMANDS = ["status", "cancel", "stop", "start", "connect"]
@@ -25,7 +28,7 @@ class OPUSControl(QGroupBox):
 
     def __init__(self, commands: list[str] = COMMANDS) -> None:
         """Create the widgets to monitor and control the OPUS interferometer."""
-        super().__init__("OPUS client view")
+        super().__init__(OPUS_TOPIC, "OPUS client view")
 
         self.commands = commands
         self.logger = logging.getLogger("OPUS")
@@ -38,9 +41,9 @@ class OPUSControl(QGroupBox):
             QSizePolicy.Policy.MinimumExpanding,
         )
 
-        pub.subscribe(self._log_request, "opus.request")
-        pub.subscribe(self._log_response, "opus.response")
-        pub.subscribe(self._log_error, "opus.error")
+        pub.subscribe(self._log_request, f"device.{OPUS_TOPIC}.request")
+        pub.subscribe(self._log_response, f"device.{OPUS_TOPIC}.response")
+        pub.subscribe(self._log_error, f"device.error.{OPUS_TOPIC}")
 
     def _create_controls(self) -> QHBoxLayout:
         """Creates the controls for communicating with the interferometer.
@@ -99,7 +102,7 @@ class OPUSControl(QGroupBox):
     ) -> None:
         self.logger.info(f"Response ({status.value}): {text}")
 
-    def _log_error(self, error: BaseException) -> None:
+    def _log_error(self, instance: DeviceInstanceRef, error: BaseException) -> None:
         self.logger.error(f"Error during request: {str(error)}")
 
     def on_command_button_clicked(self, command: str) -> None:
@@ -108,7 +111,7 @@ class OPUSControl(QGroupBox):
         Args:
             command: OPUS command to be executed
         """
-        pub.sendMessage("opus.request", command=command)
+        pub.sendMessage(f"device.{OPUS_TOPIC}.request", command=command)
 
 
 class OPUSLogHandler(logging.Handler):

--- a/finesse/gui/temp_control.py
+++ b/finesse/gui/temp_control.py
@@ -398,8 +398,8 @@ class TC4820Controls(DevicePanel):
 
     def _begin_polling(self) -> None:
         """Initiate polling the TC4820 device."""
-        # SerialDevicePanel.set_controls_enabled() will enable these, but
-        # we want them to begin disabled
+        # DevicePanel.set_controls_enabled() will enable these, but we want them to
+        # begin disabled
         self._set_sbox.setEnabled(False)
         if self._name.count("cold"):
             self._update_pbtn.setEnabled(False)

--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -1,26 +1,13 @@
 """This module contains code for interfacing with different hardware devices."""
-import sys
+from collections.abc import Sequence
+from datetime import datetime
 from decimal import Decimal
 
 from pubsub import pub
 
-if "--dummy-em27" in sys.argv:
-    from finesse.hardware.plugins.em27.dummy_opus_interface import (
-        DummyOPUSInterface as OPUSInterface,
-    )
-else:
-    from finesse.hardware.plugins.em27.opus_interface import (  # type: ignore
-        OPUSInterface,
-    )
-
-from collections.abc import Sequence
-from datetime import datetime
-
 from finesse.config import NUM_TEMPERATURE_MONITOR_CHANNELS, TEMPERATURE_MONITOR_TOPIC
 from finesse.hardware import data_file_writer  # noqa: F401
 from finesse.hardware.plugins.temperature import get_temperature_monitor_instance
-
-_opus: OPUSInterface
 
 
 def _try_get_temperatures() -> Sequence | None:
@@ -57,18 +44,3 @@ def _send_temperatures() -> None:
 
 
 pub.subscribe(_send_temperatures, f"device.{TEMPERATURE_MONITOR_TOPIC}.data.request")
-
-
-def _init_hardware():
-    global _opus
-
-    _opus = OPUSInterface()
-
-
-def _stop_hardware():
-    global _opus
-    del _opus
-
-
-pub.subscribe(_init_hardware, "window.opened")
-pub.subscribe(_stop_hardware, "window.closed")

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -308,9 +308,8 @@ class Device(AbstractDevice):
                 assert len(result) == len(kwarg_names)
 
                 # Send message with arguments
-                pub.sendMessage(
-                    f"{self.topic}.{success_topic_suffix}",
-                    **dict(zip(kwarg_names, result)),
+                self.send_message(
+                    success_topic_suffix, **dict(zip(kwarg_names, result))
                 )
 
         return decorate(func, wrapped)
@@ -344,3 +343,12 @@ class Device(AbstractDevice):
         topic_name = f"{self.topic}.{topic_name_suffix}"
         self._subscriptions.append((wrapped_func, topic_name))
         pub.subscribe(wrapped_func, topic_name)
+
+    def send_message(self, topic_suffix: str, **kwargs: Any) -> None:
+        """Send a pubsub message for this device.
+
+        Args:
+            topic_suffix: The part of the topic name after self.topic
+            **kwargs: Extra arguments to include with pubsub message
+        """
+        pub.sendMessage(f"{self.topic}.{topic_suffix}", **kwargs)

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -2,8 +2,7 @@
 
 The Device class is the top-level base class from which all devices ultimately inherit.
 Concrete classes for devices must not inherit directly from this class, but instead
-should inherit from a device base class (defined by passing is_base_type to the class
-constructor).
+should inherit from a device base class.
 """
 from __future__ import annotations
 

--- a/finesse/hardware/http_requester.py
+++ b/finesse/hardware/http_requester.py
@@ -20,13 +20,12 @@ class HTTPRequester:
         self._manager = QNetworkAccessManager()
 
     def make_request(self, url: str, callback: Callable[[QNetworkReply], Any]) -> None:
-        """Make a new HTTP request.
+        """Make a new HTTP request in the background.
 
         Args:
             url: The URL to connect to
             callback: Function to be invoked when the request finishes
         """
-        # Make HTTP request in background
         request = QNetworkRequest(url)
         request.setTransferTimeout(round(1000 * self._timeout))
         reply = self._manager.get(request)

--- a/finesse/hardware/plugins/em27/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/em27/dummy_opus_interface.py
@@ -167,6 +167,8 @@ class DummyOPUSInterface(
 
         Args:
             command: The command to run
+        Raises:
+            OPUSError: If the device is in the wrong state for this command
         """
         if command == "status":
             if self.state_machine.current_state == OPUSStateMachine.idle:

--- a/finesse/hardware/plugins/em27/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/em27/dummy_opus_interface.py
@@ -113,7 +113,11 @@ class OPUSStateMachine(StateMachine):
         logging.info(f"Current state: {target.name}")
 
 
-class DummyOPUSInterface(OPUSInterfaceBase):
+class DummyOPUSInterface(
+    OPUSInterfaceBase,
+    description="Dummy OPUS device",
+    parameters={"measure_duration": "Measurement duration in seconds"},
+):
     """A mock version of the OPUS API for testing purposes."""
 
     _COMMAND_ERRORS = {
@@ -173,11 +177,11 @@ class DummyOPUSInterface(OPUSInterfaceBase):
             self.last_error = OPUSErrorInfo.UNKNOWN_COMMAND
 
         if errinfo := self.last_error.to_tuple():
-            self.error_occurred(OPUSError.from_response(*errinfo))
-        else:
-            # Broadcast the response for the command
-            state = self.state_machine.current_state
-            self.send_response(command, status=state.value, text=state.name)
+            raise OPUSError.from_response(*errinfo)
+
+        # Broadcast the response for the command
+        state = self.state_machine.current_state
+        self.send_response(command, status=state.value, text=state.name)
 
     def _measuring_finished(self) -> None:
         """Finish measurement successfully."""

--- a/finesse/hardware/plugins/em27/opus_interface.py
+++ b/finesse/hardware/plugins/em27/opus_interface.py
@@ -6,14 +6,14 @@ The OPUS program must be running on the computer at OPUS_IP for the commands to 
 Note that this is a separate machine from the EM27!
 """
 import logging
-from functools import partial
 
 from bs4 import BeautifulSoup
 from PySide6.QtCore import Slot
-from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
+from PySide6.QtNetwork import QNetworkReply
 
 from finesse.config import OPUS_IP
 from finesse.em27_info import EM27Status
+from finesse.hardware.http_requester import HTTPRequester
 from finesse.hardware.plugins.em27.opus_interface_base import (
     OPUSError,
     OPUSInterfaceBase,
@@ -61,30 +61,20 @@ class OPUSInterface(OPUSInterfaceBase, description="OPUS spectrometer"):
     HTTP requests are handled on a background thread.
     """
 
-    def __init__(self, timeout: float = 3.0) -> None:
-        """Create a new OPUSInterface.
-
-        Args:
-            timeout: Amount of time before request times out (seconds)
-        """
+    def __init__(self) -> None:
+        """Create a new OPUSInterface."""
         super().__init__()
-
-        self._manager = QNetworkAccessManager()
-        self._timeout = timeout
+        self._requester = HTTPRequester()
 
     @Slot()
-    def _on_reply_received(self, reply: QNetworkReply, command: str) -> None:
+    def _on_reply_received(self, reply: QNetworkReply) -> tuple[EM27Status, str]:
         """Handle received HTTP reply."""
-        try:
-            if reply.error() != QNetworkReply.NetworkError.NoError:
-                raise OPUSError(f"Network error: {reply.errorString()}")
+        if reply.error() != QNetworkReply.NetworkError.NoError:
+            raise OPUSError(f"Network error: {reply.errorString()}")
 
-            response = reply.readAll().data().decode()
-            status, text = parse_response(response)
-        except Exception as e:
-            self.send_error_message(e)
-        else:
-            self.send_response(command, status, text)
+        response = reply.readAll().data().decode()
+        status, text = parse_response(response)
+        return status, text
 
     def request_command(self, command: str) -> None:
         """Request that OPUS run the specified command.
@@ -102,7 +92,9 @@ class OPUSInterface(OPUSInterfaceBase, description="OPUS spectrometer"):
         )
 
         # Make HTTP request in background
-        request = QNetworkRequest(f"http://{OPUS_IP}/opusrs/{filename}")
-        request.setTransferTimeout(round(1000 * self._timeout))
-        reply = self._manager.get(request)
-        reply.finished.connect(partial(self._on_reply_received, reply, command))
+        self._requester.make_request(
+            f"http://{OPUS_IP}/opusrs/{filename}",
+            self.pubsub_broadcast(
+                self._on_reply_received, f"response.{command}", "status", "text"
+            ),
+        )

--- a/finesse/hardware/plugins/em27/opus_interface.py
+++ b/finesse/hardware/plugins/em27/opus_interface.py
@@ -55,7 +55,7 @@ def parse_response(response: str) -> tuple[EM27Status, str]:
     return status, text
 
 
-class OPUSInterface(OPUSInterfaceBase):
+class OPUSInterface(OPUSInterfaceBase, description="OPUS spectrometer"):
     """Interface for communicating with the OPUS program.
 
     HTTP requests are handled on a background thread.
@@ -82,7 +82,7 @@ class OPUSInterface(OPUSInterfaceBase):
             response = reply.readAll().data().decode()
             status, text = parse_response(response)
         except Exception as e:
-            self.error_occurred(e)
+            self.send_error_message(e)
         else:
             self.send_response(command, status, text)
 

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -1,10 +1,8 @@
 """Code for a fake stepper motor device."""
 import logging
 
-from pubsub import pub
 from PySide6.QtCore import QTimer
 
-from finesse.config import STEPPER_MOTOR_TOPIC
 from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 
 
@@ -99,4 +97,4 @@ class DummyStepperMotor(StepperMotorBase, description="Dummy stepper motor"):
         logging.info("Move finished")
         if self._notify_requested:
             self._notify_requested = False
-            pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.move.end")
+            self.send_message("move.end")

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -10,11 +10,9 @@ The specification is available online:
 import logging
 from queue import Queue
 
-from pubsub import pub
 from PySide6.QtCore import QThread, Signal, Slot
 from serial import Serial, SerialException, SerialTimeoutException
 
-from finesse.config import STEPPER_MOTOR_TOPIC
 from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 from finesse.hardware.serial_device import SerialDevice
 
@@ -221,7 +219,7 @@ class ST10Controller(SerialDevice, StepperMotorBase, description="ST10 controlle
 
     @Slot()
     def _send_move_end_message(self) -> None:
-        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.move.end")
+        self.send_message("move.end")
 
     def _check_device_id(self) -> None:
         """Check that the ID is the correct one for an ST10.

--- a/tests/gui/hardware_set/test_device_type_control.py
+++ b/tests/gui/hardware_set/test_device_type_control.py
@@ -87,7 +87,7 @@ def test_init(
     subscribe_mock.assert_has_calls(
         [
             call(widget._on_device_opened, f"device.opening.{instance!s}"),
-            call(widget._set_device_closed, f"device.closed.{instance!s}"),
+            call(widget._on_device_closed, f"device.closed.{instance!s}"),
         ]
     )
 
@@ -236,6 +236,13 @@ def test_on_device_opened(widget: DeviceTypeControl, qtbot) -> None:
     with patch.object(widget, "_set_device_opened") as open_mock:
         widget._on_device_opened(DeviceInstanceRef("base_type"), "some_class", {})
         open_mock.assert_called_once_with("some_class")
+
+
+def test_on_device_closed(widget: DeviceTypeControl, qtbot) -> None:
+    """Test the _on_device_closed() method."""
+    with patch.object(widget, "_set_device_closed") as close_mock:
+        widget._on_device_closed(DeviceInstanceRef("base_type"))
+        close_mock.assert_called_once_with()
 
 
 def test_open_close_btn(widget: DeviceTypeControl, qtbot) -> None:

--- a/tests/gui/measure_script/test_script_view.py
+++ b/tests/gui/measure_script/test_script_view.py
@@ -8,7 +8,7 @@ import pytest
 from PySide6.QtWidgets import QPushButton, QWidget
 from pytestqt.qtbot import QtBot
 
-from finesse.config import DEFAULT_SCRIPT_PATH
+from finesse.config import DEFAULT_SCRIPT_PATH, OPUS_TOPIC
 from finesse.em27_info import EM27Status
 from finesse.gui.measure_script.script_run_dialog import ScriptRunDialog
 from finesse.gui.measure_script.script_view import ScriptControl
@@ -47,7 +47,9 @@ def test_init(settings_mock: Mock, subscribe_mock: Mock, qtbot: QtBot) -> None:
     subscribe_mock.assert_any_call(
         script_control._hide_run_dialog, "measure_script.end"
     )
-    subscribe_mock.assert_any_call(script_control._on_opus_message, "opus.response")
+    subscribe_mock.assert_any_call(
+        script_control._on_opus_message, f"device.{OPUS_TOPIC}.response"
+    )
     assert not script_control._opus_connected
 
 

--- a/tests/gui/test_device_panel.py
+++ b/tests/gui/test_device_panel.py
@@ -1,4 +1,4 @@
-"""Tests for the SerialDevicePanel."""
+"""Tests for the DevicePanel."""
 from collections.abc import Sequence
 from unittest.mock import MagicMock, patch
 
@@ -9,8 +9,8 @@ from pytestqt.qtbot import QtBot
 from finesse.gui.device_panel import DevicePanel
 
 
-class _ChildSerialDevicePanel(DevicePanel):
-    """Inherit from SerialDevicePanel in order to test __init_subclass__."""
+class _ChildDevicePanel(DevicePanel):
+    """Inherit from DevicePanel in order to test __init_subclass__."""
 
     def __init__(self) -> None:
         super().__init__("my_device", "My Panel")
@@ -24,8 +24,8 @@ class _ChildSerialDevicePanel(DevicePanel):
 
 @pytest.fixture
 def panel(qtbot: QtBot) -> DevicePanel:
-    """A fixture providing a SerialDevicePanel."""
-    return _ChildSerialDevicePanel()
+    """A fixture providing a DevicePanel."""
+    return _ChildDevicePanel()
 
 
 def _check_controls_enabled(panel: DevicePanel, enabled: bool) -> None:
@@ -37,7 +37,7 @@ def _check_controls_enabled(panel: DevicePanel, enabled: bool) -> None:
 
 
 def test_init(subscribe_mock: MagicMock, qtbot: QtBot) -> None:
-    """Test SerialDevicePanel's constructor."""
+    """Test DevicePanel's constructor."""
     panel = DevicePanel("my_device", "My Title")
 
     subscribe_mock.assert_any_call(panel._on_device_opened, "device.opened.my_device")

--- a/tests/hardware/plugins/em27/test_opus_interface.py
+++ b/tests/hardware/plugins/em27/test_opus_interface.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from PySide6.QtNetwork import QNetworkReply
 
-from finesse.config import OPUS_IP, OPUS_TOPIC
+from finesse.config import OPUS_IP
 from finesse.em27_info import EM27Status
 from finesse.hardware.plugins.em27.opus_interface import (
     OPUSError,
@@ -21,42 +21,26 @@ def opus(qtbot) -> OPUSInterface:
     return OPUSInterface()
 
 
-@patch("finesse.hardware.plugins.em27.opus_interface.QNetworkRequest")
-def test_request_status(network_request_mock: Mock, opus: OPUSInterface, qtbot) -> None:
+def test_request_status(opus: OPUSInterface, qtbot) -> None:
     """Test OPUSInterface's request_status() method."""
-    with patch.object(opus, "_manager"):
+    with patch.object(opus, "_requester") as requester_mock:
         opus.request_command("status")
-        network_request_mock.assert_called_once_with(
-            f"http://{OPUS_IP}/opusrs/stat.htm"
+        assert requester_mock.make_request.call_count == 1
+        assert (
+            requester_mock.make_request.call_args[0][0]
+            == f"http://{OPUS_IP}/opusrs/stat.htm"
         )
 
 
-@patch("finesse.hardware.plugins.em27.opus_interface.QNetworkRequest")
-def test_request_command(
-    network_request_mock: Mock, opus: OPUSInterface, qtbot
-) -> None:
+def test_request_command(opus: OPUSInterface, qtbot) -> None:
     """Test OPUSInterface's request_command() method."""
-    request = MagicMock()
-    network_request_mock.return_value = request
-    reply = MagicMock()
-
-    with patch.object(opus, "_manager") as manager_mock:
-        with patch.object(opus, "_on_reply_received") as reply_received_mock:
-            manager_mock.get.return_value = reply
-            opus.request_command("hello")
-            network_request_mock.assert_called_once_with(
-                f"http://{OPUS_IP}/opusrs/cmd.htm?opusrshello"
-            )
-            request.setTransferTimeout.assert_called_once_with(
-                round(1000 * opus._timeout)
-            )
-
-            # Check that the reply will be handled by _on_reply_received()
-            connect_mock = reply.finished.connect
-            connect_mock.assert_called_once()
-            handler = connect_mock.call_args_list[0].args[0]
-            handler()
-            reply_received_mock.assert_called_once()
+    with patch.object(opus, "_requester") as requester_mock:
+        opus.request_command("hello")
+        assert requester_mock.make_request.call_count == 1
+        assert (
+            requester_mock.make_request.call_args[0][0]
+            == f"http://{OPUS_IP}/opusrs/cmd.htm?opusrshello"
+        )
 
 
 def _format_td(name: str, value: Any) -> str:
@@ -145,7 +129,7 @@ def test_parse_response_bad_id(warning_mock: Mock) -> None:
 
 @patch("finesse.hardware.plugins.em27.opus_interface.parse_response")
 def test_on_reply_received_no_error(
-    parse_response_mock: Mock, opus: OPUSInterface, sendmsg_mock: Mock, qtbot
+    parse_response_mock: Mock, opus: OPUSInterface, qtbot
 ) -> None:
     """Test the _on_reply_received() method works when no error occurs."""
     reply = MagicMock()
@@ -155,10 +139,7 @@ def test_on_reply_received_no_error(
     parse_response_mock.return_value = ("status", "text")
 
     # Check the correct pubsub message is sent
-    opus._on_reply_received(reply, "hello")
-    sendmsg_mock.assert_called_once_with(
-        f"device.{OPUS_TOPIC}.response.hello", status="status", text="text"
-    )
+    assert opus._on_reply_received(reply) == ("status", "text")
 
 
 @patch("finesse.hardware.plugins.em27.opus_interface.parse_response")
@@ -167,12 +148,11 @@ def test_on_reply_received_network_error(
 ) -> None:
     """Test the _on_reply_received() method handles network errors."""
     reply = MagicMock()
-    reply.error = QNetworkReply.NetworkError.HostNotFoundError
-    reply.errorString("Something went wrong")
+    reply.error.return_value = QNetworkReply.NetworkError.HostNotFoundError
+    reply.errorString.return_value = "Something went wrong"
 
-    with patch.object(opus, "send_error_message") as error_mock:
-        opus._on_reply_received(reply, "hello")
-        error_mock.assert_called_once()
+    with pytest.raises(OPUSError):
+        opus._on_reply_received(reply)
 
 
 @patch("finesse.hardware.plugins.em27.opus_interface.parse_response")
@@ -184,11 +164,7 @@ def test_on_reply_received_exception(
     reply.error.return_value = QNetworkReply.NetworkError.NoError
 
     # Make parse_response() raise an exception
-    error = Exception()
-    parse_response_mock.side_effect = error
+    parse_response_mock.side_effect = RuntimeError
 
-    with patch.object(opus, "send_error_message") as error_mock:
-        opus._on_reply_received(reply, "hello")
-
-        # Check the error was caught
-        error_mock.assert_called_once_with(error)
+    with pytest.raises(RuntimeError):
+        opus._on_reply_received(reply)


### PR DESCRIPTION
This completes the work of converting the device classes to plugins :partying_face:.

As I said in the meeting this morn, this PR just converts the existing OPUS (==EM27 spectrometer) code into a plugin, but there is more refactoring needed before we can get to a generic spectrometer interface (#459).

Closes #363.