### PR TITLE
Clean up `Device` inheritance logic

### DIFF
--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -37,17 +37,18 @@ You can create a new device base like so:
 
 ```py
 class MyBaseType(
-    Device, is_base_type=True, name="my_base_type", description="Example base type"
+    Device, name="my_base_type", description="Example base type"
 ):
     # ...
 ```
 
-The `is_base_type=True` is required to register the class as a device base type. `name`
-is the short name for the base type and is used in the topic for PyPubSub messages (see
-more below). `description` provides a human-readable name for the base type, which will
-be displayed in the GUI. It is additionally possible to provide a list of possible names
-for instances of the device, but this is currently only used for temperature controllers
-(to distinguish between the hot and cold black body controllers).
+As this class inherits directly from `Device`, it will be registered as a device base
+type. `name` is the short name for the base type and is used in the topic for PyPubSub
+messages (see more below). `description` provides a human-readable name for the base
+type, which will be displayed in the GUI. It is additionally possible to provide a list
+of possible names for instances of the device, but this is currently only used for
+temperature controllers (to distinguish between the hot and cold black body
+controllers).
 
 You can create a concrete implementation of `MyBaseType` like so:
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -29,11 +29,22 @@ in the plugins directory hierarchy.
 
 ### Creating a new device type
 
-A device base type is a class providing a common interface for similar device types
-(e.g. a stepper motor). Each device base class must inherit from `Device` and each
-device class must inherit from a device base class.
+There are three "kinds" of device classes:
 
-You can create a new device base like so:
+1. Device base types, which must inherit from `Device` directly
+2. Abstract device types, which must inherit from a device base type (directly or
+   indirectly) and have at least one abstract method
+3. Concrete device types which must inherit from one of the above and have no abstract
+   methods
+
+Device base types and concrete device types are included in registries that are
+communicated to the frontend if it requests a list of plugins (abstract device types are
+excluded). Note that there are other possibilities one could imagine (e.g. a class
+inheriting from `Device` which is not registered as a device base type), but these are
+currently not possible.
+
+A device base type is a class providing a common interface for similar device types
+(e.g. a stepper motor). You can create a new device base like so:
 
 ```py
 class MyBaseType(

--- a/finesse/hardware/plugins/em27/em27_sensors.py
+++ b/finesse/hardware/plugins/em27/em27_sensors.py
@@ -70,7 +70,6 @@ class EM27Error(Exception):
 
 class EM27SensorsBase(
     Device,
-    is_base_type=True,
     name=EM27_SENSORS_TOPIC,
     description="EM27 sensors",
 ):

--- a/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -5,9 +5,7 @@ from finesse.config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 from finesse.hardware.device import Device
 
 
-class StepperMotorBase(
-    Device, is_base_type=True, name=STEPPER_MOTOR_TOPIC, description="Stepper motor"
-):
+class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper motor"):
     """A base class for stepper motor implementations."""
 
     def __init__(self) -> None:

--- a/finesse/hardware/plugins/temperature/temperature_controller_base.py
+++ b/finesse/hardware/plugins/temperature/temperature_controller_base.py
@@ -9,7 +9,6 @@ from finesse.hardware.device import Device
 
 class TemperatureControllerBase(
     Device,
-    is_base_type=True,
     name=TEMPERATURE_CONTROLLER_TOPIC,
     description="Temperature controller",
     names_short=("hot_bb", "cold_bb"),

--- a/finesse/hardware/plugins/temperature/temperature_monitor_base.py
+++ b/finesse/hardware/plugins/temperature/temperature_monitor_base.py
@@ -8,7 +8,6 @@ from finesse.hardware.device import Device
 
 class TemperatureMonitorBase(
     Device,
-    is_base_type=True,
     name=TEMPERATURE_MONITOR_TOPIC,
     description="Temperature monitor",
 ):

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -9,9 +9,7 @@ from finesse.device_info import DeviceParameter
 from finesse.hardware.device import AbstractDevice, Device, get_device_types
 
 
-class _MockBaseClass(
-    Device, is_base_type=True, name="mock", description="Mock base class"
-):
+class _MockBaseClass(Device, name="mock", description="Mock base class"):
     pass
 
 


### PR DESCRIPTION
Currently, in order to create a device base type, the user passes `is_base_type=True` to the class definition. If this parameter is omitted, it is assumed that the class is a concrete device type, in which case, the class must inherit *directly* from a base type.

There are a couple of problems with this:

1. It doesn't allow for classes that inherit indirectly from a base type
2. The extra `is_base_type` parameter is a bit ugly

I've reworked the logic a bit to fix this. Now, if a class inherits directly from `Device` it is treated as a base type (no extra argument necessary) and otherwise it is treated as a device type *only* if it is not abstract (abstract classes are ignored).

I have a use case for this: I want to have an `OPUSInterfaceBase` class which inherits from a `SpectrometerBase` class. This class will be neither a device type or a base device type, but its children will be device types.