### PR TITLE
Fix stepper motor port for FINESSE

### DIFF
--- a/finesse/gui/hardware_set/finesse_dp9800.yaml
+++ b/finesse/gui/hardware_set/finesse_dp9800.yaml
@@ -3,7 +3,7 @@ devices:
   stepper_motor:
     class_name: stepper_motor.st10_controller.ST10Controller
     params:
-      port: "0403:6011 FT1NMSVR (4)"
+      port: "0403:6011 FT1NMSVR"
       baudrate: 9600
   temperature_controller.hot_bb:
     class_name: temperature.tc4820.TC4820

--- a/finesse/gui/hardware_set/finesse_seneca.yaml
+++ b/finesse/gui/hardware_set/finesse_seneca.yaml
@@ -3,7 +3,7 @@ devices:
   stepper_motor:
     class_name: stepper_motor.st10_controller.ST10Controller
     params:
-      port: "0403:6011 FT1NMSVR (4)"
+      port: "0403:6011 FT1NMSVR"
       baudrate: 9600
   temperature_controller.hot_bb:
     class_name: temperature.tc4820.TC4820


### PR DESCRIPTION
I think I must have had the port wrong before, but it's a bit annoying that I didn't spot it, as now it is a bug in v1.2. I was a little worried that I *hadn't* made a mistake, but that the supposedly persistent USB strings I'm using aren't actually persistent. It doesn't seem like that's the case though: the ports are in the same order on two different machines (running Windows + Linux).

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
