### PR TITLE
Fix `_send_temperatures()` for Seneca device

### DIFF
--- a/finesse/hardware/__init__.py
+++ b/finesse/hardware/__init__.py
@@ -44,7 +44,10 @@ _DEFAULT_TEMPS = [Decimal("nan")] * NUM_TEMPERATURE_MONITOR_CHANNELS
 
 def _send_temperatures() -> None:
     """Send the current temperatures (or NaNs) via pubsub."""
-    temperatures = _try_get_temperatures() or _DEFAULT_TEMPS
+    temperatures = _try_get_temperatures()
+    if temperatures is None:
+        temperatures = _DEFAULT_TEMPS
+
     time = datetime.utcnow()
     pub.sendMessage(
         f"device.{TEMPERATURE_MONITOR_TOPIC}.data.response",


### PR DESCRIPTION
As the Seneca device now returns its temperatures as a numpy array, unfortunately the _send_temperatures() function no longer works with it:

```
Traceback (most recent call last):
  File "/home/alex/code/FINESSE/finesse/gui/temp_control.py", line 265, in _poll_dp9800
    pub.sendMessage(f"device.{TEMPERATURE_MONITOR_TOPIC}.data.request")
  File "/home/alex/code/FINESSE/.venv/lib/python3.11/site-packages/pubsub/core/publisher.py", line 216, in sendMessage
    topicObj.publish(**msgData)
  File "/home/alex/code/FINESSE/.venv/lib/python3.11/site-packages/pubsub/core/topicobj.py", line 452, in publish
    self.__sendMessage(msgData, topicObj, msgDataSubset)
  File "/home/alex/code/FINESSE/.venv/lib/python3.11/site-packages/pubsub/core/topicobj.py", line 482, in __sendMessage
    listener(data, self, allData)
  File "/home/alex/code/FINESSE/.venv/lib/python3.11/site-packages/pubsub/core/listener.py", line 237, in __call__
    cb(**kwargs)
  File "/home/alex/code/FINESSE/finesse/hardware/__init__.py", line 47, in _send_temperatures
    temperatures = _try_get_temperatures() or _DEFAULT_TEMPS
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Seemingly unlike Python's built-in collections, you can't check whether a numpy array is empty by looking at its "truthiness".

Fix by using an explicit if-statement.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
