### PR TITLE
Drop use of USB serial numbers

### DIFF
--- a/docs/hardware_sets.md
+++ b/docs/hardware_sets.md
@@ -15,17 +15,17 @@ devices:
   stepper_motor:
     class_name: stepper_motor.st10_controller.ST10Controller
     params:
-      port: "0403:6011 FT1NMSVR (4)"
+      port: "0403:6011 (4)"
       baudrate: 9600
   temperature_controller.hot_bb:
     class_name: temperature.tc4820.TC4820
     params:
-      port: "0403:6011 FT1NMSVR (2)"
+      port: "0403:6011 (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
     class_name: temperature.tc4820.TC4820
     params:
-      port: "0403:6011 FT1NMSVR (3)"
+      port: "0403:6011 (3)"
       baudrate: 115200
   temperature_monitor:
     class_name: temperature.dp9800.DP9800
@@ -48,10 +48,9 @@ is also a YAML object, containing key-value pairs for each of the device paramet
 used.
 
 Note that the port names are in a FINESSE-specific format. The string is composed of the
-USB vendor and product IDs, followed by the serial number (if present) and (optionally)
-a number to distinguish ports which share all these properties (as happens with
-USB-to-serial devices with multiple ports, for example). The easiest way to figure out
-these strings is to run FINESSE and click on "Manage devices". The available USB ports
-will be listed in the dialog.
+USB vendor and product IDs and (optionally) a number to distinguish ports which share
+all these properties (as happens with USB-to-serial devices with multiple ports, for
+example). The easiest way to figure out these strings is to run FINESSE and click on
+"Manage devices". The available USB ports will be listed in the dialog.
 
 [Hardware]: ./hardware.md

--- a/finesse/gui/hardware_set/finesse_dp9800.yaml
+++ b/finesse/gui/hardware_set/finesse_dp9800.yaml
@@ -3,17 +3,17 @@ devices:
   stepper_motor:
     class_name: stepper_motor.st10_controller.ST10Controller
     params:
-      port: "0403:6011 FT1NMSVR"
+      port: "0403:6011"
       baudrate: 9600
   temperature_controller.hot_bb:
     class_name: temperature.tc4820.TC4820
     params:
-      port: "0403:6011 FT1NMSVR (2)"
+      port: "0403:6011 (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
     class_name: temperature.tc4820.TC4820
     params:
-      port: "0403:6011 FT1NMSVR (3)"
+      port: "0403:6011 (3)"
       baudrate: 115200
   temperature_monitor:
     class_name: temperature.dp9800.DP9800

--- a/finesse/gui/hardware_set/finesse_seneca.yaml
+++ b/finesse/gui/hardware_set/finesse_seneca.yaml
@@ -3,22 +3,22 @@ devices:
   stepper_motor:
     class_name: stepper_motor.st10_controller.ST10Controller
     params:
-      port: "0403:6011 FT1NMSVR"
+      port: "0403:6011"
       baudrate: 9600
   temperature_controller.hot_bb:
     class_name: temperature.tc4820.TC4820
     params:
-      port: "0403:6011 FT1NMSVR (2)"
+      port: "0403:6011 (2)"
       baudrate: 115200
   temperature_controller.cold_bb:
     class_name: temperature.tc4820.TC4820
     params:
-      port: "0403:6011 FT1NMSVR (3)"
+      port: "0403:6011 (3)"
       baudrate: 115200
   temperature_monitor:
     class_name: temperature.senecak107.SenecaK107
     params:
-      port: "0403:6001 AB0LMVI5"
+      port: "0403:6001"
       baudrate: 57600
   em27_sensors:
     class_name: em27.em27_sensors.EM27Sensors

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -172,7 +172,7 @@ class ST10Controller(SerialDevice, StepperMotorBase, description="ST10 controlle
         """Create a new ST10Controller.
 
         Args:
-            port: Description of USB port (vendor ID + product ID + serial number)
+            port: Description of USB port (vendor ID + product ID)
             baudrate: Baud rate of port
             timeout: Connection timeout
 

--- a/finesse/hardware/plugins/temperature/dp9800.py
+++ b/finesse/hardware/plugins/temperature/dp9800.py
@@ -96,7 +96,7 @@ class DP9800(SerialDevice, TemperatureMonitorBase, description="DP9800"):
         """Create a new DP9800.
 
         Args:
-            port: Description of USB port (vendor ID + product ID + serial number)
+            port: Description of USB port (vendor ID + product ID)
             baudrate: Baud rate of port
         """
         SerialDevice.__init__(self, port, baudrate)

--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -43,7 +43,7 @@ class SenecaK107(SerialDevice, TemperatureMonitorBase, description="Seneca K107"
         """Create a new SenecaK107.
 
         Args:
-            port: Description of USB port (vendor ID + product ID + serial number)
+            port: Description of USB port (vendor ID + product ID)
             baudrate: Baud rate of port
             min_temp: The minimum temperature limit of the device.
             max_temp: The maximum temperature limit of the device.

--- a/finesse/hardware/plugins/temperature/tc4820.py
+++ b/finesse/hardware/plugins/temperature/tc4820.py
@@ -39,7 +39,7 @@ class TC4820(SerialDevice, TemperatureControllerBase, description="TC4820"):
 
         Args:
             name: The name of the device, to distinguish it from others
-            port: Description of USB port (vendor ID + product ID + serial number)
+            port: Description of USB port (vendor ID + product ID)
             baudrate: Baud rate of port
             max_attempts: Maximum number of attempts for requests
         """

--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -7,7 +7,7 @@ from finesse.hardware.serial_device import _get_usb_serial_ports, _port_info_to_
 @patch("finesse.hardware.serial_device.comports")
 def test_get_usb_serial_ports_cached(comports_mock: Mock) -> None:
     """Check that _get_usb_serial_ports() works when results have been cached."""
-    serial_ports = {_port_info_to_str(1, 2, "SERIAL", 0): "COM1"}
+    serial_ports = {_port_info_to_str(1, 2, 0): "COM1"}
     with patch("finesse.hardware.serial_device._serial_ports", serial_ports):
         assert _get_usb_serial_ports() == serial_ports
         comports_mock.assert_not_called()
@@ -18,7 +18,6 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
     """Test _get_usb_serial_ports()."""
     VID = 1
     PID = 2
-    SERIAL = "SERIAL"
 
     ports = []
     for comport in ("COM1", "COM2", "COM3"):
@@ -27,7 +26,6 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
 
         info.vid = VID
         info.pid = PID
-        info.serial_number = SERIAL
 
         ports.append(info)
 
@@ -38,6 +36,6 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
 
     with patch("finesse.hardware.serial_device._serial_ports", None):
         assert _get_usb_serial_ports() == {
-            _port_info_to_str(VID, PID, SERIAL, 0): "COM1",
-            _port_info_to_str(VID, PID, SERIAL, 1): "COM3",
+            _port_info_to_str(VID, PID, 0): "COM1",
+            _port_info_to_str(VID, PID, 1): "COM3",
         }


### PR DESCRIPTION
# Description

Owing to #458, we cannot rely on USB serial numbers on Windows (at least until the upstream bug is fixed). In the interim, drop the use of serial numbers to distinguish devices and just use the vendor and product IDs. I have confirmed with @jonemurray that both the FINESSE and UNIRAS rigs will use serial adaptors of different makes/models, so these IDs will be different.

Once the upstream bug is fixed, we should revert this change, otherwise users will not be able to use two USB serial adaptors of the same make and model at the same time (or, at least, they won't be able to use the hardware set functionality).

Closes #458.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
