### PR TITLE
`ScriptRunner`: Add proper transitions for cancelling from "waiting" states

### DIFF
--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -203,6 +203,10 @@ class ScriptRunner(StateMachine):
     """Trigger a move to the angle for the next measurement."""
     finish = moving.to(not_running)
     """To be called when all measurements are complete."""
+    cancel_waiting_to_move = waiting_to_move.to(not_running)
+    """Cancel the script from a waiting to move state."""
+    cancel_waiting_to_measure = waiting_to_measure.to(not_running)
+    """Cancel the script from a waiting to measure state."""
 
     def __init__(
         self,
@@ -374,9 +378,10 @@ class ScriptRunner(StateMachine):
                 self.cancel_move()
             case self.measuring:
                 self.cancel_measuring()
-            case self.waiting_to_measure | self.waiting_to_move:
-                # These states don't need any special handling
-                self.current_state = self.not_running
+            case self.waiting_to_measure:
+                self.cancel_waiting_to_measure()
+            case self.waiting_to_move:
+                self.cancel_waiting_to_move()
 
         logging.info("Aborting measure script")
 


### PR DESCRIPTION
# Description

It seems that assigning to the `current_state` of a state machine circumvents all the hooks etc., which in the case of `ScriptRunner` causes issues if the user clicks cancel while a script is paused (#463). Fix by adding proper transitions for cancelling from "waiting" states.

Fixes #463.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
