### PR TITLE
Fix: Sort COM ports

### DIFF
--- a/finesse/hardware/serial_device.py
+++ b/finesse/hardware/serial_device.py
@@ -1,6 +1,8 @@
 """Provides a base class for USB serial devices."""
 from __future__ import annotations
 
+import logging
+
 from serial import Serial, SerialException
 from serial.tools.list_ports import comports
 
@@ -49,6 +51,14 @@ def _get_usb_serial_ports() -> dict[str, str]:
 
         _serial_ports[_port_info_to_str(*key, counter[key])] = port.device
         counter[key] += 1
+
+    if not _serial_ports:
+        logging.warning("No USB serial devices found")
+    else:
+        port_strs = "\t- ".join(
+            f"{port}: {desc}" for desc, port in _serial_ports.items()
+        )
+        logging.info(f"Found the following USB serial devices:\n{port_strs}")
 
     # Sort by the string representation of the key
     _serial_ports = dict(sorted(_serial_ports.items(), key=lambda item: item[0]))

--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -1,7 +1,13 @@
 """Tests for core serial device code."""
 from unittest.mock import MagicMock, Mock, patch
 
-from finesse.hardware.serial_device import _get_usb_serial_ports, _port_info_to_str
+import pytest
+
+from finesse.hardware.serial_device import (
+    _get_port_number,
+    _get_usb_serial_ports,
+    _port_info_to_str,
+)
 
 
 @patch("finesse.hardware.serial_device.comports")
@@ -20,7 +26,7 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
     PID = 2
 
     ports = []
-    for comport in ("COM1", "COM2", "COM3"):
+    for comport in ("COM3", "COM2", "COM1"):
         info = MagicMock()
         info.device = comport
 
@@ -39,3 +45,16 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
             _port_info_to_str(VID, PID, 0): "COM1",
             _port_info_to_str(VID, PID, 1): "COM3",
         }
+
+
+@pytest.mark.parametrize(
+    "port,number",
+    (
+        (f"{prefix}{number}", number)
+        for number in (1, 2, 10)
+        for prefix in ("COM", "/dev/ttyUSB")
+    ),
+)
+def test_get_port_number(port: str, number: int) -> None:
+    """Test _get_port_number()."""
+    assert _get_port_number(port) == number


### PR DESCRIPTION
# Description

I found another problem with getting the USB serial ports: it turns out they're not sorted, so you can get, e.g. COM5 appearing before COM4. This breaks FINESSE which uses the order to distinguish COM ports on multiport devices. Fix by sorting the COM ports.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
