### PR TITLE
Fix: Use `closeEvent()` cf. `hideEvent()` to identify when window closed

### DIFF
--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -1,7 +1,7 @@
 """Code for FINESSE's main GUI window."""
 
 from pubsub import pub
-from PySide6.QtGui import QHideEvent, QShowEvent
+from PySide6.QtGui import QCloseEvent, QShowEvent
 from PySide6.QtWidgets import (
     QGridLayout,
     QGroupBox,
@@ -98,6 +98,6 @@ class MainWindow(QMainWindow):
         """Send window.opened message."""
         pub.sendMessage("window.opened")
 
-    def hideEvent(self, event: QHideEvent) -> None:
+    def closeEvent(self, event: QCloseEvent) -> None:
         """Send window.closed message."""
         pub.sendMessage("window.closed")


### PR DESCRIPTION
# Description

I think this bug must have been around for a while and it's rather embarrassing. It turns out we've been using the main window's `hideEvent` method to check for when the window is closed. While it *is* run when the window is closed, it also turns out it's invoked when the window is minimised (on Windows at least). This means that currently if you minimise the window, all of the connected devices will disconnect, as they are supposed to do when the window closes.

I'm not sure whether `closeEvent` wasn't working for me on Linux before (it seems fine now, although admittedly I am using a weird tiling window manager), or if I went with `hideEvent` for the symmetry with the `showEvent` handling we have next to it. In any case, I didn't think it would be invoked when the window was minimised.

Oops.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
