### PR TITLE
Fix: Move device error message code to HardwareSetsControl

### DIFF
--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -216,7 +216,6 @@ class DeviceTypeControl(QGroupBox):
         # pubsub subscriptions
         pub.subscribe(self._on_device_opened, f"device.opening.{instance!s}")
         pub.subscribe(self._set_device_closed, f"device.closed.{instance!s}")
-        pub.subscribe(self._show_error_message, f"device.error.{instance!s}")
 
     def _update_open_btn_enabled_state(self) -> None:
         """Enable button depending on whether there are options for all params.
@@ -304,20 +303,6 @@ class DeviceTypeControl(QGroupBox):
     def _close_device(self) -> None:
         """Close the device."""
         close_device(self._device_instance)
-
-    def _show_error_message(
-        self, instance: DeviceInstanceRef, error: BaseException
-    ) -> None:
-        """Show an error message when something has gone wrong with the device.
-
-        Todo:
-            The name of the device isn't currently very human readable.
-        """
-        show_error_message(
-            self,
-            f"A fatal error has occurred with the {instance!s} device: {error!s}",
-            title="Device error",
-        )
 
     def _on_open_close_clicked(self) -> None:
         """Open/close the connection of the chosen device when the button is pushed."""

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -75,6 +75,7 @@ class HardwareSetsControl(QGroupBox):
         self._connected_devices: set[OpenDeviceArgs] = set()
         pub.subscribe(self._on_device_opened, "device.opening")
         pub.subscribe(self._on_device_closed, "device.closed")
+        pub.subscribe(self._on_device_error, "device.error")
 
         self._combo = HardwareSetsComboBox()
         """A combo box for the different hardware sets."""
@@ -237,3 +238,17 @@ class HardwareSetsControl(QGroupBox):
         except StopIteration:
             # No device of this type found
             pass
+
+    def _on_device_error(
+        self, instance: DeviceInstanceRef, error: BaseException
+    ) -> None:
+        """Show an error message when something has gone wrong with the device.
+
+        Todo:
+            The name of the device isn't currently very human readable.
+        """
+        show_error_message(
+            self,
+            f"A fatal error has occurred with the {instance!s} device: {error!s}",
+            title="Device error",
+        )

--- a/tests/gui/hardware_set/test_device_type_control.py
+++ b/tests/gui/hardware_set/test_device_type_control.py
@@ -88,7 +88,6 @@ def test_init(
         [
             call(widget._on_device_opened, f"device.opening.{instance!s}"),
             call(widget._set_device_closed, f"device.closed.{instance!s}"),
-            call(widget._show_error_message, f"device.error.{instance!s}"),
         ]
     )
 
@@ -237,15 +236,6 @@ def test_on_device_opened(widget: DeviceTypeControl, qtbot) -> None:
     with patch.object(widget, "_set_device_opened") as open_mock:
         widget._on_device_opened(DeviceInstanceRef("base_type"), "some_class", {})
         open_mock.assert_called_once_with("some_class")
-
-
-@patch("finesse.gui.hardware_set.device_view.show_error_message")
-def test_show_error_message(
-    error_message_mock: Mock, widget: DeviceTypeControl, qtbot
-) -> None:
-    """Test the _show_error_message() method."""
-    widget._show_error_message(DeviceInstanceRef("base_type"), RuntimeError("boo"))
-    error_message_mock.assert_called_once()
 
 
 def test_open_close_btn(widget: DeviceTypeControl, qtbot) -> None:

--- a/tests/gui/hardware_set/test_hardware_sets_view.py
+++ b/tests/gui/hardware_set/test_hardware_sets_view.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 
 import pytest
 
+from finesse.device_info import DeviceInstanceRef
 from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
 from finesse.gui.hardware_set.hardware_sets_view import (
     HardwareSetsControl,
@@ -295,6 +296,15 @@ def test_on_device_closed_not_found(hw_control: HardwareSetsControl, qtbot) -> N
     assert not hw_control._connected_devices
     with does_not_raise():
         hw_control._on_device_closed(device.instance)
+
+
+@patch("finesse.gui.hardware_set.hardware_sets_view.show_error_message")
+def test_on_device_error(
+    error_message_mock: Mock, hw_control: HardwareSetsControl, qtbot
+) -> None:
+    """Test the _on_device_error() method."""
+    hw_control._on_device_error(DeviceInstanceRef("base_type"), RuntimeError("boo"))
+    error_message_mock.assert_called_once()
 
 
 def test_show_manage_devices_dialog(hw_control: HardwareSetsControl, qtbot) -> None:


### PR DESCRIPTION
# Description

Currently, the code responsible for showing an error message when a device error occurs lives in the DeviceControl class, where it always has. The problem is that nowadays a DeviceControl is only created when the user clicks "Manage devices", meaning that otherwise no error dialogs will be shown for device errors.

Fix by moving the relevant code to the HardwareSetsControl class instead.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
