### PR TITLE
Refresh COM ports if device not found

### DIFF
--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -1,9 +1,12 @@
 """Tests for core serial device code."""
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from serial import SerialException
 
 from finesse.hardware.serial_device import (
+    SerialDevice,
     _get_port_number,
     _get_usb_serial_ports,
     _port_info_to_str,
@@ -19,8 +22,13 @@ def test_get_usb_serial_ports_cached(comports_mock: Mock) -> None:
         comports_mock.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "refresh,serial_ports", ((False, None), (True, {"key": "value"}))
+)
 @patch("finesse.hardware.serial_device.comports")
-def test_get_usb_serial_ports(comports_mock: Mock) -> None:
+def test_get_usb_serial_ports(
+    comports_mock: Mock, refresh: bool, serial_ports: Any
+) -> None:
     """Test _get_usb_serial_ports()."""
     VID = 1
     PID = 2
@@ -40,8 +48,8 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
 
     comports_mock.return_value = ports
 
-    with patch("finesse.hardware.serial_device._serial_ports", None):
-        assert _get_usb_serial_ports() == {
+    with patch("finesse.hardware.serial_device._serial_ports", serial_ports):
+        assert _get_usb_serial_ports(refresh) == {
             _port_info_to_str(VID, PID, 0): "COM1",
             _port_info_to_str(VID, PID, 1): "COM3",
         }
@@ -58,3 +66,60 @@ def test_get_usb_serial_ports(comports_mock: Mock) -> None:
 def test_get_port_number(port: str, number: int) -> None:
     """Test _get_port_number()."""
     assert _get_port_number(port) == number
+
+
+def test_get_port_number_bad() -> None:
+    """Test _get_port_number() when a bad value is provided."""
+    with pytest.raises(ValueError):
+        _get_port_number("NO_NUMBER")
+
+
+@patch("finesse.hardware.serial_device._serial_ports", {"name1": "COM1"})
+@patch("finesse.hardware.serial_device.Serial")
+def test_init(serial_mock: Mock) -> None:
+    """Test SerialDevice's constructor."""
+    serial = MagicMock()
+    serial_mock.return_value = serial
+    dev = SerialDevice("name1", 1234)
+    serial_mock.assert_called_once_with(port="COM1", baudrate=1234)
+    assert dev.serial is serial
+
+
+@patch(
+    "finesse.hardware.serial_device._get_usb_serial_ports",
+    return_value={"name2": "COM2"},
+)
+@patch("finesse.hardware.serial_device._serial_ports", {"name1": "COM1"})
+@patch("finesse.hardware.serial_device.Serial")
+def test_init_refresh_succeed(serial_mock: Mock, get_ports_mock: Mock) -> None:
+    """Test SerialDevice's constructor succeeds after refreshing ports."""
+    serial = MagicMock()
+    serial_mock.return_value = serial
+    dev = SerialDevice("name2", 1234)
+    serial_mock.assert_called_once_with(port="COM2", baudrate=1234)
+    assert dev.serial is serial
+
+
+@patch(
+    "finesse.hardware.serial_device._get_usb_serial_ports",
+    return_value={"name2": "COM2"},
+)
+@patch("finesse.hardware.serial_device._serial_ports", {"name1": "COM1"})
+@patch("finesse.hardware.serial_device.Serial")
+def test_init_refresh_fail(serial_mock: Mock, get_ports_mock: Mock) -> None:
+    """Test SerialDevice's constructor raises an exception if the port isn't found."""
+    with pytest.raises(SerialException):
+        SerialDevice("name3", 1234)
+
+
+@patch("finesse.hardware.serial_device._serial_ports", {"name1": "COM1"})
+@patch("finesse.hardware.serial_device.Serial")
+def test_close(serial_mock: Mock) -> None:
+    """Test SerialDevice's close() method."""
+    serial = MagicMock()
+    serial_mock.return_value = serial
+    dev = SerialDevice("name1", 1234)
+    serial_mock.assert_called_once_with(port="COM1", baudrate=1234)
+
+    dev.close()
+    serial.close.assert_called_once_with()


### PR DESCRIPTION
# Description

THIS SHOULD NOT BE MERGED BEFORE v1.3

If the user starts FINESSE with one or more of the USB devices not connected (or powered off) then they may be unable to use it, even if it is connected later. The only remedy is to restart the program. The reason for this is because the list of serial ports is retrieved once when the SerialDevice class is created and the result is cached.

An easy workaround for this is to force-refresh the list of serial ports if a given port isn't found. This is a small QoL improvement for users.

This relates to #335, but doesn't fix it (the list of serial ports in the GUI won't be updated when they are refreshed).

Someone needs to test this before we merge it. To test:

- Start FINESSE with *at least one USB device disconnected*
- Try to connect to a FINESSE hardware set; you should get an error
- Connect the USB cables
- Try to connect again; it should succeed

You don't need a working spectrometer to test this.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
