### PR TITLE
OPUS: Poll status on backend

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -68,6 +68,14 @@ TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
 OPUS_IP = "10.10.0.2"
 """The IP address of the machine running the OPUS software."""
 
+OPUS_POLLING_INTERVAL = 1.0
+"""How long to wait between polls of the EM27's status.
+
+Note that in reality the minimum poll interval is ~2s, because that's how long the
+device takes to reply. This value then determines how often we wait before even starting
+a request.
+"""
+
 SPECTROMETER_TOPIC = "spectrometer"
 """The topic name to use for spectrometer-related messages."""
 

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import yaml
 from pubsub import pub
-from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QWidget
 from schema import And, Or, Schema, SchemaError
 from statemachine import State, StateMachine
@@ -125,11 +124,6 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
         raise ParseError() from e
 
 
-def _poll_spectrometer_status() -> None:
-    """Request the spectrometer's status."""
-    pub.sendMessage(f"device.{SPECTROMETER_TOPIC}.request", command="status")
-
-
 class ScriptIterator:
     """Allows for iterating through a Script with the required number of repeats."""
 
@@ -211,21 +205,13 @@ class ScriptRunner(StateMachine):
     def __init__(
         self,
         script: Script,
-        min_poll_interval: float = 1.0,
         parent: QWidget | None = None,
     ) -> None:
         """Create a new ScriptRunner.
 
-        Note that the EM27 often takes more than one second to respond to requests,
-        hence why we set a minimum polling interval rather than an absolute one.
-
         Args:
             script: The script to run
-            min_poll_interval: Minimum rate at which to poll EM27 (seconds)
             parent: The parent widget
-
-        Todo:
-            Error handling for the stepper motor
         """
         self.script = script
         """The running script."""
@@ -240,12 +226,6 @@ class ScriptRunner(StateMachine):
         """The current measurement to acquire."""
         self.current_measurement_count: int
         """How many times a measurement has been recorded at the current angle."""
-
-        self._check_status_timer = QTimer()
-        """A timer which checks whether the EM27's measurement is complete."""
-        self._check_status_timer.setSingleShot(True)
-        self._check_status_timer.setInterval(round(1000 * min_poll_interval))
-        self._check_status_timer.timeout.connect(_poll_spectrometer_status)
 
         # Send stop command in case motor is moving
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.stop")
@@ -272,7 +252,7 @@ class ScriptRunner(StateMachine):
             return
 
         # Stepper motor messages
-        pub.unsubscribe(self.start_measuring, f"device.{STEPPER_MOTOR_TOPIC}.move.end")
+        pub.unsubscribe(self.finish_moving, f"device.{STEPPER_MOTOR_TOPIC}.move.end")
         pub.unsubscribe(
             self._on_stepper_motor_error, f"device.error.{STEPPER_MOTOR_TOPIC}"
         )
@@ -331,11 +311,10 @@ class ScriptRunner(StateMachine):
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.notify_on_stopped")
 
     def on_exit_measuring(self) -> None:
-        """Ensure that the polling timer is stopped."""
-        self._check_status_timer.stop()
-
+        """Unsubscribe from pubsub topics."""
         pub.unsubscribe(
-            self._on_spectrometer_status_received, f"device.{SPECTROMETER_TOPIC}.status"
+            self._measuring_end,
+            f"device.{SPECTROMETER_TOPIC}.status.connected",
         )
 
     def on_enter_waiting_to_move(self) -> None:
@@ -353,7 +332,7 @@ class ScriptRunner(StateMachine):
             self._request_measurement()
 
     def on_exit_waiting_to_measure(self) -> None:
-        """Ensure that we have unsubscribed from pubsub topics."""
+        """Unsubscribe from pubsub topics."""
         pub.unsubscribe(
             self._measuring_start, f"device.{SPECTROMETER_TOPIC}.status.measuring"
         )
@@ -373,19 +352,10 @@ class ScriptRunner(StateMachine):
         )
         self.start_measuring()
 
-        # Start polling
+        # Listen for status changes
         pub.subscribe(
-            self._on_spectrometer_status_received, f"device.{SPECTROMETER_TOPIC}.status"
+            self._measuring_end, f"device.{SPECTROMETER_TOPIC}.status.connected"
         )
-        _poll_spectrometer_status()
-
-    def _on_spectrometer_status_received(self, status: SpectrometerStatus):
-        """Move on to the next measurement if the measurement has finished."""
-        if status == SpectrometerStatus.CONNECTED:  # indicates measurement is finished
-            self._measuring_end()
-        else:
-            # Poll again later
-            self._check_status_timer.start()
 
     def abort(self) -> None:
         """Abort the current measure script run."""
@@ -435,7 +405,7 @@ class ScriptRunner(StateMachine):
             f"The measure script will stop running.\n\n{error!s}",
         )
 
-    def _measuring_end(self) -> None:
+    def _measuring_end(self, status: SpectrometerStatus) -> None:
         """Move onto the next measurement or perform another measurement here."""
         self.current_measurement_count += 1
         if self.current_measurement_count == self.current_measurement.measurements:

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -364,15 +364,11 @@ class ScriptRunner(StateMachine):
         if not self.paused:
             self.finish_waiting_for_measure()
 
-    def _measuring_started(
-        self,
-        status: SpectrometerStatus,
-        text: str,
-    ):
+    def _measuring_started(self, status: SpectrometerStatus):
         """Start polling the EM27 so we know when the measurement is finished."""
         _poll_spectrometer_status()
 
-    def _status_received(self, status: SpectrometerStatus, text: str):
+    def _status_received(self, status: SpectrometerStatus):
         """Move on to the next measurement if the measurement has finished."""
         if status == SpectrometerStatus.CONNECTED:  # indicates measurement is finished
             self._measuring_end()

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -129,7 +129,7 @@ class ScriptControl(QGroupBox):
         self.run_dialog.hide()
         del self.run_dialog
 
-    def _on_spectrometer_message(self, status: SpectrometerStatus, text: str) -> None:
+    def _on_spectrometer_message(self, status: SpectrometerStatus) -> None:
         """Change the enable counter when the spectrometer connects/disconnects."""
         if status.is_connected == self._spectrometer_connected:
             # The connection status hasn't changed

--- a/finesse/gui/measure_script/script_view.py
+++ b/finesse/gui/measure_script/script_view.py
@@ -63,7 +63,8 @@ class ScriptControl(QGroupBox):
         # Monitor spectrometer to enable/disable run button on connect/disconnect
         self._spectrometer_connected = False
         pub.subscribe(
-            self._on_spectrometer_message, f"device.{SPECTROMETER_TOPIC}.response"
+            self._on_spectrometer_status,
+            f"device.{SPECTROMETER_TOPIC}.status",
         )
 
         # Show/hide self.run_dialog on measure script begin/end
@@ -129,7 +130,7 @@ class ScriptControl(QGroupBox):
         self.run_dialog.hide()
         del self.run_dialog
 
-    def _on_spectrometer_message(self, status: SpectrometerStatus) -> None:
+    def _on_spectrometer_status(self, status: SpectrometerStatus) -> None:
         """Change the enable counter when the spectrometer connects/disconnects."""
         if status.is_connected == self._spectrometer_connected:
             # The connection status hasn't changed

--- a/finesse/gui/spectrometer_view.py
+++ b/finesse/gui/spectrometer_view.py
@@ -24,7 +24,7 @@ from finesse.spectrometer_status import SpectrometerStatus
 class SpectrometerControl(DevicePanel):
     """Class to monitor and control spectrometers."""
 
-    COMMANDS = ("status", "cancel", "stop", "start", "connect")
+    COMMANDS = ("connect", "start", "stop", "cancel")
     """The default commands shown."""
 
     def __init__(self, commands: Sequence[str] = COMMANDS) -> None:

--- a/finesse/gui/spectrometer_view.py
+++ b/finesse/gui/spectrometer_view.py
@@ -96,15 +96,11 @@ class SpectrometerControl(DevicePanel):
         """Log when a command request is sent."""
         self.logger.info(f'Executing command "{command}"')
 
-    def _log_response(
-        self,
-        status: SpectrometerStatus,
-        text: str,
-    ) -> None:
-        self.logger.info(f"Response ({status.value}): {text}")
+    def _log_response(self, status: SpectrometerStatus) -> None:
+        self.logger.info(f"Status: {status.name}")
 
     def _log_error(self, instance: DeviceInstanceRef, error: BaseException) -> None:
-        self.logger.error(f"Error during request: {str(error)}")
+        self.logger.error(f"Error during request: {error!s}")
 
     def on_command_button_clicked(self, command: str) -> None:
         """Execute the given command by sending a message to the appropriate topic.

--- a/finesse/gui/spectrometer_view.py
+++ b/finesse/gui/spectrometer_view.py
@@ -43,7 +43,7 @@ class SpectrometerControl(DevicePanel):
         )
 
         pub.subscribe(self._log_request, f"device.{SPECTROMETER_TOPIC}.request")
-        pub.subscribe(self._log_response, f"device.{SPECTROMETER_TOPIC}.response")
+        pub.subscribe(self._log_response, f"device.{SPECTROMETER_TOPIC}.status")
         pub.subscribe(self._log_error, f"device.error.{SPECTROMETER_TOPIC}")
 
     def _create_controls(self) -> QHBoxLayout:

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -99,10 +99,6 @@ class OPUSStateMachine(StateMachine):
         """Stop the measurement timer."""
         self.measure_timer.stop()
 
-    def on_enter_state(self, target: State) -> None:
-        """Log all state transitions."""
-        logging.info(f"Current state: {target.name}")
-
 
 class DummyOPUSInterface(
     OPUSInterfaceBase,

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -162,9 +162,6 @@ class DummyOPUSInterface(
     def request_command(self, command: str) -> None:
         """Execute the specified command on the device.
 
-        Note that we treat "status" as a command, even though it requires a different
-        URL to access.
-
         Args:
             command: The command to run
         Raises:
@@ -182,7 +179,8 @@ class DummyOPUSInterface(
             raise OPUSError.from_response(*errinfo)
 
         # Broadcast the response for the command
-        self.send_response(command, self.state_machine.current_state.value)
+        value = self.state_machine.current_state_value
+        self.send_status_message(value)
 
     def _measuring_finished(self) -> None:
         """Finish measurement successfully."""

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -182,8 +182,7 @@ class DummyOPUSInterface(
             raise OPUSError.from_response(*errinfo)
 
         # Broadcast the response for the command
-        state = self.state_machine.current_state
-        self.send_response(command, status=state.value, text=state.name)
+        self.send_response(command, self.state_machine.current_state.value)
 
     def _measuring_finished(self) -> None:
         """Finish measurement successfully."""

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -175,7 +175,3 @@ class DummyOPUSInterface(
     def on_enter_state(self, target: State) -> None:
         """Broadcast state changes via pubsub."""
         self.send_status_message(target.value)
-
-    def on_exit_measuring(self) -> None:
-        """Finish measurement successfully."""
-        logging.info("Measurement complete")

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -137,6 +137,14 @@ class DummyOPUSInterface(
         # Monitor state changes
         self.state_machine.add_observer(self)
 
+    def close(self) -> None:
+        """Close the device.
+
+        If a measurement is running, cancel it.
+        """
+        self.state_machine.measure_timer.stop()
+        super().close()
+
     def _run_command(self, command: str) -> None:
         """Try to run the specified command.
 

--- a/finesse/hardware/plugins/spectrometer/opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface.py
@@ -76,6 +76,11 @@ class OPUSInterface(OPUSInterfaceBase, description="OPUS spectrometer"):
 
         self._request_status()
 
+    def close(self) -> None:
+        """Close the device."""
+        self._status_timer.stop()
+        super().close()
+
     @Slot()
     def _on_reply_received(self, reply: QNetworkReply) -> None:
         """Handle received HTTP reply."""

--- a/finesse/hardware/plugins/spectrometer/opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface.py
@@ -52,8 +52,6 @@ def parse_response(response: str) -> SpectrometerStatus:
     if errcode is not None:
         raise OPUSError.from_response(errcode, errtext)
 
-    logging.info(f"OPUS response ({status.value}): {text}")
-
     return status
 
 

--- a/finesse/hardware/plugins/spectrometer/opus_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface_base.py
@@ -29,9 +29,6 @@ class OPUSInterfaceBase(Device, name=SPECTROMETER_TOPIC, description="OPUS devic
     def request_command(self, command: str) -> None:
         """Request that OPUS run the specified command.
 
-        Note that we treat "status" as a command, even though it requires a different
-        URL to access.
-
         Args:
             command: Name of command to run
         """

--- a/finesse/hardware/plugins/spectrometer/opus_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface_base.py
@@ -36,8 +36,6 @@ class OPUSInterfaceBase(Device, name=SPECTROMETER_TOPIC, description="OPUS devic
             command: Name of command to run
         """
 
-    def send_response(
-        self, command: str, status: SpectrometerStatus, text: str
-    ) -> None:
+    def send_response(self, command: str, status: SpectrometerStatus) -> None:
         """Broadcast the device's response via pubsub."""
-        self.send_message(f"response.{command}", status=status, text=text)
+        self.send_message(f"response.{command}", status=status)

--- a/finesse/hardware/plugins/spectrometer/opus_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface_base.py
@@ -36,6 +36,6 @@ class OPUSInterfaceBase(Device, name=SPECTROMETER_TOPIC, description="OPUS devic
             command: Name of command to run
         """
 
-    def send_response(self, command: str, status: SpectrometerStatus) -> None:
-        """Broadcast the device's response via pubsub."""
-        self.send_message(f"response.{command}", status=status)
+    def send_status_message(self, status: SpectrometerStatus) -> None:
+        """Send a status update via pubsub."""
+        self.send_message(f"status.{status.name.lower()}", status=status)

--- a/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -15,11 +15,6 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
         """
         super().__init__()
 
-        # Versions of methods which catch and broadcast errors via pubsub
-        self._move_to = self.pubsub_errors(self.move_to)
-        self._stop_moving = self.pubsub_errors(self.stop_moving)
-        self._notify_on_stopped = self.pubsub_errors(self.notify_on_stopped)
-
         self.subscribe(self.move_to, "move.begin")
         self.subscribe(self.stop_moving, "stop")
         self.subscribe(self.notify_on_stopped, "notify_on_stopped")

--- a/tests/gui/measure_script/conftest.py
+++ b/tests/gui/measure_script/conftest.py
@@ -12,10 +12,12 @@ from finesse.gui.measure_script.script_run_dialog import ScriptRunDialog
 
 
 @pytest.fixture
-def runner():
+def runner(subscribe_mock: MagicMock, sendmsg_mock: MagicMock) -> ScriptRunner:
     """Fixture for a ScriptRunner in its initial state."""
     script = Script(Path(), 1, ({"angle": 0.0, "measurements": 3},))
     runner = ScriptRunner(script)
+    subscribe_mock.reset_mock()
+    sendmsg_mock.reset_mock()
     runner._check_status_timer = MagicMock()
     return runner
 
@@ -27,6 +29,7 @@ def runner_measuring(
     """Fixture for a ScriptRunner in a measuring state."""
     runner.start_moving()
     runner.start_measuring()
+    subscribe_mock.reset_mock()
     sendmsg_mock.reset_mock()
     return runner
 

--- a/tests/gui/measure_script/conftest.py
+++ b/tests/gui/measure_script/conftest.py
@@ -24,12 +24,17 @@ def runner(subscribe_mock: MagicMock, sendmsg_mock: MagicMock) -> ScriptRunner:
 
 @pytest.fixture
 def runner_measuring(
-    runner: ScriptRunner, subscribe_mock: MagicMock, sendmsg_mock: MagicMock
+    runner: ScriptRunner,
+    subscribe_mock: MagicMock,
+    unsubscribe_mock: MagicMock,
+    sendmsg_mock: MagicMock,
 ) -> ScriptRunner:
     """Fixture for a ScriptRunner in a measuring state."""
     runner.start_moving()
+    runner.finish_moving()
     runner.start_measuring()
     subscribe_mock.reset_mock()
+    unsubscribe_mock.reset_mock()
     sendmsg_mock.reset_mock()
     return runner
 

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -207,7 +207,7 @@ def test_measuring_started_success(
     runner.current_state = ScriptRunner.measuring
 
     # Simulate response from EM27
-    runner._measuring_started(SpectrometerStatus.IDLE, "")
+    runner._measuring_started(SpectrometerStatus.IDLE)
 
     # Check the request is sent to the EM27
     poll_spectrometer_mock.assert_called_once()
@@ -219,7 +219,7 @@ def test_status_received(
 ) -> None:
     """Test that polling the EM27's status works."""
     with patch.object(runner_measuring, "_measuring_end") as measuring_end_mock:
-        runner_measuring._status_received(status, "")
+        runner_measuring._status_received(status)
 
         if status == SpectrometerStatus.CONNECTED:  # indicates success
             measuring_end_mock.assert_called_once()

--- a/tests/gui/measure_script/test_script_view.py
+++ b/tests/gui/measure_script/test_script_view.py
@@ -48,7 +48,8 @@ def test_init(settings_mock: Mock, subscribe_mock: Mock, qtbot: QtBot) -> None:
         script_control._hide_run_dialog, "measure_script.end"
     )
     subscribe_mock.assert_any_call(
-        script_control._on_spectrometer_message, f"device.{SPECTROMETER_TOPIC}.response"
+        script_control._on_spectrometer_status,
+        f"device.{SPECTROMETER_TOPIC}.status",
     )
     assert not script_control._spectrometer_connected
 
@@ -283,7 +284,7 @@ def test_on_opus_message_connect(
     script_control._spectrometer_connected = already_connected
 
     with patch.object(script_control, "_enable_counter") as counter_mock:
-        script_control._on_spectrometer_message(status)
+        script_control._on_spectrometer_status(status)
         if already_connected:
             counter_mock.increment.assert_not_called()
         else:
@@ -308,7 +309,7 @@ def test_on_opus_message_disconnect(
     script_control._spectrometer_connected = already_connected
 
     with patch.object(script_control, "_enable_counter") as counter_mock:
-        script_control._on_spectrometer_message(status)
+        script_control._on_spectrometer_status(status)
         if not already_connected:
             counter_mock.decrement.assert_not_called()
         else:

--- a/tests/gui/measure_script/test_script_view.py
+++ b/tests/gui/measure_script/test_script_view.py
@@ -283,7 +283,7 @@ def test_on_opus_message_connect(
     script_control._spectrometer_connected = already_connected
 
     with patch.object(script_control, "_enable_counter") as counter_mock:
-        script_control._on_spectrometer_message(status, "")
+        script_control._on_spectrometer_message(status)
         if already_connected:
             counter_mock.increment.assert_not_called()
         else:
@@ -308,7 +308,7 @@ def test_on_opus_message_disconnect(
     script_control._spectrometer_connected = already_connected
 
     with patch.object(script_control, "_enable_counter") as counter_mock:
-        script_control._on_spectrometer_message(status, "")
+        script_control._on_spectrometer_message(status)
         if not already_connected:
             counter_mock.decrement.assert_not_called()
         else:

--- a/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
@@ -46,9 +46,9 @@ def test_request_status(state: State, dev: DummyOPUSInterface) -> None:
     """Test the request_status() method."""
     dev.state_machine.current_state = state
 
-    with patch.object(dev, "send_response") as response_mock:
+    with patch.object(dev, "send_status_message") as status_mock:
         dev.request_command("status")
-        response_mock.assert_called_once_with("status", state.value)
+        status_mock.assert_called_once_with(state.value)
 
 
 def test_request_status_idle(dev: DummyOPUSInterface) -> None:
@@ -76,13 +76,13 @@ def test_request_command_success(
 ) -> None:
     """Test the request_command() method."""
     with patch.object(dev.state_machine, "measure_timer") as timer_mock:
-        with patch.object(dev, "send_response") as response_mock:
+        with patch.object(dev, "send_status_message") as status_mock:
             dev.state_machine.current_state = initial_state
             dev.request_command(command)
 
     # Check that the right response message was sent
     state = dev.state_machine.current_state
-    response_mock.assert_called_once_with(command, state.value)
+    status_mock.assert_called_once_with(state.value)
 
     # Check that the right thing has been done to the timer
     if timer_command:

--- a/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
@@ -187,10 +187,3 @@ def test_on_enter_state(state: State, opus: DummyOPUSInterface) -> None:
     """Test that state changes are broadcast."""
     opus.on_enter_state(state)
     opus.send_status_message.assert_called_once_with(state.value)  # type: ignore
-
-
-@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.logging")
-def test_on_exit_measuring(logging_mock: Mock, opus: DummyOPUSInterface) -> None:
-    """Test that a message is logged when measuring ends."""
-    opus.on_exit_measuring()
-    logging_mock.info.assert_called()

--- a/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
@@ -1,10 +1,10 @@
 """Tests for DummyOPUSInterface."""
 
-from typing import cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from statemachine import State
+from statemachine.exceptions import TransitionNotAllowed
 
 from finesse.hardware.plugins.spectrometer.dummy_opus_interface import (
     DummyOPUSInterface,
@@ -15,99 +15,182 @@ from finesse.hardware.plugins.spectrometer.dummy_opus_interface import (
 
 
 @pytest.fixture
-@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.QTimer")
-def dev(timer_mock: Mock) -> DummyOPUSInterface:
+@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.OPUSStateMachine")
+def opus(sm_mock: Mock) -> DummyOPUSInterface:
     """A fixture for DummyOPUSInterface."""
+    sm_mock.return_value = MagicMock()
+
+    with patch.object(DummyOPUSInterface, "on_enter_state"):
+        opus = DummyOPUSInterface()
+        opus.send_status_message = MagicMock()  # type: ignore[method-assign]
+        return opus
+
+
+@pytest.fixture
+@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.QTimer")
+def sm(timer_mock: Mock) -> OPUSStateMachine:
+    """A fixture for OPUSStateMachine."""
     timer_mock.return_value = MagicMock()
-
-    return DummyOPUSInterface()
-
-
-def test_init(dev: DummyOPUSInterface) -> None:
-    """Test that the timer's signal is connected correctly."""
-    assert dev.last_error == OPUSErrorInfo.NO_ERROR
-
-    timeout = cast(MagicMock, dev.state_machine.measure_timer.timeout)
-    timeout.connect.assert_called_once_with(dev.state_machine.stop)
+    return OPUSStateMachine(1.0)
 
 
-def test_finish_measuring(dev: DummyOPUSInterface) -> None:
-    """Check that the finish_measuring() slot works."""
-    dev.state_machine.current_state = OPUSStateMachine.measuring
-    dev.state_machine.stop()
-    assert dev.last_error == OPUSErrorInfo.NO_ERROR
+class _MockObserver:
+    """A state machine observer which tracks state changes."""
+
+    def __init__(self) -> None:
+        self._states: list[State] = []
+
+    def on_enter_state(self, target: State) -> None:
+        self._states.append(target)
+
+    def assert_has_states(self, *states: State) -> None:
+        assert states == tuple(self._states)
 
 
-@pytest.mark.parametrize(
-    "state",
-    (state for state in OPUSStateMachine.states if state != OPUSStateMachine.idle),
-)
-def test_request_status(state: State, dev: DummyOPUSInterface) -> None:
-    """Test the request_status() method."""
-    dev.state_machine.current_state = state
-
-    with patch.object(dev, "send_status_message") as status_mock:
-        dev.request_command("status")
-        status_mock.assert_called_once_with(state.value)
-
-
-def test_request_status_idle(dev: DummyOPUSInterface) -> None:
-    """Test the request_status() method raises an error if device not connected."""
-    dev.state_machine.current_state = OPUSStateMachine.idle
-
-    with pytest.raises(OPUSError):
-        dev.request_command("status")
-
-
-_COMMANDS = (
-    ("cancel", OPUSStateMachine.measuring, "stop"),
-    ("stop", OPUSStateMachine.measuring, "stop"),
-    ("start", OPUSStateMachine.connected, "start"),
-    ("connect", OPUSStateMachine.idle, None),
-)
-
-
-@pytest.mark.parametrize("command,initial_state,timer_command", _COMMANDS)
-def test_request_command_success(
-    command: str,
-    initial_state: State,
-    timer_command: str | None,
-    dev: DummyOPUSInterface,
+@pytest.mark.parametrize("duration_secs,duration_ms", ((0.5, 500), (1.0, 1000)))
+@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.QTimer")
+def test_sm_init(
+    timer_mock: Mock, duration_secs: float, duration_ms: int, qtbot
 ) -> None:
-    """Test the request_command() method."""
-    with patch.object(dev.state_machine, "measure_timer") as timer_mock:
-        with patch.object(dev, "send_status_message") as status_mock:
-            dev.state_machine.current_state = initial_state
-            dev.request_command(command)
+    """Test the state machine's constructor."""
+    timer = MagicMock()
+    timer_mock.return_value = timer
 
-    # Check that the right response message was sent
-    state = dev.state_machine.current_state
-    status_mock.assert_called_once_with(state.value)
-
-    # Check that the right thing has been done to the timer
-    if timer_command:
-        getattr(timer_mock, timer_command).assert_called_once()
+    sm = OPUSStateMachine(duration_secs)
+    timer.setInterval.assert_called_once_with(duration_ms)
+    timer.setSingleShot.assert_called_once_with(True)
+    timer.timeout.connect.assert_called_once_with(sm.stop)
 
 
-@pytest.mark.parametrize(
-    "command,initial_state",
-    (
-        (command, state)
-        for command, required_state, _ in _COMMANDS
-        for state in OPUSStateMachine.states
-        if state != required_state  # only choose invalid states
-    ),
-)
-def test_request_command_fail(
-    command: str, initial_state: State, dev: DummyOPUSInterface
-) -> None:
-    """Test the request_command() method when the initial state is wrong."""
+def test_sm_connect(sm: OPUSStateMachine) -> None:
+    """Test the connect() method."""
+    assert sm.current_state == OPUSStateMachine.idle
+    observer = _MockObserver()
+    sm.add_observer(observer)
+    sm.connect()
+    observer.assert_has_states(OPUSStateMachine.connecting, OPUSStateMachine.connected)
+
+
+def test_sm_start(sm: OPUSStateMachine) -> None:
+    """Test the start() method."""
+    with patch.object(sm, "measure_timer") as timer_mock:
+        sm.current_state = OPUSStateMachine.connected
+        observer = _MockObserver()
+        sm.add_observer(observer)
+        sm.start()
+        observer.assert_has_states(OPUSStateMachine.measuring)
+        timer_mock.start.assert_called_once_with()
+
+
+def test_sm_stop(sm: OPUSStateMachine) -> None:
+    """Test the stop() method."""
+    with patch.object(sm, "measure_timer") as timer_mock:
+        sm.current_state = OPUSStateMachine.measuring
+        observer = _MockObserver()
+        sm.add_observer(observer)
+        sm.stop()
+        observer.assert_has_states(
+            OPUSStateMachine.finishing, OPUSStateMachine.connected
+        )
+        timer_mock.stop.assert_called_once_with()
+
+
+def test_sm_cancel(sm: OPUSStateMachine) -> None:
+    """Test the cancel() method."""
+    with patch.object(sm, "measure_timer") as timer_mock:
+        sm.current_state = OPUSStateMachine.measuring
+        observer = _MockObserver()
+        sm.add_observer(observer)
+        sm.cancel()
+        observer.assert_has_states(
+            OPUSStateMachine.cancelling, OPUSStateMachine.connected
+        )
+        timer_mock.stop.assert_called_once_with()
+
+
+@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.OPUSStateMachine")
+def test_init(sm_mock: Mock) -> None:
+    """Test the constructor."""
+    sm = MagicMock()
+    sm_mock.return_value = sm
+
+    with patch.object(DummyOPUSInterface, "on_enter_state") as state_mock:
+        opus = DummyOPUSInterface(1.0)
+        assert opus.state_machine is sm
+        sm_mock.assert_called_once_with(1.0)
+        sm.add_observer.assert_called_once_with(opus)
+        state_mock.assert_called_once_with(sm.current_state)
+
+
+def test_close(opus: DummyOPUSInterface) -> None:
+    """Test the close() method."""
+    with patch.object(opus, "state_machine") as sm_mock:
+        opus.close()
+        sm_mock.measure_timer.stop.assert_called_once_with()
+
+
+@pytest.mark.parametrize("command", ("connect", "start", "stop", "cancel"))
+def test_run_command_success(command: str, opus: DummyOPUSInterface) -> None:
+    """Test the _run_command() method."""
+    with patch.object(opus, "state_machine") as sm_mock:
+        opus._run_command(command)
+        getattr(sm_mock, command).assert_called_once_with()
+
+
+_COMMAND_ERRORS = {
+    "cancel": OPUSErrorInfo.NOT_RUNNING,
+    "stop": OPUSErrorInfo.NOT_RUNNING_OR_FINISHING,
+    "start": OPUSErrorInfo.NOT_CONNECTED,
+    "connect": OPUSErrorInfo.NOT_IDLE,
+}
+"""The error thrown by each command when in an invalid state."""
+
+_COMMANDS = _COMMAND_ERRORS.keys()
+
+
+@pytest.mark.parametrize("command", _COMMANDS)
+def test_run_command_fail(command: str, opus: DummyOPUSInterface) -> None:
+    """Test the _run_command() when an error occurs."""
+    with patch.object(opus, "state_machine") as sm_mock:
+        getattr(sm_mock, command).side_effect = TransitionNotAllowed(
+            MagicMock(), MagicMock()
+        )
+        with pytest.raises(OPUSError):
+            opus._run_command(command)
+
+
+@pytest.mark.parametrize("command", _COMMANDS)
+def test_request_command_success(command: str, opus: DummyOPUSInterface) -> None:
+    """Test the request_command() method when the command succeeds."""
+    with patch.object(opus, "_run_command") as run_mock:
+        opus.request_command(command)
+        run_mock.assert_called_once_with(command)
+
+
+def test_request_command_fail(opus: DummyOPUSInterface) -> None:
+    """Test the request_command() method when the command fails."""
+    with patch.object(opus, "_run_command") as run_mock:
+        run_mock.side_effect = OPUSError
+        with pytest.raises(OPUSError):
+            opus.request_command("start")
+    run_mock.assert_called_once_with("start")
+
+
+def test_request_command_non_existent(opus: DummyOPUSInterface) -> None:
+    """Test that request_command() raises an error for an invalid command."""
     with pytest.raises(OPUSError):
-        dev.state_machine.current_state = initial_state
-        dev.request_command(command)
+        opus.request_command("non_existent")
 
 
-def test_request_command_bad_command(dev: DummyOPUSInterface) -> None:
-    """Check that request_command() handles non-existent commands correctly."""
-    with pytest.raises(OPUSError):
-        dev.request_command("non_existent_command")
+@pytest.mark.parametrize("state", OPUSStateMachine.states)
+def test_on_enter_state(state: State, opus: DummyOPUSInterface) -> None:
+    """Test that state changes are broadcast."""
+    opus.on_enter_state(state)
+    opus.send_status_message.assert_called_once_with(state.value)  # type: ignore
+
+
+@patch("finesse.hardware.plugins.spectrometer.dummy_opus_interface.logging")
+def test_on_exit_measuring(logging_mock: Mock, opus: DummyOPUSInterface) -> None:
+    """Test that a message is logged when measuring ends."""
+    opus.on_exit_measuring()
+    logging_mock.info.assert_called()

--- a/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
@@ -48,9 +48,7 @@ def test_request_status(state: State, dev: DummyOPUSInterface) -> None:
 
     with patch.object(dev, "send_response") as response_mock:
         dev.request_command("status")
-        response_mock.assert_called_once_with(
-            "status", status=state.value, text=state.name
-        )
+        response_mock.assert_called_once_with("status", state.value)
 
 
 def test_request_status_idle(dev: DummyOPUSInterface) -> None:
@@ -84,7 +82,7 @@ def test_request_command_success(
 
     # Check that the right response message was sent
     state = dev.state_machine.current_state
-    response_mock.assert_called_once_with(command, status=state.value, text=state.name)
+    response_mock.assert_called_once_with(command, state.value)
 
     # Check that the right thing has been done to the timer
     if timer_command:

--- a/tests/hardware/plugins/spectrometer/test_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface.py
@@ -132,8 +132,10 @@ def test_on_reply_received_no_error(
     # NB: This value is of the wrong type, but it doesn't matter here
     parse_response_mock.return_value = "status"
 
-    # Check the correct pubsub message is sent
-    assert opus._on_reply_received(reply) == "status"
+    # Check the status is send
+    with patch.object(opus, "send_status_message") as status_mock:
+        opus._on_reply_received(reply)
+        status_mock.assert_called_once_with("status")
 
 
 @patch("finesse.hardware.plugins.spectrometer.opus_interface.parse_response")

--- a/tests/hardware/plugins/spectrometer/test_opus_interface_base.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface_base.py
@@ -1,0 +1,32 @@
+"""Test the OPUSInterfaceBase class."""
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from finesse.config import SPECTROMETER_TOPIC
+from finesse.hardware.plugins.spectrometer.opus_interface_base import OPUSInterfaceBase
+from finesse.spectrometer_status import SpectrometerStatus
+
+
+class _MyOPUSClass(OPUSInterfaceBase, description="My OPUS class"):
+    def request_command(self, command: str) -> None:
+        pass
+
+
+@patch("finesse.hardware.plugins.spectrometer.opus_interface_base.Device.subscribe")
+def test_init(subscribe_mock: Mock) -> None:
+    """Test the constructor."""
+    opus = _MyOPUSClass()
+    subscribe_mock.assert_called_once_with(opus.request_command, "request")
+
+
+@pytest.mark.parametrize("status", SpectrometerStatus)
+def test_send_status_message(
+    status: SpectrometerStatus, sendmsg_mock: MagicMock
+) -> None:
+    """Test the send_status_message() method."""
+    opus = _MyOPUSClass()
+    opus.send_status_message(status)
+    sendmsg_mock.assert_called_once_with(
+        f"device.{SPECTROMETER_TOPIC}.status.{status.name.lower()}", status=status
+    )


### PR DESCRIPTION
# Description

This PR simplifies the OPUS API for reporting the device's status. It's the last big PR on the road to #459 -- after this there are just some smaller frontend changes and then a very small amount of refactoring.

The OPUS device itself reports its status in response to a command or when it is explicitly requested, which is reflected in our current API. This means there are two ways the frontend can end up being notified of a status change, whereas it makes more sense to have a single "status changed" message. It also doesn't make much sense to have the frontend be responsible for polling the backend -- if just changes in status are communicated it simplifies much of the frontend logic. There's no particular reason why a spectrometer needs to have a polling-based interface (though the ABB spectrometer does too) so I think it's more sensible to keep this encapsulated in the specific device classes. (Maybe someday someone will make a spectrometer which can do proper push notifications.)

The hardest part of implementing this was changing the state machines for running measure scripts and the `DummyOPUSInterface`. Accordingly, I had to fix and replace a whole lot of tests, which means the diff looks rather large. The changes to the actual code are much smaller though.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
