### PR TITLE
Replace plethora of tools with `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,40 +15,25 @@ repos:
     hooks:
       - id: prettier
         files: '\.(json|yaml|yml)$'
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.38.0
     hooks:
-      - id: pyupgrade
-        args: ["--py311-plus"]
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
+      - id: markdownlint
+        args: ["--disable", "MD013", "MD041", "--"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
     hooks:
-      - id: autoflake
-  - repo: https://github.com/PyCQA/isort
-    rev: "5.13.0"
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
-  - repo: https://github.com/psf/black
-    rev: "23.11.0"
-    hooks:
-      - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-docstrings]
+      - id: ruff
+        types_or: [python]
+        args: [--fix]
+      - id: ruff-format
+        types_or: [python]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.7.1"
     hooks:
       - id: mypy
         additional_dependencies:
           [types-beautifulsoup4, types-decorator, types-PyYAML]
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
-    hooks:
-      - id: markdownlint
-        args: ["--disable", "MD013", "MD041", "--"]
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
     "recommendations": [
-        "ms-python.black-formatter",
-        "ms-python.flake8",
+        "ms-python.python",
         "ms-python.mypy-type-checker",
-        "ms-python.python"
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "charliermarsh.ruff"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,17 @@
 {
     "[python]": {
-        "editor.formatOnSave": true,
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "charliermarsh.ruff"
     },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "editor.formatOnSave": true,
     "editor.rulers": [88],
 
     // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693

--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -128,7 +128,7 @@ class DataFileControl(QGroupBox):
         msg_box = QMessageBox(
             QMessageBox.Icon.Critical,
             "Error writing to file",
-            f"An error occurred while writing the data file: {str(error)}",
+            f"An error occurred while writing the data file: {error!s}",
             QMessageBox.StandardButton.Ok,
             self,
         )

--- a/finesse/gui/hardware_set/device_view.py
+++ b/finesse/gui/hardware_set/device_view.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
-from typing import AbstractSet, Any, cast
+from collections.abc import Mapping, Sequence, Set
+from typing import Any, cast
 
 from pubsub import pub
 from PySide6.QtWidgets import (
@@ -319,7 +319,7 @@ class DeviceTypeControl(QGroupBox):
 class DeviceControl(QGroupBox):
     """Allows for viewing and connecting to devices."""
 
-    def __init__(self, connected_devices: AbstractSet[OpenDeviceArgs]) -> None:
+    def __init__(self, connected_devices: Set[OpenDeviceArgs]) -> None:
         """Create a new DeviceControl."""
         super().__init__("Device control")
         self.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)

--- a/finesse/gui/hardware_set/hardware_sets_view.py
+++ b/finesse/gui/hardware_set/hardware_sets_view.py
@@ -1,7 +1,7 @@
 """Provides a panel for choosing between hardware sets and (dis)connecting."""
-from collections.abc import Mapping
+from collections.abc import Mapping, Set
 from pathlib import Path
-from typing import AbstractSet, Any, cast
+from typing import Any, cast
 
 from frozendict import frozendict
 from pubsub import pub
@@ -47,9 +47,7 @@ def _get_last_selected_hardware_set() -> HardwareSet | None:
 class ManageDevicesDialog(QDialog):
     """A dialog for manually opening, closing and configuring devices."""
 
-    def __init__(
-        self, parent: QWidget, connected_devices: AbstractSet[OpenDeviceArgs]
-    ) -> None:
+    def __init__(self, parent: QWidget, connected_devices: Set[OpenDeviceArgs]) -> None:
         """Create a new ManageDevicesDialog.
 
         Args:

--- a/finesse/gui/images/__init__.py
+++ b/finesse/gui/images/__init__.py
@@ -1,0 +1,1 @@
+"""Image assets for the GUI."""

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -77,7 +77,7 @@ class Script:
             with open(file_path) as f:
                 return cls(file_path, **parse_script(f))
         except OSError as e:
-            show_error_message(parent, f"Error: Could not read {file_path}: {str(e)}")
+            show_error_message(parent, f"Error: Could not read {file_path}: {e!s}")
         except ParseError:
             show_error_message(parent, f"Error: {file_path} is in an invalid format")
         return None

--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -106,7 +106,7 @@ class ScriptEditDialog(QDialog):
                 yaml.safe_dump(script, f)
         except Exception as e:
             show_error_message(
-                self, f"Error occurred while saving file {file_path}:\n{str(e)}"
+                self, f"Error occurred while saving file {file_path}:\n{e!s}"
             )
             return False
 

--- a/finesse/gui/spectrometer_view.py
+++ b/finesse/gui/spectrometer_view.py
@@ -104,7 +104,7 @@ class SpectrometerControl(DevicePanel):
         self.logger.info(f"Response ({status.value}): {text}")
 
     def _log_error(self, instance: DeviceInstanceRef, error: BaseException) -> None:
-        self.logger.error(f"Error during request: {str(error)}")
+        self.logger.error(f"Error during request: {error!s}")
 
     def on_command_button_clicked(self, command: str) -> None:
         """Execute the given command by sending a message to the appropriate topic.

--- a/finesse/gui/uncaught_exceptions.py
+++ b/finesse/gui/uncaught_exceptions.py
@@ -64,7 +64,7 @@ def _show_uncaught_exception_dialog(
     dialog.setWindowTitle("Uncaught exception")
     dialog.resize(700, 500)
 
-    label = QLabel(f"An unhandled error has occurred: {repr(exc_value)}")
+    label = QLabel(f"An unhandled error has occurred: {exc_value!r}")
     textEdit = QPlainTextEdit(traceback_str)
     textEdit.setReadOnly(True)
     buttonBox = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from inspect import isabstract, signature
-from typing import Any, get_type_hints
+from typing import Any, ClassVar, get_type_hints
 
 from decorator import decorate
 from pubsub import pub
@@ -65,11 +65,11 @@ def get_device_types() -> dict[DeviceBaseTypeInfo, list[DeviceTypeInfo]]:
 class AbstractDevice(ABC):
     """An abstract base class for devices."""
 
-    _device_base_type_info: DeviceBaseTypeInfo
+    _device_base_type_info: ClassVar[DeviceBaseTypeInfo]
     """Information about the device's base type."""
-    _device_description: str
+    _device_description: ClassVar[str]
     """A human-readable name."""
-    _device_parameters: dict[str, DeviceParameter] = {}
+    _device_parameters: ClassVar[dict[str, DeviceParameter]] = {}
     """Possible parameters that this device type accepts.
 
     The key represents the parameter name and the value is a list of possible values.

--- a/finesse/hardware/manage_devices.py
+++ b/finesse/hardware/manage_devices.py
@@ -59,7 +59,7 @@ def _open_device(
     try:
         _devices[instance] = cls(**params_with_name)
     except Exception as error:
-        logging.error(f"Failed to open {instance!s} device: {str(error)}")
+        logging.error(f"Failed to open {instance!s} device: {error!s}")
         pub.sendMessage(f"device.error.{instance!s}", instance=instance, error=error)
     else:
         logging.info("Opened device")

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import Callable
 from enum import Enum
+from typing import ClassVar
 
 from PySide6.QtCore import QTimer
 from statemachine import State, StateMachine
@@ -120,7 +121,7 @@ class DummyOPUSInterface(
 ):
     """A mock version of the OPUS API for testing purposes."""
 
-    _COMMAND_ERRORS = {
+    _COMMAND_ERRORS: ClassVar = {
         "cancel": OPUSErrorInfo.NOT_RUNNING,
         "stop": OPUSErrorInfo.NOT_RUNNING_OR_FINISHING,
         "start": OPUSErrorInfo.NOT_CONNECTED,

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -88,12 +88,12 @@ class _SerialReader(QThread):
         """
         raw = self.serial.read_until(b"\r")
 
-        logging.debug(f"(ST10) <<< {repr(raw)}")
+        logging.debug(f"(ST10) <<< {raw!r}")
 
         try:
             return raw[:-1].decode("ascii")
         except UnicodeDecodeError:
-            raise ST10ControllerError(f"Invalid message received: {repr(raw)}")
+            raise ST10ControllerError(f"Invalid message received: {raw!r}")
 
     def _read_error(self, error: BaseException) -> None:
         if self.stopping:
@@ -384,7 +384,7 @@ class ST10Controller(SerialDevice, StepperMotorBase, description="ST10 controlle
             UnicodeEncodeError: Malformed message
         """
         data = f"{message}\r".encode("ascii")
-        logging.debug(f"(ST10) >>> {repr(data)}")
+        logging.debug(f"(ST10) >>> {data!r}")
         self.serial.write(data)
 
     def _write_check(self, message: str) -> None:

--- a/finesse/hardware/plugins/temperature/tc4820.py
+++ b/finesse/hardware/plugins/temperature/tc4820.py
@@ -139,7 +139,7 @@ class TC4820(SerialDevice, TemperatureControllerBase, description="TC4820"):
             try:
                 return self.read_int()
             except MalformedMessageError as e:
-                logging.warn(f"Malformed message: {str(e)}; retrying")
+                logging.warn(f"Malformed message: {e!s}; retrying")
 
         raise SerialException(
             f"Maximum number of attempts (={self.max_attempts}) exceeded"

--- a/finesse/hardware/pubsub_decorators.py
+++ b/finesse/hardware/pubsub_decorators.py
@@ -2,7 +2,6 @@
 import logging
 import traceback
 from collections.abc import Callable
-from typing import Any
 
 from decorator import decorator
 from pubsub import pub
@@ -13,13 +12,13 @@ def _error_occurred(error_topic: str, error: BaseException) -> None:
     traceback_str = "".join(traceback.format_tb(error.__traceback__))
 
     # Write details including stack trace to program log
-    logging.error(f"Caught error ({error_topic}): {str(error)}\n\n{traceback_str}")
+    logging.error(f"Caught error ({error_topic}): {error!s}\n\n{traceback_str}")
 
     # Notify listeners
     pub.sendMessage(error_topic, error=error)
 
 
-def pubsub_errors(error_topic: str, **extra_kwargs: Any) -> Callable:
+def pubsub_errors(error_topic: str) -> Callable:
     """Catch exceptions and broadcast via pubsub.
 
     Args:
@@ -30,6 +29,6 @@ def pubsub_errors(error_topic: str, **extra_kwargs: Any) -> Callable:
         try:
             return func(*args, **kwargs)
         except Exception as error:
-            _error_occurred(error_topic, error, **extra_kwargs)
+            _error_occurred(error_topic, error)
 
     return decorator(wrapped)

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,46 +62,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "black"
-version = "23.11.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-23.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dbea0bb8575c6b6303cc65017b46351dc5953eea5c0a59d7b7e3a2d2f433a911"},
-    {file = "black-23.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:412f56bab20ac85927f3a959230331de5614aecda1ede14b373083f62ec24e6f"},
-    {file = "black-23.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d136ef5b418c81660ad847efe0e55c58c8208b77a57a28a503a5f345ccf01394"},
-    {file = "black-23.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:6c1cac07e64433f646a9a838cdc00c9768b3c362805afc3fce341af0e6a9ae9f"},
-    {file = "black-23.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479"},
-    {file = "black-23.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244"},
-    {file = "black-23.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221"},
-    {file = "black-23.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5"},
-    {file = "black-23.11.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:45aa1d4675964946e53ab81aeec7a37613c1cb71647b5394779e6efb79d6d187"},
-    {file = "black-23.11.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4c44b7211a3a0570cc097e81135faa5f261264f4dfaa22bd5ee2875a4e773bd6"},
-    {file = "black-23.11.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a9acad1451632021ee0d146c8765782a0c3846e0e0ea46659d7c4f89d9b212b"},
-    {file = "black-23.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:fc7f6a44d52747e65a02558e1d807c82df1d66ffa80a601862040a43ec2e3142"},
-    {file = "black-23.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7f622b6822f02bfaf2a5cd31fdb7cd86fcf33dab6ced5185c35f5db98260b055"},
-    {file = "black-23.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:250d7e60f323fcfc8ea6c800d5eba12f7967400eb6c2d21ae85ad31c204fb1f4"},
-    {file = "black-23.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5133f5507007ba08d8b7b263c7aa0f931af5ba88a29beacc4b2dc23fcefe9c06"},
-    {file = "black-23.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:421f3e44aa67138ab1b9bfbc22ee3780b22fa5b291e4db8ab7eee95200726b07"},
-    {file = "black-23.11.0-py3-none-any.whl", hash = "sha256:54caaa703227c6e0c87b76326d0862184729a69b73d3b7305b6288e1d830067e"},
-    {file = "black-23.11.0.tar.gz", hash = "sha256:4c68855825ff432d197229846f971bc4d6666ce90492e5b02013bcaca4d9ab05"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -430,37 +390,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pyt
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
-name = "flake8"
-version = "6.0.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
-    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.10.0,<2.11.0"
-pyflakes = ">=3.0.0,<3.1.0"
-
-[[package]]
-name = "flake8-docstrings"
-version = "1.7.0"
-description = "Extension for flake8 which uses pydocstyle to check docstrings"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8_docstrings-1.7.0-py2.py3-none-any.whl", hash = "sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75"},
-    {file = "flake8_docstrings-1.7.0.tar.gz", hash = "sha256:4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-pydocstyle = ">=2.1"
-
-[[package]]
 name = "fonttools"
 version = "4.39.3"
 description = "Tools to manipulate font files"
@@ -596,17 +525,6 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
-]
-
-[[package]]
-name = "isort"
-version = "5.13.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.13.1-py3-none-any.whl", hash = "sha256:56a51732c25f94ca96f6721be206dd96a95f42950502eb26c1015d333bc6edb7"},
-    {file = "isort-5.13.1.tar.gz", hash = "sha256:aaed790b463e8703fb1eddb831dfa8e8616bacde2c083bd557ef73c8189b7263"},
 ]
 
 [[package]]
@@ -837,17 +755,6 @@ packaging = ">=20.0"
 pillow = ">=8"
 pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "mergedeep"
@@ -1314,17 +1221,6 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.10.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
-    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
-]
-
-[[package]]
 name = "pycsvy"
 version = "0.2.2"
 description = "Python reader/writer for CSV files with YAML header information."
@@ -1339,23 +1235,6 @@ files = [
 PyYAML = ">=6.0,<7.0"
 
 [[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3)"]
-
-[[package]]
 name = "pydot"
 version = "1.4.2"
 description = "Python interface to Graphviz's Dot"
@@ -1368,17 +1247,6 @@ files = [
 
 [package.dependencies]
 pyparsing = ">=2.1.4"
-
-[[package]]
-name = "pyflakes"
-version = "3.0.1"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
-]
 
 [[package]]
 name = "pygments"
@@ -1684,7 +1552,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1692,15 +1559,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1717,7 +1577,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1725,7 +1584,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1836,6 +1694,32 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.1.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7f80496854fdc65b6659c271d2c26e90d4d401e6a4a31908e7e334fab4645aac"},
+    {file = "ruff-0.1.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1ea109bdb23c2a4413f397ebd8ac32cb498bee234d4191ae1a310af760e5d287"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b0c2de9dd9daf5e07624c24add25c3a490dbf74b0e9bca4145c632457b3b42a"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:69a4bed13bc1d5dabf3902522b5a2aadfebe28226c6269694283c3b0cecb45fd"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de02ca331f2143195a712983a57137c5ec0f10acc4aa81f7c1f86519e52b92a1"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:45b38c3f8788a65e6a2cab02e0f7adfa88872696839d9882c13b7e2f35d64c5f"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c64cb67b2025b1ac6d58e5ffca8f7b3f7fd921f35e78198411237e4f0db8e73"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dcc6bb2f4df59cb5b4b40ff14be7d57012179d69c6565c1da0d1f013d29951b"},
+    {file = "ruff-0.1.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df2bb4bb6bbe921f6b4f5b6fdd8d8468c940731cb9406f274ae8c5ed7a78c478"},
+    {file = "ruff-0.1.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:276a89bcb149b3d8c1b11d91aa81898fe698900ed553a08129b38d9d6570e717"},
+    {file = "ruff-0.1.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:90c958fe950735041f1c80d21b42184f1072cc3975d05e736e8d66fc377119ea"},
+    {file = "ruff-0.1.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6b05e3b123f93bb4146a761b7a7d57af8cb7384ccb2502d29d736eaade0db519"},
+    {file = "ruff-0.1.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:290ecab680dce94affebefe0bbca2322a6277e83d4f29234627e0f8f6b4fa9ce"},
+    {file = "ruff-0.1.7-py3-none-win32.whl", hash = "sha256:416dfd0bd45d1a2baa3b1b07b1b9758e7d993c256d3e51dc6e03a5e7901c7d80"},
+    {file = "ruff-0.1.7-py3-none-win_amd64.whl", hash = "sha256:4af95fd1d3b001fc41325064336db36e3d27d2004cdb6d21fd617d45a172dd96"},
+    {file = "ruff-0.1.7-py3-none-win_arm64.whl", hash = "sha256:0683b7bfbb95e6df3c7c04fe9d78f631f8e8ba4868dfc932d43d690698057e2e"},
+    {file = "ruff-0.1.7.tar.gz", hash = "sha256:dffd699d07abf54833e5f6cc50b85a6ff043715da8788c4a79bcd4ab4734d306"},
+]
+
+[[package]]
 name = "schema"
 version = "0.7.5"
 description = "Simple data validation library"
@@ -1887,17 +1771,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-
-[[package]]
-name = "snowballstemmer"
-version = "2.2.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-optional = false
-python-versions = "*"
-files = [
-    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
-    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 
 [[package]]
@@ -2047,4 +1920,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "c17cd1b8658f72ffa932efa13f5b60b3817ebbc6b3f836422354e7d9b6e7caa1"
+content-hash = "ae93368b9b68806bde9c3154bc0c4f4f68030c3ed212a9ad0be27176ffc13d9b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,17 +31,14 @@ pytest = "^7.4"
 pytest-cov = "^4.1.0"
 pytest-mypy = "^0.10.1"
 pytest-mock = "^3.12.0"
-isort = "^5.13.1"
 pre-commit = "^3.6.0"
-black = "^23.11.0"
-flake8 = "^6.0.0"
-flake8-docstrings = "^1.6.0"
 pyinstaller = "^6.3.0"
 types-pyyaml = "^6.0.12.12"
 types-beautifulsoup4 = "^4.12.0.7"
 pytest-qt = "^4.2.0"
 types-decorator = "^5.1.8.4"
 pydot = "^1.4.2"
+ruff = "^0.1.7"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.3"
@@ -52,8 +49,20 @@ mkdocs-gen-files = "^0.5.0"
 mkdocs-literate-nav = "^0.6.1"
 mkdocs-section-index = "^0.3.8"
 
-[tool.isort]
-profile = "black"
+
+[tool.ruff]
+select = [
+    "D",   # pydocstyle
+    "E",   # pycodestyle
+    "F",   # Pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "RUF", # ruff
+]
+target-version = "py311"
+
+[tool.ruff.pydocstyle]
+convention = "google"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/gui/test_data_file_view.py
+++ b/tests/gui/test_data_file_view.py
@@ -93,7 +93,7 @@ def test_show_error_message(
     msgbox_mock.assert_called_once_with(
         msgbox_mock.Icon.Critical,
         "Error writing to file",
-        f"An error occurred while writing the data file: {str(error)}",
+        f"An error occurred while writing the data file: {error!s}",
         msgbox_mock.StandardButton.Ok,
         data_file,
     )

--- a/tests/hardware/plugins/spectrometer/test_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface.py
@@ -46,7 +46,7 @@ def test_request_command(opus: OPUSInterface, qtbot) -> None:
 def _format_td(name: str, value: Any) -> str:
     if value is None:
         return ""
-    return f'<td id="{name}">{str(value)}</td>'
+    return f'<td id="{name}">{value!s}</td>'
 
 
 def _get_opus_html(


### PR DESCRIPTION
I've been looking at whether to swap our exiting tooling in `poetry_template_2` for `ruff` and thought I'd try it out on the FINESSE codebase. It found a number of small stylistic issues with the current codebase and fixed most of them automatically.

I've used it to replace:

- autoflake
- black
- isort
- flake8 (and flake8-docstrings)
- pyupgrade

In addition, I also enabled ruff's own rule set.

I was concerned that it might not be so hot with `pyupgrade`'s checks, so went back in the git history to before I enabled `pyupgrade` and ran `ruff` over the codebase. It seemed to do a pretty decent job, though there was one check that `pyupgrade` could auto-fix that `ruff` couldn't. In the grand scheme of things though, it seems nicer to just be using a single tool.

Although it found various small issues all over the place, there are no merge conflicts with other things I've been working on with FINESSE, so I thought I should get this merged.