### PR TITLE
Add a generic `SpectrometerBase` class

### DIFF
--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -343,7 +343,7 @@ class ScriptRunner(StateMachine):
         NB: This is also invoked on repeat measurements
         """
         pub.sendMessage("measure_script.start_measuring", script_runner=self)
-        pub.sendMessage(f"device.{SPECTROMETER_TOPIC}.request", command="start")
+        pub.sendMessage(f"device.{SPECTROMETER_TOPIC}.start_measuring")
 
     def _measuring_start(self, status: SpectrometerStatus):
         """Start the next measurement."""

--- a/finesse/hardware/plugins/spectrometer/opus_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface_base.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
-from finesse.config import SPECTROMETER_TOPIC
-from finesse.hardware.device import Device
-from finesse.spectrometer_status import SpectrometerStatus
+from finesse.hardware.plugins.spectrometer.spectrometer_base import SpectrometerBase
 
 
 class OPUSError(Exception):
@@ -17,13 +15,24 @@ class OPUSError(Exception):
         return cls(f"Error {errcode}: {errtext}")
 
 
-class OPUSInterfaceBase(Device, name=SPECTROMETER_TOPIC, description="OPUS device"):
+class OPUSInterfaceBase(SpectrometerBase):
     """Base class providing an interface to the OPUS program."""
 
-    def __init__(self) -> None:
-        """Create a new OPUSInterfaceBase."""
-        super().__init__()
-        self.subscribe(self.request_command, "request")
+    def connect(self) -> None:
+        """Connect to the spectrometer."""
+        self.request_command("connect")
+
+    def start_measuring(self) -> None:
+        """Start a new measurement."""
+        self.request_command("start")
+
+    def stop_measuring(self) -> None:
+        """Stop the current measurement when finished."""
+        self.request_command("stop")
+
+    def cancel_measuring(self) -> None:
+        """Cancel the current measurement immediately."""
+        self.request_command("cancel")
 
     @abstractmethod
     def request_command(self, command: str) -> None:
@@ -32,7 +41,3 @@ class OPUSInterfaceBase(Device, name=SPECTROMETER_TOPIC, description="OPUS devic
         Args:
             command: Name of command to run
         """
-
-    def send_status_message(self, status: SpectrometerStatus) -> None:
-        """Send a status update via pubsub."""
-        self.send_message(f"status.{status.name.lower()}", status=status)

--- a/finesse/hardware/plugins/spectrometer/spectrometer_base.py
+++ b/finesse/hardware/plugins/spectrometer/spectrometer_base.py
@@ -1,0 +1,42 @@
+"""Provides a generic base class for spectrometers."""
+from abc import abstractmethod
+
+from finesse.config import SPECTROMETER_TOPIC
+from finesse.hardware.device import Device
+from finesse.spectrometer_status import SpectrometerStatus
+
+
+class SpectrometerBase(Device, name=SPECTROMETER_TOPIC, description="Spectrometer"):
+    """A generic base class for spectrometers."""
+
+    def __init__(self) -> None:
+        """Create a new SpectrometerBase."""
+        super().__init__()
+
+        for command in (
+            "connect",
+            "start_measuring",
+            "stop_measuring",
+            "cancel_measuring",
+        ):
+            self.subscribe(getattr(self, command), command)
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Connect to the spectrometer."""
+
+    @abstractmethod
+    def start_measuring(self) -> None:
+        """Start a new measurement."""
+
+    @abstractmethod
+    def stop_measuring(self) -> None:
+        """Stop the current measurement when finished."""
+
+    @abstractmethod
+    def cancel_measuring(self) -> None:
+        """Cancel the current measurement immediately."""
+
+    def send_status_message(self, status: SpectrometerStatus) -> None:
+        """Send a status update via pubsub."""
+        self.send_message(f"status.{status.name.lower()}", status=status)

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -143,11 +143,7 @@ def test_start_measuring(
     runner.start_measuring()
     assert runner.current_state == ScriptRunner.measuring
 
-    # Check that measuring has been triggered
-    sendmsg_mock.assert_any_call(
-        f"device.{SPECTROMETER_TOPIC}.request", command="start"
-    )
-
+    sendmsg_mock.assert_any_call(f"device.{SPECTROMETER_TOPIC}.start_measuring")
     sendmsg_mock.assert_any_call("measure_script.start_measuring", script_runner=runner)
 
 

--- a/tests/hardware/plugins/spectrometer/test_spectrometer_base.py
+++ b/tests/hardware/plugins/spectrometer/test_spectrometer_base.py
@@ -1,0 +1,43 @@
+"""Tests for the SpectrometerBase class."""
+from unittest.mock import call, patch
+
+import pytest
+
+from finesse.hardware.plugins.spectrometer.spectrometer_base import SpectrometerBase
+from finesse.spectrometer_status import SpectrometerStatus
+
+
+class _MockSpectrometer(SpectrometerBase, description="Mock spectrometer"):
+    def connect(self) -> None:
+        pass
+
+    def start_measuring(self) -> None:
+        pass
+
+    def stop_measuring(self) -> None:
+        pass
+
+    def cancel_measuring(self) -> None:
+        pass
+
+
+def test_init() -> None:
+    """Test the constructor."""
+    with patch.object(_MockSpectrometer, "subscribe") as subscribe_mock:
+        dev = _MockSpectrometer()
+        commands = ("connect", "start_measuring", "stop_measuring", "cancel_measuring")
+        subscribe_mock.assert_has_calls(
+            [call(getattr(dev, command), command) for command in commands],
+            any_order=True,
+        )
+
+
+@pytest.mark.parametrize("status", SpectrometerStatus)
+def test_send_status_message(status: SpectrometerStatus) -> None:
+    """Test the send_status_message() method."""
+    with patch.object(_MockSpectrometer, "send_message") as sendmsg_mock:
+        dev = _MockSpectrometer()
+        dev.send_status_message(status)
+        sendmsg_mock.assert_called_once_with(
+            f"status.{status.name.lower()}", status=status
+        )


### PR DESCRIPTION
# Description

Add a generic spectrometer base class and use it as the parent of `OPUSInterfaceBase`. This is the final change I want to make before we release v1.3 :partying_face: 

I do have some other changes that I'd like to see merged (in particular I'd like to implement #471 which should make it easier to develop the new spectrometer driver), but unfortunately Jon won't be able to test until next week, so I think we should be conservative about introducing new changes at this point. I'll open PRs for the remaining bits and they can be merged once someone has an opportunity to test them in the lab.

Fixes #459.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [x] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
