### PR TITLE
Amalgamate "stop" and "cancel" commands for spectrometers

### DIFF
--- a/finesse/gui/spectrometer_view.py
+++ b/finesse/gui/spectrometer_view.py
@@ -19,7 +19,6 @@ class SpectrometerControl(DevicePanel):
             "connect": "Connect",
             "start_measuring": "Start",
             "stop_measuring": "Stop",
-            "cancel_measuring": "Cancel",
         }
     )
     """The default commands shown (key=command, value=label)."""
@@ -28,7 +27,7 @@ class SpectrometerControl(DevicePanel):
         {
             SpectrometerStatus.IDLE: {"connect"},
             SpectrometerStatus.CONNECTED: {"start_measuring"},
-            SpectrometerStatus.MEASURING: {"stop_measuring", "cancel_measuring"},
+            SpectrometerStatus.MEASURING: {"stop_measuring"},
         }
     )
     """Which buttons to enable for different states."""

--- a/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_opus_interface.py
@@ -72,7 +72,7 @@ class OPUSStateMachine(StateMachine):
         """Timer signalling the end of a measurement."""
         self.measure_timer.setInterval(round(measure_duration * 1000))
         self.measure_timer.setSingleShot(True)
-        self.measure_timer.timeout.connect(self.stop)
+        self.measure_timer.timeout.connect(self._on_measure_finished)
 
         super().__init__()
 
@@ -81,13 +81,13 @@ class OPUSStateMachine(StateMachine):
         self._start_connecting()
         self._finish_connecting()
 
-    def cancel(self) -> None:
-        """Cancel the current measurement."""
+    def stop(self) -> None:
+        """Stop the current measurement."""
         self._cancel_measuring()
         self._reset_after_cancelling()
         logging.info("Cancelling current measurement")
 
-    def stop(self) -> None:
+    def _on_measure_finished(self) -> None:
         """Finish measurement successfully."""
         self._start_finishing_measuring()
         self._finish_measuring()

--- a/finesse/hardware/plugins/spectrometer/opus_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface_base.py
@@ -27,11 +27,7 @@ class OPUSInterfaceBase(SpectrometerBase):
         self.request_command("start")
 
     def stop_measuring(self) -> None:
-        """Stop the current measurement when finished."""
-        self.request_command("stop")
-
-    def cancel_measuring(self) -> None:
-        """Cancel the current measurement immediately."""
+        """Stop the current measurement."""
         self.request_command("cancel")
 
     @abstractmethod

--- a/finesse/hardware/plugins/spectrometer/spectrometer_base.py
+++ b/finesse/hardware/plugins/spectrometer/spectrometer_base.py
@@ -17,7 +17,6 @@ class SpectrometerBase(Device, name=SPECTROMETER_TOPIC, description="Spectromete
             "connect",
             "start_measuring",
             "stop_measuring",
-            "cancel_measuring",
         ):
             self.subscribe(getattr(self, command), command)
 
@@ -31,11 +30,7 @@ class SpectrometerBase(Device, name=SPECTROMETER_TOPIC, description="Spectromete
 
     @abstractmethod
     def stop_measuring(self) -> None:
-        """Stop the current measurement when finished."""
-
-    @abstractmethod
-    def cancel_measuring(self) -> None:
-        """Cancel the current measurement immediately."""
+        """Stop the current measurement."""
 
     def send_status_message(self, status: SpectrometerStatus) -> None:
         """Send a status update via pubsub."""

--- a/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_dummy_opus_interface.py
@@ -59,7 +59,7 @@ def test_sm_init(
     sm = OPUSStateMachine(duration_secs)
     timer.setInterval.assert_called_once_with(duration_ms)
     timer.setSingleShot.assert_called_once_with(True)
-    timer.timeout.connect.assert_called_once_with(sm.stop)
+    timer.timeout.connect.assert_called_once_with(sm._on_measure_finished)
 
 
 def test_sm_connect(sm: OPUSStateMachine) -> None:
@@ -89,19 +89,6 @@ def test_sm_stop(sm: OPUSStateMachine) -> None:
         observer = _MockObserver()
         sm.add_observer(observer)
         sm.stop()
-        observer.assert_has_states(
-            OPUSStateMachine.finishing, OPUSStateMachine.connected
-        )
-        timer_mock.stop.assert_called_once_with()
-
-
-def test_sm_cancel(sm: OPUSStateMachine) -> None:
-    """Test the cancel() method."""
-    with patch.object(sm, "measure_timer") as timer_mock:
-        sm.current_state = OPUSStateMachine.measuring
-        observer = _MockObserver()
-        sm.add_observer(observer)
-        sm.cancel()
         observer.assert_has_states(
             OPUSStateMachine.cancelling, OPUSStateMachine.connected
         )

--- a/tests/hardware/plugins/spectrometer/test_opus_interface_base.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface_base.py
@@ -39,10 +39,4 @@ def test_start_measuring(opus: _MockOPUS) -> None:
 def test_stop_measuring(opus: _MockOPUS) -> None:
     """Test the stop_measuring() method."""
     opus.stop_measuring()
-    opus.assert_command_requested("stop")
-
-
-def test_cancel_measuring(opus: _MockOPUS) -> None:
-    """Test the cancel_measuring() method."""
-    opus.cancel_measuring()
     opus.assert_command_requested("cancel")

--- a/tests/hardware/plugins/spectrometer/test_spectrometer_base.py
+++ b/tests/hardware/plugins/spectrometer/test_spectrometer_base.py
@@ -17,15 +17,12 @@ class _MockSpectrometer(SpectrometerBase, description="Mock spectrometer"):
     def stop_measuring(self) -> None:
         pass
 
-    def cancel_measuring(self) -> None:
-        pass
-
 
 def test_init() -> None:
     """Test the constructor."""
     with patch.object(_MockSpectrometer, "subscribe") as subscribe_mock:
         dev = _MockSpectrometer()
-        commands = ("connect", "start_measuring", "stop_measuring", "cancel_measuring")
+        commands = ("connect", "start_measuring", "stop_measuring")
         subscribe_mock.assert_has_calls(
             [call(getattr(dev, command), command) for command in commands],
             any_order=True,


### PR DESCRIPTION
# Description

DO NOT MERGE BEFORE v1.3

The OPUS API allows for sending both a "cancel" and a "stop" command during a measurement. "Cancel" stops the measurement immediately but it's not apparent what "stop" does (maybe it stops after the current series of measurements?). Either way, we don't need the separate stop command, so let's just drop the stop command and replace it with what we're currently calling cancel.

This means we can simplify `SpectrometerBase` slightly and drop a button from the GUI.

This code needs to be tested on real hardware before being merged. You will need the spectrometer for this.

A reasonable test would be:

1. Choose the "FINESSE (with DP9800)" hardware set from the dropdown box in the top left and click "Connect"
2. In the spectrometer panel, click the "Connect" button
3. Try starting a measurement by clicking the "Start" button and confirm that it has started in OPUS
4. Try cancelling this measurement partway through by clicking the "Stop" button and confirm that it has stopped in OPUS
5. Try running a measure script (I've attached an example one, but any should do)

Fixes #471.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
