### PR TITLE
Seneca out-of-range temperature detection

### DIFF
--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -151,10 +151,8 @@ class SenecaK107(
         # Adjusts for minimum temperature limit
         calc += self.MIN_TEMP
 
-        nan = float("nan")
-
-        calc[calc > self.MAX_TEMP] = nan
-        calc[calc < self.MIN_TEMP] = nan
+        calc[calc > self.MAX_TEMP] = numpy.nan
+        calc[calc < self.MIN_TEMP] = numpy.nan
 
         if numpy.isnan(calc).any():
             logging.warn(f"Out-of-range temperature(s) detected: {calc}")

--- a/finesse/hardware/plugins/temperature/senecak107.py
+++ b/finesse/hardware/plugins/temperature/senecak107.py
@@ -155,7 +155,7 @@ class SenecaK107(
         calc[calc < self.MIN_TEMP] = numpy.nan
 
         if numpy.isnan(calc).any():
-            logging.warn(f"Out-of-range temperature(s) detected: {calc}")
+            logging.warning(f"Out-of-range temperature(s) detected: {calc}")
 
         return calc
 

--- a/tests/hardware/plugins/temperature/test_senecaK107.py
+++ b/tests/hardware/plugins/temperature/test_senecaK107.py
@@ -87,12 +87,12 @@ def test_parse_data(dev: SenecaK107, data: bytes) -> None:
     expected = [
         19.946250000000006,
         20.085000000000008,
-        631.4406250000001,
-        631.4175,
+        float("nan"),
+        float("nan"),
         20.14281249999999,
-        631.4406250000001,
+        float("nan"),
         19.946250000000006,
-        631.4406250000001,
+        float("nan"),
     ]
     parsed = dev.parse_data(data)
 

--- a/tests/hardware/plugins/temperature/test_senecaK107.py
+++ b/tests/hardware/plugins/temperature/test_senecaK107.py
@@ -87,12 +87,12 @@ def test_parse_data(dev: SenecaK107, data: bytes) -> None:
     expected = [
         19.946250000000006,
         20.085000000000008,
-        float("nan"),
-        float("nan"),
+        numpy.nan,
+        numpy.nan,
         20.14281249999999,
-        float("nan"),
+        numpy.nan,
         19.946250000000006,
-        float("nan"),
+        numpy.nan,
     ]
     parsed = dev.parse_data(data)
 


### PR DESCRIPTION
Added logic to `calc_temp()` that replaces temperatures outside the minimum and maximum temperature ranges with NaNs. If the resulting numpy array contains NaNs, a warning is raised.

Tests have also been altered to expect the NaN values when parsing the data.

Closes #490 