### PR TITLE
Layout change - Data file view moved to left side

### DIFF
--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -5,8 +5,8 @@ from typing import cast
 
 from pubsub import pub
 from PySide6.QtWidgets import (
+    QGridLayout,
     QGroupBox,
-    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMessageBox,
@@ -35,7 +35,7 @@ class DataFileControl(QGroupBox):
         """Create a new DataFileControl."""
         super().__init__("Data file")
 
-        layout = QHBoxLayout()
+        layout = QGridLayout()
 
         self.open_dir_widget = OpenDirectoryWidget(
             parent=self,
@@ -44,18 +44,18 @@ class DataFileControl(QGroupBox):
         )
         """Lets the user choose the destination for data files."""
         self.open_dir_widget.set_path(_get_previous_destination_dir())
-        layout.addWidget(QLabel("Destination directory:"))
-        layout.addWidget(self.open_dir_widget)
+        layout.addWidget(QLabel("Destination directory:"), 0, 0)
+        layout.addWidget(self.open_dir_widget, 0, 1)
 
         self.filename_prefix_widget = QLineEdit()
         self.filename_prefix_widget.setText(_get_previous_filename_prefix())
-        layout.addWidget(QLabel("Filename prefix:"))
-        layout.addWidget(self.filename_prefix_widget)
+        layout.addWidget(QLabel("Filename prefix:"), 1, 0)
+        layout.addWidget(self.filename_prefix_widget, 1, 1)
 
         self.record_btn = QPushButton("Start recording")
         """Toggles recording state."""
         self.record_btn.clicked.connect(self._toggle_recording)
-        layout.addWidget(self.record_btn)
+        layout.addWidget(self.record_btn, 1, 2)
 
         self.setLayout(layout)
 

--- a/finesse/gui/data_file_view.py
+++ b/finesse/gui/data_file_view.py
@@ -7,11 +7,13 @@ from pubsub import pub
 from PySide6.QtWidgets import (
     QGridLayout,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMessageBox,
     QPushButton,
     QSizePolicy,
+    QWidget,
 )
 
 from finesse.config import DEFAULT_DATA_FILE_PATH
@@ -47,15 +49,22 @@ class DataFileControl(QGroupBox):
         layout.addWidget(QLabel("Destination directory:"), 0, 0)
         layout.addWidget(self.open_dir_widget, 0, 1)
 
+        layout.addWidget(QLabel("Filename prefix:"), 1, 0)
+
+        filename = QWidget()
+        filename_layout = QHBoxLayout()
+
         self.filename_prefix_widget = QLineEdit()
         self.filename_prefix_widget.setText(_get_previous_filename_prefix())
-        layout.addWidget(QLabel("Filename prefix:"), 1, 0)
-        layout.addWidget(self.filename_prefix_widget, 1, 1)
-
         self.record_btn = QPushButton("Start recording")
         """Toggles recording state."""
         self.record_btn.clicked.connect(self._toggle_recording)
-        layout.addWidget(self.record_btn, 1, 2)
+        filename_layout.addWidget(self.filename_prefix_widget)
+        filename_layout.addWidget(self.record_btn)
+
+        filename.setLayout(filename_layout)
+
+        layout.addWidget(filename, 1, 1)
 
         self.setLayout(layout)
 

--- a/finesse/gui/main_window.py
+++ b/finesse/gui/main_window.py
@@ -66,11 +66,15 @@ class MainWindow(QMainWindow):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
         )
 
+        # Setup for data file widgets
+        data_file = DataFileControl()
+
         layout_left.addWidget(hardware_sets, 0, 0, 1, 2)
         layout_left.addWidget(measure_script, 1, 0, 1, 2)
         layout_left.addWidget(stepper_motor, 2, 0, 1, 1)
         layout_left.addWidget(spectrometer, 2, 1, 1, 1)
         layout_left.addWidget(em27_monitor, 3, 0, 1, 2)
+        layout_left.addWidget(data_file, 4, 0, 1, 2)
 
         layout_right = QGridLayout()
 
@@ -83,14 +87,10 @@ class MainWindow(QMainWindow):
             "cold", TEMPERATURE_MONITOR_COLD_BB_IDX, allow_update=False
         )
 
-        # Setup for data file widgets
-        data_file = DataFileControl()
-
         layout_right.addWidget(bb_monitor, 1, 0, 1, 2)
         layout_right.addWidget(temp_monitor, 2, 0, 1, 2)
         layout_right.addWidget(tc_hot, 3, 0, 1, 1)
         layout_right.addWidget(tc_cold, 3, 1, 1, 1)
-        layout_right.addWidget(data_file, 4, 0, 1, 2)
 
         # Display widgets in two columns
         left = QWidget()


### PR DESCRIPTION
GUI layout change to move Data file view from right side to left side.

I think this change makes sense for the layout as it creates a divide between the temperature monitoring views on the right and the config/other sensors on the left.
![image](https://github.com/ImperialCollegeLondon/FINESSE/assets/108276827/669ded4f-32d5-4484-9bec-a230730f8c1e)

However now that the Data file view is on the left, its width is shortened and the directory/filename fields are a bit stubby. I suggest changing the layout of the Data file view so that these two fields are vertically aligned. I've attempted to do this with the `QGridLayout` but I still need to play around to get the elements aligned properly.
![image](https://github.com/ImperialCollegeLondon/FINESSE/assets/108276827/f081ad4e-80c1-450f-a010-d14049de3729)


Opening in draft to get feedback on this layout change before it's refined.

Closes #420 