### PR TITLE
Add an interface to FTSW500

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -85,7 +85,7 @@ FTSW500_PORT = 7778
 FTSW500_POLLING_INTERVAL = 1.0
 """How long to wait between polls of the EM27's status."""
 
-FTSW500_TIMEOUT = 1.0
+FTSW500_TIMEOUT = 5.0
 """How long to wait for a response from FTSW500 for."""
 
 SPECTROMETER_TOPIC = "spectrometer"

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -76,6 +76,12 @@ device takes to reply. This value then determines how often we wait before even 
 a request.
 """
 
+FTSW500_HOST = "127.0.0.1"
+"""The IP address or hostname of the machine running the FTSW500 software."""
+
+FTSW500_PORT = 7778
+"""The port on which the TCP server of FTSW500 is listening."""
+
 SPECTROMETER_TOPIC = "spectrometer"
 """The topic name to use for spectrometer-related messages."""
 

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -83,7 +83,7 @@ FTSW500_PORT = 7778
 """The port on which the TCP server of FTSW500 is listening."""
 
 FTSW500_POLLING_INTERVAL = 1.0
-"""How long to wait between polls of the EM27's status."""
+"""How long to wait between polls of FTSW500's status."""
 
 FTSW500_TIMEOUT = 5.0
 """How long to wait for a response from FTSW500 for."""

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -82,6 +82,12 @@ FTSW500_HOST = "127.0.0.1"
 FTSW500_PORT = 7778
 """The port on which the TCP server of FTSW500 is listening."""
 
+FTSW500_POLLING_INTERVAL = 1.0
+"""How long to wait between polls of the EM27's status."""
+
+FTSW500_TIMEOUT = 1.0
+"""How long to wait for a response from FTSW500 for."""
+
 SPECTROMETER_TOPIC = "spectrometer"
 """The topic name to use for spectrometer-related messages."""
 

--- a/finesse/hardware/plugins/spectrometer/dummy_ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_ftsw500_interface.py
@@ -1,0 +1,1 @@
+"""Provides a dummy FTSW500 interferometer device for interfacing with."""

--- a/finesse/hardware/plugins/spectrometer/dummy_ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/dummy_ftsw500_interface.py
@@ -1,1 +1,0 @@
-"""Provides a dummy FTSW500 interferometer device for interfacing with."""

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -49,7 +49,7 @@ def parse_response(response: bytes) -> SpectrometerStatus | None:
         SpectrometerStatus: the generic spectrometer device state of FTSW500
     """
     msg = response.decode()
-    if "NAK" in msg:
+    if msg.startswith("NAK"):
         if "&" in msg:
             try:
                 status = int(msg.split("&")[1])
@@ -58,7 +58,7 @@ def parse_response(response: bytes) -> SpectrometerStatus | None:
                 return None
         else:
             return None
-    elif "ACK" in msg:
+    elif msg.startswith("ACK"):
         if "&" in msg:
             try:
                 status = int(msg.split("&")[1])

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -1,1 +1,194 @@
-"""Module containing code for sending commands to FTSW500 for the ABB spectrometer."""
+"""Module containing code for sending commands to FTSW500 for the ABB spectrometer.
+
+Communication is via TCP.
+
+The FTSW500 program must be running on the computer at FTSW500_HOST for the commands to
+work.
+"""
+
+import logging
+from socket import AF_INET, SOCK_STREAM, socket
+
+from PySide6.QtCore import QTimer
+
+from finesse.config import (
+    FTSW500_HOST,
+    FTSW500_POLLING_INTERVAL,
+    FTSW500_PORT,
+    FTSW500_TIMEOUT,
+)
+from finesse.hardware.plugins.spectrometer.ftsw500_interface_base import (
+    FTSW500Error,
+    FTSW500InterfaceBase,
+)
+from finesse.spectrometer_status import SpectrometerStatus
+
+
+def parse_response(response: bytes) -> SpectrometerStatus | None:
+    r"""Parse FTSW500's response.
+
+    The server always returns a response after having received a command. The response
+    will start with the tag "ACK" in case of success, or "NAK" otherwise, and is
+    terminated by the end-of-line character "\n". An answer can also contain a string
+    value or message after the tag, which will be preceded by "&". For example, querying
+    whether the instrument is currently measuring data would yield a response
+    "ACK&true\n" or "ACK&false\n".
+
+    Querying the FTSW500 state yields one of the following values:
+    0: when disconnected
+    1: when in the process of connecting to an instrument
+    2: when acquiring data without saving it
+    3: when acquiring and saving data
+    -1: when in an intermediate state that should normally not last for a long time
+        (less than 500 ms) or when the FTSW500_SDK object is not well initialized
+
+    Args:
+        response: the byte sequence received from FTSW500
+
+    Returns:
+        SpectrometerStatus: the generic spectrometer device state of FTSW500
+    """
+    msg = response.decode()
+    if "NAK" in msg:
+        if "&" in msg:
+            try:
+                status = int(msg.split("&")[1])
+            except ValueError:
+                logging.error(f"{msg.split('&')[1][:-1]}")
+                return None
+        else:
+            return None
+    elif "ACK" in msg:
+        if "&" in msg:
+            try:
+                status = int(msg.split("&")[1])
+            except ValueError:
+                logging.info(f"{msg.split('&')[1][:-1]}")
+                return None
+        else:
+            return None
+    else:
+        raise FTSW500Error("Unrecognised response")
+
+    if status == -1:
+        return SpectrometerStatus(1)
+    elif status in (0, 1, 2, 3):
+        return SpectrometerStatus(status)
+    else:
+        raise FTSW500Error("Unable to parse response")
+
+
+class FTSW500Interface(FTSW500InterfaceBase, description="FTSW500 spectrometer"):
+    """Interface for communicating with the FTSW500 program."""
+
+    def __init__(self) -> None:
+        """Create a new FTSW500Interface."""
+        super().__init__()
+
+        self._requester = socket(AF_INET, SOCK_STREAM)
+        self._requester.settimeout(FTSW500_TIMEOUT)
+
+        self._requester.connect((FTSW500_HOST, FTSW500_PORT))
+
+        self._status = SpectrometerStatus.UNDEFINED
+
+        self._status_timer = QTimer()
+        self._status_timer.timeout.connect(self._request_status)
+        self._status_timer.setInterval(int(FTSW500_POLLING_INTERVAL * 1000))
+        self._status_timer.setSingleShot(True)
+
+        self._request_status()
+
+    def _check_is_modal_dialog_open(self) -> bool:
+        """Query whether FTSW500 has a modal dialog open."""
+        self._requester.sendall(b"isModalMessageDisplayed\n")
+        data = self._requester.recv(1024)
+        if data != b"":
+            if data.decode().split("&")[1] == "true\n":
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def _check_is_nonmodal_dialog_open(self) -> bool:
+        """Query whether FTSW500 has a non-modal dialog open."""
+        self._requester.sendall(b"isNonModalMessageDisplayed\n")
+        data = self._requester.recv(1024)
+        if data != b"":
+            if data.decode().split("&")[1] == "true\n":
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def _regurgitate_modal_dialog_message(self) -> None:
+        """Obtain the last modal message displayed on FTSW500 and log it."""
+        if self._check_is_modal_dialog_open():
+            self._requester.sendall(b"getLastModalMessageDisplayed\n")
+            data = self._requester.recv(1024)
+            logging.info(f"FTSW500: {data.decode().split('&')[1][:-1]}")
+            self._requester.sendall(b"closeModalDialogMessage\n")
+            self._requester.recv(1024)
+
+    def _regurgitate_nonmodal_dialog_message(self) -> None:
+        """Obtain the last non-modal message displayed on FTSW500 and log it."""
+        if self._check_is_nonmodal_dialog_open():
+            self._requester.sendall(b"getLastNonModalMessageDisplayed\n")
+            data = self._requester.recv(1024)
+            logging.info(f"FTSW500: {data.decode().split('&')[1][:-1]}")
+            self._requester.sendall(b"closeNonModalDialogMessage\n")
+            self._requester.recv(1024)
+
+    def _close_FTSW500(self) -> None:
+        """Close the FTSW500 program."""
+        self._requester.sendall(b"closeFTSW500\n")
+
+    def _disconnect(self) -> None:
+        """Disconnect from the spectrometer."""
+        self._requester.sendall(b"clickDisconnectButton\n")
+        self._requester.recv(1024)
+
+    def close(self) -> None:
+        """Close the device."""
+        if self._status == SpectrometerStatus.CONNECTED:
+            self._disconnect()
+            self._regurgitate_nonmodal_dialog_message()
+        self._requester.close()
+        self._status_timer.stop()
+        super().close()
+
+    def _on_reply_received(self, reply: bytes) -> None:
+        """Handle received reply.
+
+        Args:
+            reply: the byte sequence received from the FTSW500 program
+        """
+        new_status = parse_response(reply)
+        if new_status is not None:
+            if new_status != self._status:
+                self._status = new_status
+                self.send_status_message(new_status)
+
+        self._status_timer.start()
+
+        self._regurgitate_nonmodal_dialog_message()
+        self._regurgitate_modal_dialog_message()
+
+    def _make_request(self, command) -> None:
+        """Make a request."""
+        self._requester.sendall(command)
+        self._on_reply_received(self._requester.recv(1024))
+
+    def _request_status(self) -> None:
+        """Request the current status from FTSW500."""
+        self.request_command(b"getFTSW500State\n")
+
+    def request_command(self, command: bytes) -> None:
+        """Request that FTSW500 run the specified command.
+
+        Args:
+            command: Name of command to run
+        """
+        self._make_request(command)

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -1,9 +1,14 @@
-"""Module containing code for sending commands to FTSW500 for the ABB spectrometer.
+r"""Module containing code for sending commands to FTSW500 for the ABB spectrometer.
 
 Communication is via TCP.
 
 The FTSW500 program must be running on the computer at FTSW500_HOST for the commands to
-work.
+work. The server always returns a response after having received a command. The response
+will start with the tag "ACK" in case of success, or "NAK" otherwise, and is terminated
+by the end-of-line character "\n". An answer can also contain a string value or message
+after the tag, which will be preceded by "&". For example, querying whether the
+instrument is currently measuring data would yield a response "ACK&true\n" or
+"ACK&false\n".
 """
 
 import logging
@@ -25,14 +30,7 @@ from finesse.spectrometer_status import SpectrometerStatus
 
 
 def parse_response(response: bytes) -> SpectrometerStatus | None:
-    r"""Parse FTSW500's response.
-
-    The server always returns a response after having received a command. The response
-    will start with the tag "ACK" in case of success, or "NAK" otherwise, and is
-    terminated by the end-of-line character "\n". An answer can also contain a string
-    value or message after the tag, which will be preceded by "&". For example, querying
-    whether the instrument is currently measuring data would yield a response
-    "ACK&true\n" or "ACK&false\n".
+    """Parse FTSW500's response.
 
     Querying the FTSW500 state yields one of the following values:
     0: when disconnected
@@ -54,7 +52,7 @@ def parse_response(response: bytes) -> SpectrometerStatus | None:
         status = int(msg.split("&")[1])
     elif msg.startswith("NAK&"):
         raise FTSW500Error(msg.split("&")[1])
-    else:
+    else:  # i.e. "ACK"
         return None
 
     if status == -1:

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -86,6 +86,37 @@ class FTSW500Interface(FTSW500InterfaceBase, description="FTSW500 spectrometer")
 
         self._request_status()
 
+    def _set_output_path_prefix(self, output_path_prefix: str) -> None:
+        """Set the output path prefix for FTSW500 data."""
+        self._requester.sendall(
+            f"setOutputPathPrefixField&{output_path_prefix}\n".encode()
+        )
+        self._requester.recv(1024)
+
+    def _set_output_prefix(self, output_prefix: str) -> None:
+        """Set the output prefix for FTSW500 data."""
+        self._requester.sendall(f"setOutputPrefixOnlyField&{output_prefix}\n".encode())
+        self._requester.recv(1024)
+
+    def set_data_description(self, data_description: str) -> None:
+        """Set the description for FTSW500 data."""
+        self._requester.sendall(
+            f"setDataDescriptionField&{data_description}\n".encode()
+        )
+        self._requester.recv(1024)
+
+    def set_num_measurements(self, num_measurements: int) -> None:
+        """Set the number of measurements for FTSW500 to record."""
+        self._requester.sendall(
+            f"setNumberMeasurementField&{num_measurements}\n".encode()
+        )
+        self._requester.recv(1024)
+
+    def set_temperature(self, temperature: float) -> None:
+        """Set the temperature for FTSW500 data."""
+        self._requester.sendall(f"setTemperatureField&{temperature}\n".encode())
+        self._requester.recv(1024)
+
     def _check_is_modal_dialog_open(self) -> bool:
         """Query whether FTSW500 has a modal dialog open."""
         self._requester.sendall(b"isModalMessageDisplayed\n")

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -49,26 +49,13 @@ def parse_response(response: bytes) -> SpectrometerStatus | None:
         SpectrometerStatus: the generic spectrometer device state of FTSW500
     """
     msg = response.decode()
-    if msg.startswith("NAK"):
-        if "&" in msg:
-            try:
-                status = int(msg.split("&")[1])
-            except ValueError:
-                logging.error(f"{msg.split('&')[1][:-1]}")
-                return None
-        else:
-            return None
-    elif msg.startswith("ACK"):
-        if "&" in msg:
-            try:
-                status = int(msg.split("&")[1])
-            except ValueError:
-                logging.info(f"{msg.split('&')[1][:-1]}")
-                return None
-        else:
-            return None
+    print(msg[:-1])
+    if msg.startswith("ACK&"):
+        status = int(msg.split("&")[1])
+    elif msg.startswith("NAK&"):
+        raise FTSW500Error(msg.split("&")[1])
     else:
-        raise FTSW500Error("Unrecognised response")
+        return None
 
     if status == -1:
         return SpectrometerStatus(1)
@@ -103,11 +90,8 @@ class FTSW500Interface(FTSW500InterfaceBase, description="FTSW500 spectrometer")
         """Query whether FTSW500 has a modal dialog open."""
         self._requester.sendall(b"isModalMessageDisplayed\n")
         data = self._requester.recv(1024)
-        if data != b"":
-            if data.decode().split("&")[1] == "true\n":
-                return True
-            else:
-                return False
+        if data.decode().split("&")[1] == "true\n":
+            return True
         else:
             return False
 
@@ -115,11 +99,8 @@ class FTSW500Interface(FTSW500InterfaceBase, description="FTSW500 spectrometer")
         """Query whether FTSW500 has a non-modal dialog open."""
         self._requester.sendall(b"isNonModalMessageDisplayed\n")
         data = self._requester.recv(1024)
-        if data != b"":
-            if data.decode().split("&")[1] == "true\n":
-                return True
-            else:
-                return False
+        if data.decode().split("&")[1] == "true\n":
+            return True
         else:
             return False
 

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -1,0 +1,1 @@
+"""Module containing code for sending commands to FTSW500 for the ABB spectrometer."""

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface_base.py
@@ -20,18 +20,18 @@ class FTSW500InterfaceBase(SpectrometerBase):
 
     def connect(self) -> None:
         """Connect to the spectrometer."""
-        self.request_command("connect")
+        self.request_command(b"clickConnectButton\n")
 
     def start_measuring(self) -> None:
         """Start a new measurement."""
-        self.request_command("start")
+        self.request_command(b"clickStartAcquisitionButton\n")
 
     def stop_measuring(self) -> None:
         """Stop the current measurement."""
-        self.request_command("cancel")
+        self.request_command(b"clickStopAcquisitionButton\n")
 
     @abstractmethod
-    def request_command(self, command: str) -> None:
+    def request_command(self, command: bytes) -> None:
         """Request that FTSW500 run the specified command.
 
         Args:

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface_base.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface_base.py
@@ -1,0 +1,39 @@
+"""Provides a base class for interfacing with the FTSW500 program."""
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from finesse.hardware.plugins.spectrometer.spectrometer_base import SpectrometerBase
+
+
+class FTSW500Error(Exception):
+    """Indicates that an error occurred with an FTSW500 device."""
+
+    @classmethod
+    def from_response(cls, errcode: int, errtext: str) -> FTSW500Error:
+        """Create an FTSW500Error from the information given in the device response."""
+        return cls(f"Error {errcode}: {errtext}")
+
+
+class FTSW500InterfaceBase(SpectrometerBase):
+    """Base class providing an interface to the FTSW500 program."""
+
+    def connect(self) -> None:
+        """Connect to the spectrometer."""
+        self.request_command("connect")
+
+    def start_measuring(self) -> None:
+        """Start a new measurement."""
+        self.request_command("start")
+
+    def stop_measuring(self) -> None:
+        """Stop the current measurement."""
+        self.request_command("cancel")
+
+    @abstractmethod
+    def request_command(self, command: str) -> None:
+        """Request that FTSW500 run the specified command.
+
+        Args:
+            command: Name of command to run
+        """


### PR DESCRIPTION
# Description

This PR adds an interface to ABB's FTSW500 software.

A new spectrometer interface base device, `FTSW500InterfaceBase`, is added, which inherits from the abstract `SpectrometerBase` class. This provides the core `connect`, `start_measuring` and `stop_measuring` commands, which are executed when the corresponding buttons on the GUI are pressed.

The `FTSW500Interface` provides the underlying functionality for sending instructions to FTSW500, as well as receiving and handling any responses. The status of FTSW500 is translated into a `SpectrometerStatus` which largely provides a compatible set of states. The main difference is that once FTSW500 connects to an instrument, it begins acquiring data, but requires further instruction to write acquired data to file. This is in contrast to the interface to the EM27, which always writes acquired data to file, but does not begin acquiring until told to. (We could, of course, mimic this behaviour with FTSW500 by effectively making `connect` redundant, then having `start_measuring` perform `connect` + `start measuring`.)

I'm sure some of this can be tidied up but I thought I'd get some feedback first.

Fixes #322 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [X] Pre-commit hooks run successfully (`pre-commit run -a`)
- [X] All tests pass (`pytest`)
- [X] The documentation builds without warnings (`mkdocs build -s`)
- [X] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
