### PR TITLE
Make spectrometers configurable

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -85,8 +85,8 @@ TEMPERATURE_MONITOR_TOPIC = "temperature_monitor"
 TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
 """The topic name to use for temperature controller-related messages."""
 
-DEFAULT_OPUS_HOST = "10.10.0.2"
-"""The IP address of the machine running the OPUS software."""
+DEFAULT_OPUS_HOST = "localhost"
+"""The IP address or hostname of the machine running the OPUS software."""
 
 DEFAULT_OPUS_PORT = 80
 """The port for OPUS HTTP requests."""

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -99,13 +99,13 @@ device takes to reply. This value then determines how often we wait before even 
 a request.
 """
 
-FTSW500_HOST = "127.0.0.1"
+DEFAULT_FTSW500_HOST = "localhost"
 """The IP address or hostname of the machine running the FTSW500 software."""
 
-FTSW500_PORT = 7778
+DEFAULT_FTSW500_PORT = 7778
 """The port on which the TCP server of FTSW500 is listening."""
 
-FTSW500_POLLING_INTERVAL = 1.0
+DEFAULT_FTSW500_POLLING_INTERVAL = 1.0
 """How long to wait between polls of FTSW500's status."""
 
 FTSW500_TIMEOUT = 5.0

--- a/finesse/config.py
+++ b/finesse/config.py
@@ -85,10 +85,13 @@ TEMPERATURE_MONITOR_TOPIC = "temperature_monitor"
 TEMPERATURE_CONTROLLER_TOPIC = "temperature_controller"
 """The topic name to use for temperature controller-related messages."""
 
-OPUS_IP = "10.10.0.2"
+DEFAULT_OPUS_HOST = "10.10.0.2"
 """The IP address of the machine running the OPUS software."""
 
-OPUS_POLLING_INTERVAL = 1.0
+DEFAULT_OPUS_PORT = 80
+"""The port for OPUS HTTP requests."""
+
+DEFAULT_OPUS_POLLING_INTERVAL = 1.0
 """How long to wait between polls of the EM27's status.
 
 Note that in reality the minimum poll interval is ~2s, because that's how long the

--- a/finesse/gui/hardware_set/finesse_dp9800.yaml
+++ b/finesse/gui/hardware_set/finesse_dp9800.yaml
@@ -24,3 +24,6 @@ devices:
     class_name: spectrometer.em27_sensors.EM27Sensors
   spectrometer:
     class_name: spectrometer.opus_interface.OPUSInterface
+    params:
+      host: 10.10.0.2
+      port: 80

--- a/finesse/gui/hardware_set/finesse_seneca.yaml
+++ b/finesse/gui/hardware_set/finesse_seneca.yaml
@@ -24,3 +24,6 @@ devices:
     class_name: spectrometer.em27_sensors.EM27Sensors
   spectrometer:
     class_name: spectrometer.opus_interface.OPUSInterface
+    params:
+      host: 10.10.0.2
+      port: 80

--- a/finesse/hardware/http_requester.py
+++ b/finesse/hardware/http_requester.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any
 
+from PySide6.QtCore import QUrl
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 
 from finesse.config import DEFAULT_HTTP_TIMEOUT
@@ -20,7 +21,9 @@ class HTTPRequester:
         self._timeout = timeout
         self._manager = QNetworkAccessManager()
 
-    def make_request(self, url: str, callback: Callable[[QNetworkReply], Any]) -> None:
+    def make_request(
+        self, url: str | QUrl, callback: Callable[[QNetworkReply], Any]
+    ) -> None:
         """Make a new HTTP request in the background.
 
         Args:

--- a/tests/hardware/plugins/spectrometer/test_ftsw500_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_ftsw500_interface.py
@@ -9,9 +9,9 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from finesse.config import (
-    FTSW500_HOST,
-    FTSW500_POLLING_INTERVAL,
-    FTSW500_PORT,
+    DEFAULT_FTSW500_HOST,
+    DEFAULT_FTSW500_POLLING_INTERVAL,
+    DEFAULT_FTSW500_PORT,
     FTSW500_TIMEOUT,
 )
 from finesse.hardware.plugins.spectrometer.ftsw500_interface import (
@@ -74,13 +74,17 @@ def test_init(status_mock: Mock, decorator_mock: Mock, qtbot) -> None:
         # Check socket is created correctly and connection is attempted
         socket_ctor.assert_called_once_with(AF_INET, SOCK_STREAM)
         sock.settimeout.assert_called_once_with(FTSW500_TIMEOUT)
-        sock.connect.assert_called_once_with((FTSW500_HOST, FTSW500_PORT))
+        sock.connect.assert_called_once_with(
+            (DEFAULT_FTSW500_HOST, DEFAULT_FTSW500_PORT)
+        )
 
         # Check that _update_status() is called to get initial status
         status_mock.assert_called_once_with()
 
         # Check that timer to poll status is configured correctly but not started
-        assert dev._status_timer.interval() == int(FTSW500_POLLING_INTERVAL * 1000)
+        assert dev._status_timer.interval() == int(
+            DEFAULT_FTSW500_POLLING_INTERVAL * 1000
+        )
         assert dev._status_timer.isSingleShot()
         decorator_mock.assert_called_with(status_mock)
         assert not dev._status_timer.isActive()

--- a/tests/hardware/plugins/spectrometer/test_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from PySide6.QtNetwork import QNetworkReply
 
-from finesse.config import OPUS_IP
+from finesse.config import DEFAULT_OPUS_HOST, DEFAULT_OPUS_PORT
 from finesse.hardware.plugins.spectrometer.opus_interface import (
     OPUSError,
     OPUSInterface,
@@ -33,6 +33,9 @@ def test_init(timer_mock: Mock, subscribe_mock: Mock) -> None:
 
     with patch.object(OPUSInterface, "_request_status") as status_mock:
         opus = OPUSInterface()
+        assert opus._url.scheme() == "http"
+        assert opus._url.host() == DEFAULT_OPUS_HOST
+        assert opus._url.port() == DEFAULT_OPUS_PORT
         status_mock.assert_called_once_with()
 
         assert opus._status == SpectrometerStatus.UNDEFINED
@@ -62,8 +65,8 @@ def test_make_request(opus: OPUSInterface, qtbot) -> None:
         opus._make_request("hello.htm")
         assert requester_mock.make_request.call_count == 1
         assert (
-            requester_mock.make_request.call_args[0][0]
-            == f"http://{OPUS_IP}/opusrs/hello.htm"
+            requester_mock.make_request.call_args[0][0].toString()
+            == f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs/hello.htm"
         )
 
 


### PR DESCRIPTION
# Description

The two spectrometer types (`FTSW500Interface` and `OPUSInterface`) have various parameters that users may want to change, e.g. the hostname to connect to. Currently these parameters are all hardcoded, but it's easy enough to make them into "device parameters" like we have for other device classes, so they can be changed manually from the GUI. Let's do this so that we don't have a bunch of unnecessarily hardcoded parameters.

While I haven't verified that `OPUSInterface` still works with the real hardware, as I don't have it, we have unit tests to ensure that the URLs requested are unchanged.

Fixes #547. Fixes #557.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
