### PR TITLE
Fix up pyproject.toml for new version of ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ mkdocs-gen-files = "^0.5.0"
 mkdocs-literate-nav = "^0.6.1"
 mkdocs-section-index = "^0.3.8"
 
-
 [tool.ruff]
-select = [
+target-version = "py311"
+lint.select = [
     "D",   # pydocstyle
     "E",   # pycodestyle
     "F",   # Pyflakes
@@ -63,10 +63,7 @@ select = [
     "UP",  # pyupgrade
     "RUF", # ruff
 ]
-target-version = "py311"
-
-[tool.ruff.pydocstyle]
-convention = "google"
+lint.pydocstyle.convention = "google"
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
Ruff's started issuing warnings about our `pyproject.toml`. Fix it up.

Fixes #558.