### PR TITLE
Misc device fixes and tidy-ups

### DIFF
--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -87,11 +87,6 @@ class AbstractDevice(ABC):
         """
         super().__init_subclass__()
 
-        # Every time we create a new class, create a new _device_parameters attribute,
-        # so that _add_parameters() and _update_parameter_defaults() don't clobber
-        # values for the parent class.
-        cls._device_parameters = deepcopy(cls._device_parameters)
-
         cls._add_parameters(parameters)
         cls._update_parameter_defaults()
 
@@ -102,6 +97,14 @@ class AbstractDevice(ABC):
     ) -> None:
         """Store extra device parameters in a class attribute."""
         arg_types = get_type_hints(cls.__init__)
+
+        # We want to copy device parameters from the parent class, but only if they are
+        # also present in this class's constructor
+        params = set(arg_types.keys()).intersection(cls._device_parameters.keys())
+        cls._device_parameters = {
+            name: deepcopy(cls._device_parameters[name]) for name in params
+        }
+
         for name, value in parameters.items():
             if isinstance(value, str):
                 # Only a description provided

--- a/finesse/hardware/device.py
+++ b/finesse/hardware/device.py
@@ -100,9 +100,10 @@ class AbstractDevice(ABC):
 
         # We want to copy device parameters from the parent class, but only if they are
         # also present in this class's constructor
-        params = set(arg_types.keys()).intersection(cls._device_parameters.keys())
         cls._device_parameters = {
-            name: deepcopy(cls._device_parameters[name]) for name in params
+            k: deepcopy(v)
+            for k, v in cls._device_parameters.items()
+            if k in arg_types.keys()
         }
 
         for name, value in parameters.items():

--- a/finesse/hardware/plugins/decades/decades.py
+++ b/finesse/hardware/plugins/decades/decades.py
@@ -127,3 +127,4 @@ class Decades(
     def close(self) -> None:
         """Close the device."""
         self._poll_timer.stop()
+        super().close()

--- a/finesse/hardware/plugins/spectrometer/em27_sensors.py
+++ b/finesse/hardware/plugins/spectrometer/em27_sensors.py
@@ -129,3 +129,4 @@ class EM27Sensors(
     def close(self) -> None:
         """Close the device."""
         self._poll_timer.stop()
+        super().close()

--- a/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
+++ b/finesse/hardware/plugins/spectrometer/ftsw500_interface.py
@@ -171,17 +171,6 @@ class FTSW500Interface(
 
         return _parse_response(response[:-1])
 
-    def _request_command_internal(self, command: str) -> None:
-        """Request that FTSW500 run the specified command and update the status.
-
-        Internal function called by request_command(), which doesn't do error
-        forwarding via pubsub.
-        """
-        self._make_request(command)
-
-        # Request a status update
-        self._update_status()
-
     def request_command(self, command: str) -> None:
         """Request that FTSW500 run the specified command.
 
@@ -192,5 +181,7 @@ class FTSW500Interface(
         Args:
             command: Name of command to run
         """
-        # Make the request, forwarding any errors raised to the frontend
-        self.pubsub_errors(lambda: self._request_command_internal(command))()
+        self._make_request(command)
+
+        # Request a status update
+        self._update_status()

--- a/finesse/hardware/plugins/temperature/dummy_temperature_monitor.py
+++ b/finesse/hardware/plugins/temperature/dummy_temperature_monitor.py
@@ -42,9 +42,6 @@ class DummyTemperatureMonitor(
 
         super().__init__()
 
-    def close(self) -> None:
-        """Close the connection to the device."""
-
     def get_temperatures(self) -> Sequence:
         """Get current temperatures."""
         return [producer() for producer in self._temperature_producers]

--- a/tests/hardware/plugins/spectrometer/test_ftsw500_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_ftsw500_interface.py
@@ -243,28 +243,10 @@ def test_update_status_try_again(ftsw: FTSW500Interface) -> None:
             ftsw._status_timer.start.assert_called_once_with()
 
 
-def test_request_command_internal(ftsw: FTSW500Interface) -> None:
-    """Test the _request_command_internal() method."""
+def test_request_command(ftsw: FTSW500Interface) -> None:
+    """Test the request_command() method."""
     with patch.object(ftsw, "_make_request") as request_mock:
         with patch.object(ftsw, "_update_status") as status_mock:
-            ftsw._request_command_internal("madeUpCommand")
-            request_mock.assert_called_once_with("madeUpCommand")
-            status_mock.assert_called_once_with()
-
-
-def test_request_command_success(ftsw: FTSW500Interface) -> None:
-    """Test the request_command() method when the command succeeds."""
-    with patch.object(ftsw, "_request_command_internal") as request_mock:
-        ftsw.request_command("madeUpCommand")
-        request_mock.assert_called_once_with("madeUpCommand")
-
-
-def test_request_command_fail(ftsw: FTSW500Interface) -> None:
-    """Test the request_command() method when the command fails."""
-    with patch.object(ftsw, "_request_command_internal") as request_mock:
-        with patch.object(ftsw, "send_error_message") as error_mock:
-            error = FTSW500Error()
-            request_mock.side_effect = error
             ftsw.request_command("madeUpCommand")
             request_mock.assert_called_once_with("madeUpCommand")
-            error_mock.assert_called_once_with(error)
+            status_mock.assert_called_once_with()

--- a/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from finesse.config import STEPPER_MOTOR_TOPIC
-from finesse.device_info import DeviceInstanceRef
 from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 
 
@@ -69,16 +67,3 @@ def test_angle(stepper: _MockStepperMotor) -> None:
     stepper._steps_per_rotation = 180
     stepper.step = 180
     assert stepper.angle == 360.0
-
-
-def test_send_error_message(
-    sendmsg_mock: MagicMock, stepper: _MockStepperMotor
-) -> None:
-    """Test the send_error_message() method."""
-    error = Exception()
-    stepper.send_error_message(error)
-    sendmsg_mock.assert_called_once_with(
-        f"device.error.{STEPPER_MOTOR_TOPIC}",
-        instance=DeviceInstanceRef(STEPPER_MOTOR_TOPIC),
-        error=error,
-    )

--- a/tests/hardware/test_device.py
+++ b/tests/hardware/test_device.py
@@ -1,5 +1,6 @@
 """Tests for device.py."""
 
+from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, Mock, patch
@@ -318,6 +319,20 @@ def test_device_subscribe_errors_only(
 def test_device_subscribe_broadcast(device: Device, subscribe_mock: MagicMock) -> None:
     """Test the subscribe() method with a message sent for error and success."""
     _device_subscribe_test(device, subscribe_mock, "pubsub_broadcast", "suffix", "name")
+
+
+def test_device_ignored_class():
+    """Test that it is possible to create a class not saved to a device registry."""
+    with patch.object(Device, "_init_base_type") as init_base_mock:
+        with patch.object(Device, "_init_device_type") as init_device_mock:
+
+            class IgnoredMockClass(_MockBaseClass):
+                @abstractmethod
+                def some_method():
+                    pass
+
+            init_base_mock.assert_not_called()
+            init_device_mock.assert_not_called()
 
 
 def test_device_init() -> None:


### PR DESCRIPTION
# Description

In the course of my failed refactor and while working on #457 I've found various small problems and I thought they probably deserved their own PR, so that the one for #457 doesn't end up too big and convoluted.

Commit summary:

- Fix a couple of small issues with `Device`'s `__init_subclass__` magic (they aren't breaking anything at present, but they are a blocker for the code I've written for #457)
- Various devices' implementations of `close()` don't call `super().close()`, which could break things
- `FTSW500Interface`: Remove unnecessary error handling code for `request_command()` (because we subscribe to messages with `self.subscribe()`, error handling is taken care of)
- Add some missing tests and remove a duplicate

Fixes #563. Fixes #564.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [x] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
