### PR TITLE
Fix OPUS request URLs

### DIFF
--- a/finesse/hardware/http_requester.py
+++ b/finesse/hardware/http_requester.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any
 
-from PySide6.QtCore import QUrl
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 
 from finesse.config import DEFAULT_HTTP_TIMEOUT
@@ -21,9 +20,7 @@ class HTTPRequester:
         self._timeout = timeout
         self._manager = QNetworkAccessManager()
 
-    def make_request(
-        self, url: str | QUrl, callback: Callable[[QNetworkReply], Any]
-    ) -> None:
+    def make_request(self, url: str, callback: Callable[[QNetworkReply], Any]) -> None:
         """Make a new HTTP request in the background.
 
         Args:

--- a/finesse/hardware/plugins/spectrometer/opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface.py
@@ -9,7 +9,7 @@ Note that this is a separate machine from the EM27!
 import logging
 
 from bs4 import BeautifulSoup
-from PySide6.QtCore import QTimer, QUrl, Slot
+from PySide6.QtCore import QTimer, Slot
 from PySide6.QtNetwork import QNetworkReply
 
 from finesse.config import (
@@ -92,11 +92,8 @@ class OPUSInterface(
         """
         super().__init__()
         self._requester = HTTPRequester()
-        self._url = QUrl()
+        self._url = f"http://{host}:{port}/opusrs"
         """URL to make requests."""
-        self._url.setScheme("http")
-        self._url.setHost(host)
-        self._url.setPort(port)
 
         self._status = SpectrometerStatus.UNDEFINED
         """The last known status of the spectrometer."""
@@ -132,9 +129,8 @@ class OPUSInterface(
 
     def _make_request(self, filename: str) -> None:
         """Make an HTTP request in the background."""
-        self._url.setPath(f"/opusrs/{filename}")
         self._requester.make_request(
-            self._url, self.pubsub_errors(self._on_reply_received)
+            f"{self._url}/{filename}", self.pubsub_errors(self._on_reply_received)
         )
 
     def _request_status(self) -> None:

--- a/tests/hardware/plugins/spectrometer/test_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface.py
@@ -2,7 +2,7 @@
 
 from itertools import product
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
 from PySide6.QtNetwork import QNetworkReply
@@ -33,9 +33,7 @@ def test_init(timer_mock: Mock, subscribe_mock: Mock) -> None:
 
     with patch.object(OPUSInterface, "_request_status") as status_mock:
         opus = OPUSInterface()
-        assert opus._url.scheme() == "http"
-        assert opus._url.host() == DEFAULT_OPUS_HOST
-        assert opus._url.port() == DEFAULT_OPUS_PORT
+        assert opus._url == f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs"
         status_mock.assert_called_once_with()
 
         assert opus._status == SpectrometerStatus.UNDEFINED
@@ -63,10 +61,8 @@ def test_make_request(opus: OPUSInterface, qtbot) -> None:
     """Test OPUSInterface's request_command() method."""
     with patch.object(opus, "_requester") as requester_mock:
         opus._make_request("hello.htm")
-        assert requester_mock.make_request.call_count == 1
-        assert (
-            requester_mock.make_request.call_args[0][0].toString()
-            == f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs/hello.htm"
+        requester_mock.make_request.assert_called_once_with(
+            f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs/hello.htm", ANY
         )
 
 

--- a/tests/hardware/plugins/spectrometer/test_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface.py
@@ -57,12 +57,13 @@ def test_request_command(command: str, opus: OPUSInterface, qtbot) -> None:
         request_mock.assert_called_once_with(f"cmd.htm?opusrs{command}")
 
 
-def test_make_request(opus: OPUSInterface, qtbot) -> None:
+@pytest.mark.parametrize("filename", ("hello.htm", "hello.htm?somequery"))
+def test_make_request(opus: OPUSInterface, filename: str, qtbot) -> None:
     """Test OPUSInterface's request_command() method."""
     with patch.object(opus, "_requester") as requester_mock:
-        opus._make_request("hello.htm")
+        opus._make_request(filename)
         requester_mock.make_request.assert_called_once_with(
-            f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs/hello.htm", ANY
+            f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs/{filename}", ANY
         )
 
 


### PR DESCRIPTION
# Description

Since commit 72b6e851, the request URLs used by `OPUSInterface` have been broken (#574), which causes commands to fail (e.g. starting recording). Fix by creating the URL from a string rather than a `QUrl`. We had unit tests for this but they didn't catch it.

Fixes #574.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
