### PR TITLE
Fix mypy error in test

### DIFF
--- a/tests/gui/test_path_widget.py
+++ b/tests/gui/test_path_widget.py
@@ -11,7 +11,7 @@ from finesse.gui.path_widget import PathWidget
 class DummyWidget(PathWidget):
     """Override abstract member functions so we can create an instance."""
 
-    def try_get_path_from_dialog(self) -> Path | None:
+    def try_get_path_from_dialog(self) -> None:
         """Try to get the file name by raising a dialog."""
         return None
 

--- a/tests/gui/test_path_widget.py
+++ b/tests/gui/test_path_widget.py
@@ -13,7 +13,7 @@ class DummyWidget(PathWidget):
 
     def try_get_path_from_dialog(self) -> Path | None:
         """Try to get the file name by raising a dialog."""
-        return super().try_get_path_from_dialog()
+        return None
 
 
 @pytest.fixture()


### PR DESCRIPTION
It seems the latest version of `mypy` has noticed the trickery I was doing with this method and is complaining about it.

The body of the method is never actually executed -- we just need it because the parent class is abstract -- but let's replace it with something that `mypy` is happier.