### PR TITLE
Fix some comparisons to appease ruff

### DIFF
--- a/tests/hardware/plugins/temperature/test_dummy_temperature_controller.py
+++ b/tests/hardware/plugins/temperature/test_dummy_temperature_controller.py
@@ -25,7 +25,7 @@ def test_power() -> None:
     dev = DummyTemperatureController("hot_bb", power_params=params)
     assert dev._power_producer.mean == params.mean
     assert dev._power_producer.standard_deviation == params.standard_deviation
-    assert dev._power_producer.type == int
+    assert dev._power_producer.type is int
 
 
 @pytest.mark.parametrize("alarm_status", range(2))

--- a/tests/hardware/test_noise_producer.py
+++ b/tests/hardware/test_noise_producer.py
@@ -25,7 +25,7 @@ def test_init_defaults(rng_mock: Mock) -> None:
     noise = NoiseProducer()
     assert noise.mean == 0.0
     assert noise.standard_deviation == 1.0
-    assert noise.type == float
+    assert noise.type is float
     rng_mock.assert_called_once_with(42)
     assert noise.rng is mock2
 


### PR DESCRIPTION
It seems like I just broke the CI by merging some bot PRs. Now things are failing because of a (presumably new) ruff check. Not sure why the CI didn't catch it, but in any case it's easy to fix.