### PR TITLE
Fix: CI: Install Poetry with pipx instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v3.0.0
-        with:
-          poetry-version: 1.8.3
+        run: pipx install poetry
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The `ubuntu-latest` GitHub runner is currently failing due to #651. Fix by installing Poetry with pipx instead of using the GitHub Action.

Fixes #645. Fixes #651.