### PR TITLE
Tidy GitHub workflows

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,0 +1,16 @@
+name: Build documentation
+description: Build documentation with MkDocs
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dot for generating diagrams
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt install graphviz
+
+    - name: Build documentation with MkDocs
+      shell: bash
+      run: |
+        poetry run python docs/gen_state_machine_diagrams.py
+        poetry run mkdocs build --strict

--- a/.github/actions/build-win-exe/action.yml
+++ b/.github/actions/build-win-exe/action.yml
@@ -1,0 +1,13 @@
+name: Build Windows executable
+description: Create bundled executable with pyinstaller
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Pandoc
+      shell: bash
+      run: choco install pandoc
+
+    - name: Build package
+      shell: bash
+      run: poetry run pyinstaller FINESSE.spec

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,34 @@
+name: Set up
+description: Set up Python environment and install dependencies
+inputs:
+  python-version:
+    description: The Python version to use
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: poetry
+
+    - name: Install system dependencies in Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt update
+
+        # For documentation
+        sudo apt install graphviz
+
+        # Without this, PySide6 gives an ImportError
+        sudo apt install libegl1
+
+    - name: Install dependencies
+      shell: bash
+      run: poetry install

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,9 +23,6 @@ runs:
       run: |
         sudo apt update
 
-        # For documentation
-        sudo apt install graphviz
-
         # Without this, PySide6 gives an ImportError
         sudo apt install libegl1
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,9 @@
 name: Check links in Markdown files
 on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1" # midnight every Monday
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,21 +26,21 @@ jobs:
         run: poetry run pytest --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && success()
+        if: runner.os == 'Linux' && success()
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check documentation builds correctly
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         uses: ./.github/actions/build-docs
 
       - name: Build exe
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         uses: ./.github/actions/build-win-exe
 
       - uses: actions/upload-artifact@v4
-        if: success() && matrix.os == 'windows-latest'
+        if: success() && runner.os == 'Windows'
         with:
           name: FINESSE
           path: dist/FINESSE.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        name: Check links in markdown files
-        with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
-          config-file: .mlc_config.json
-
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,9 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Check for documentation errors with MkDocs
+      - name: Check documentation builds correctly
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          poetry run python docs/gen_state_machine_diagrams.py
-          poetry run mkdocs build -s
+        uses: ./.github/actions/build-docs
 
       - name: Install Pandoc
         if: matrix.os == 'windows-latest'
@@ -56,18 +54,3 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/FINESSE.exe
-
-  docs:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
-        with:
-          python-version: "3.11"
-
-      - name: Deploy Docs
-        run: |
-          poetry run python docs/gen_state_machine_diagrams.py
-          poetry run mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,30 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Poetry
-        run: pipx install poetry
-
-      - uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
-
-      - name: Install system dependencies in Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt update
-
-          # For documentation
-          sudo apt install graphviz
-
-          # Without this, PySide6 gives an ImportError
-          sudo apt install libegl1
-
-      - name: Install dependencies
-        run: |
-          poetry env use "${{ matrix.python-version }}"
-          poetry install
 
       - name: Run tests
         run: poetry run pytest --cov-report=xml
@@ -84,28 +63,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup
         with:
           python-version: "3.11"
-
-      - name: Install system dependencies in Linux
-        run: |
-          sudo apt update
-
-          # For documentation
-          sudo apt install graphviz
-
-          # Without this, PySide6 gives an ImportError
-          sudo apt install libegl1
-
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v3.0.0
-        with:
-          poetry-version: 1.2.2
-
-      - name: Install dependencies
-        run: poetry install
 
       - name: Deploy Docs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/build-win-exe
 
       - uses: actions/upload-artifact@v4
-        if: success() && runner.os == 'Windows'
+        if: runner.os == 'Windows' && success()
         with:
           name: FINESSE
           path: dist/FINESSE.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest --cov-report=xml
-        env:
-          QT_QPA_PLATFORM: offscreen
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,22 +35,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: ./.github/actions/build-docs
 
-      - name: Install Pandoc
+      - name: Build exe
         if: matrix.os == 'windows-latest'
-        run: choco install pandoc
-
-      - name: Build package
-        if: matrix.os == 'windows-latest'
-        run: poetry run pyinstaller FINESSE.spec
+        uses: ./.github/actions/build-win-exe
 
       - uses: actions/upload-artifact@v4
         if: success() && matrix.os == 'windows-latest'
         with:
           name: FINESSE
           path: dist/FINESSE.exe
-
-      - name: Upload release artifacts
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows-latest'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/FINESSE.exe

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Build documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.11"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - uses: ./.github/actions/build-docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  release:
+
+jobs:
+  upload_exe:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.11"
+      - uses: ./.github/actions/build-win-exe
+
+      - name: Upload release artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/FINESSE.exe


### PR DESCRIPTION
As with many of our projects, FINESSE currently has one large workflow file which does several different things (running tests, building documentation, building release artifacts) and I thought it would be cleaner to try to separate this out a bit.

Specifically:

* I made separate composite actions for installing dependencies, building the docs and building the EXE file
* I made two new workflows for deploying the documentation and uploading the release artifacts (viz. generated EXE file)

The docs workflow uses the new GitHub Actions method for deploying docs rather than the `gh-pages` branch, which brings a few advantages. I tested that the action actually works by deploying from this branch.