### PR TITLE
Added 'PAUSED' to progress bar text when measurement script paused

### DIFF
--- a/finesse/gui/measure_script/script_run_dialog.py
+++ b/finesse/gui/measure_script/script_run_dialog.py
@@ -105,8 +105,10 @@ class ScriptRunDialog(QDialog):
         if self._pause_btn.text() == "Pause":
             pub.sendMessage("measure_script.pause")
             self._pause_btn.setText("Unpause")
+            self._progress_bar.setFormat("PAUSED (%p%)")
         else:
             pub.sendMessage("measure_script.unpause")
+            self._progress_bar.setFormat("%p%")
             self._pause_btn.setText("Pause")
 
     def closeEvent(self, event: QCloseEvent) -> None:

--- a/tests/gui/measure_script/test_script_run_dialog.py
+++ b/tests/gui/measure_script/test_script_run_dialog.py
@@ -143,3 +143,39 @@ def test_on_start_measuring(
             f"Carrying out measurement {runner_measuring.current_measurement_count + 1}"
             f" of {runner_measuring.current_measurement.measurements}",
         )
+
+
+def test_toggle_paused(
+    run_dialog: ScriptRunDialog,
+    runner: ScriptRunner,
+    sendmsg_mock: MagicMock,
+    qtbot: QtBot,
+) -> None:
+    """Test the widgets update correctly when paused/unpaused."""
+    with patch.object(run_dialog, "_progress_bar") as progress_bar_mock:
+        with patch.object(run_dialog, "_pause_btn") as pause_btn_mock:
+            pause_btn_mock.text.return_value = "Pause"  # Start off in unpaused state
+            # Pause
+            run_dialog._toggle_paused()
+
+            # Check "pause" broadcast
+            sendmsg_mock.assert_any_call("measure_script.pause")
+
+            # Check progress bar string format is updated to display "PAUSED"
+            progress_bar_mock.setFormat.assert_called_with("PAUSED (%p%)")
+
+            # Check pause button text is updated
+            pause_btn_mock.setText.assert_called_once_with("Unpause")
+
+            pause_btn_mock.text.return_value = "Unpause"  # Now in paused state
+            # Unpause
+            run_dialog._toggle_paused()
+
+            # Check "unpause" broadcast
+            sendmsg_mock.assert_any_call("measure_script.unpause")
+
+            # Check progress bar string format is reverted to display percentage
+            progress_bar_mock.setFormat.assert_called_with("%p%")
+
+            # Check pause button text is updated
+            pause_btn_mock.setText.assert_called_with("Pause")


### PR DESCRIPTION
# Description

This PR contains an update to the measure script dialog window, such that when the script is paused, the progress bar text changes from `xy%` to `PAUSED (xy%)`, and back to `xy%` when unpaused.

This is achieved by updating the `format` attribute of the associated `QProgressBar`, rather than explicitly changing the displayed text.

Fixes #285 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [X] Pre-commit hooks run successfully (`pre-commit run -a`)
- [X] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [X] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests have been added or an issue has been opened to tackle that in the future.
