### PR TITLE
Add versions to hardware sets and measurement scripts

### DIFF
--- a/docs/hardware_sets.md
+++ b/docs/hardware_sets.md
@@ -10,6 +10,7 @@ Hardware sets are represented in a [YAML](https://yaml.org) format. Custom hardw
 can be created and imported into FINESSE. Here is an example:
 
 ```yaml
+version: 1
 name: My hardware set
 devices:
   stepper_motor:
@@ -41,16 +42,17 @@ devices:
       port: 80
 ```
 
-The `name` property defines a human-readable name for the hardware set, to be displayed
-in the GUI and the `devices` property contains information about the devices in this
-hardware set. The `devices` array consists of key-value pairs, with the keys
-corresponding to device base types (see [Hardware]). The values are YAML objects with a
-`class_name` property and (optionally) a `params` property. `class_name` is a string
-corresponding to the Python class name, along with the last part of the module name (all
-plugins are in the `finesse.hardware.plugins` module, so this part is omitted). `params`
-is also a YAML object, containing key-value pairs for each of the device parameters (see
-[Hardware] again). If any of the parameters are omitted, their default values will be
-used.
+The `version` defines the version of the schema that should be used for validating the
+hardware set file. The `name` property defines a human-readable name for the hardware
+set, to be displayed in the GUI and the `devices` property contains information about
+the devices in this hardware set. The `devices` array consists of key-value pairs, with
+the keys corresponding to device base types (see [Hardware]). The values are YAML
+objects with a `class_name` property and (optionally) a `params` property. `class_name`
+is a string corresponding to the Python class name, along with the last part of the
+module name (all plugins are in the `finesse.hardware.plugins` module, so this part is
+omitted). `params` is also a YAML object, containing key-value pairs for each of the
+device parameters (see [Hardware] again). If any of the parameters are omitted, their
+default values will be used.
 
 Note that the port names are in a FINESSE-specific format. The string is composed of the
 USB vendor and product IDs and (optionally) a number to distinguish ports which share

--- a/docs/measure_scripts.md
+++ b/docs/measure_scripts.md
@@ -8,6 +8,7 @@ These files are written in [YAML](https://yaml.org/) format, with certain proper
 Here is an example:
 
 ```yaml
+version: 1
 repeats: 10
 sequence:
 - angle: zenith
@@ -16,6 +17,8 @@ sequence:
   measurements: 3
 ```
 
+The `version` defines the version of the schema that should be used for validating the
+hardware set file.
 First is the `repeats` property, which specifies how many times *the entire sequence* is
 run. The `sequence` property specifies which angles the mirror should move to (`angle`)
 and how many measurements should be recorded at each of these positions

--- a/finesse/gui/hardware_set/dummy.yaml
+++ b/finesse/gui/hardware_set/dummy.yaml
@@ -1,3 +1,4 @@
+version: 1
 name: "Dummy devices"
 devices:
   stepper_motor:

--- a/finesse/gui/hardware_set/dummy_ftsw500.yaml
+++ b/finesse/gui/hardware_set/dummy_ftsw500.yaml
@@ -1,3 +1,4 @@
+version: 1
 name: "Dummy devices + FTSW500 spectrometer"
 devices:
   stepper_motor:

--- a/finesse/gui/hardware_set/finesse.yaml
+++ b/finesse/gui/hardware_set/finesse.yaml
@@ -1,3 +1,4 @@
+version: 1
 name: FINESSE
 devices:
   stepper_motor:

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -39,16 +39,18 @@ class Script:
     """Represents a measure script, including its file path and data."""
 
     def __init__(
-        self, path: Path, repeats: int, sequence: Sequence[dict[str, Any]]
+        self, path: Path, version: int, repeats: int, sequence: Sequence[dict[str, Any]]
     ) -> None:
         """Create a new Script.
 
         Args:
             path: The file path to this measure script
+            version: The version of the measure script format
             repeats: The number of times to repeat the sequence of measurements
             sequence: Different measurements (i.e. angle + num measurements) to record
         """
         self.path = path
+        self.version = version
         self.repeats = repeats
         self.sequence = [Measurement(**val) for val in sequence]
         self.runner: ScriptRunner | None = None
@@ -106,6 +108,7 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
 
     schema = Schema(
         {
+            "version": int,
             "repeats": measurements_type,
             "sequence": And(
                 nonempty_list,

--- a/tests/gui/hardware_set/conftest.py
+++ b/tests/gui/hardware_set/conftest.py
@@ -9,6 +9,7 @@ from finesse.gui.hardware_set.hardware_set import HardwareSet, OpenDeviceArgs
 
 _HW_SETS = (
     HardwareSet(
+        1,
         "Test 1",
         frozenset(
             (
@@ -24,6 +25,7 @@ _HW_SETS = (
         False,
     ),
     HardwareSet(
+        1,
         "Test 2",
         frozenset(
             (

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -73,9 +73,9 @@ def test_hardware_set_save(dump_mock: Mock, to_plain_mock: Mock) -> None:
         for i in range(2)
     )
     to_plain_mock.side_effect = ((f"key{i}", i) for i in range(2))
-    hw_set = HardwareSet(NAME, frozenset(devices), FILE_PATH, False)
+    hw_set = HardwareSet(1, NAME, frozenset(devices), FILE_PATH, False)
     hw_set.save(file_path)
-    expected = {"name": NAME, "devices": {"key0": 0, "key1": 1}}
+    expected = {"version": 1, "name": NAME, "devices": {"key0": 0, "key1": 1}}
     assert dump_mock.call_count == 1
     assert dump_mock.mock_calls[0].args[0] == expected
 
@@ -87,7 +87,7 @@ def test_hardware_set_save_and_load(tmp_path: Path) -> None:
         for i in range(2)
     )
     save_path = tmp_path / "file.yaml"
-    hw_set1 = HardwareSet(NAME, frozenset(devices), save_path, False)
+    hw_set1 = HardwareSet(1, NAME, frozenset(devices), save_path, False)
     hw_set1.save(save_path)
     hw_set2 = HardwareSet.load(save_path, False)
     assert hw_set1 == hw_set2
@@ -98,18 +98,18 @@ def test_hardware_set_save_and_load(tmp_path: Path) -> None:
     (
         # Built-in HardwareSets come before user ones
         (
-            HardwareSet("B", frozenset(), Path("b.yaml"), True),
-            HardwareSet("A", frozenset(), Path("a.yaml"), False),
+            HardwareSet(1, "B", frozenset(), Path("b.yaml"), True),
+            HardwareSet(1, "A", frozenset(), Path("a.yaml"), False),
         ),
         # Then sort by name
         (
-            HardwareSet("A", frozenset(), Path("2.yaml"), True),
-            HardwareSet("B", frozenset(), Path("1.yaml"), True),
+            HardwareSet(1, "A", frozenset(), Path("2.yaml"), True),
+            HardwareSet(1, "B", frozenset(), Path("1.yaml"), True),
         ),
         # Lastly, sort by file name
         (
-            HardwareSet(NAME, frozenset(), Path("a.yaml"), True),
-            HardwareSet(NAME, frozenset(), Path("b.yaml"), True),
+            HardwareSet(1, NAME, frozenset(), Path("a.yaml"), True),
+            HardwareSet(1, NAME, frozenset(), Path("b.yaml"), True),
         ),
     ),
 )
@@ -126,10 +126,12 @@ def test_hardware_set_lt(hw_set1: HardwareSet, hw_set2: HardwareSet) -> None:
         # Device given without params
         (
             {
+                "version": 1,
                 "name": NAME,
                 "devices": {"stepper_motor": {"class_name": "MyStepperMotor"}},
             },
             HardwareSet(
+                1,
                 NAME,
                 frozenset((OpenDeviceArgs.create("stepper_motor", "MyStepperMotor"),)),
                 FILE_PATH,
@@ -139,6 +141,7 @@ def test_hardware_set_lt(hw_set1: HardwareSet, hw_set2: HardwareSet) -> None:
         # Device given with params
         (
             {
+                "version": 1,
                 "name": NAME,
                 "devices": {
                     "stepper_motor": {
@@ -148,6 +151,7 @@ def test_hardware_set_lt(hw_set1: HardwareSet, hw_set2: HardwareSet) -> None:
                 },
             },
             HardwareSet(
+                1,
                 NAME,
                 frozenset(
                     (
@@ -184,6 +188,7 @@ def test_load(validate_mock: Mock, data: dict[str, Any], expected: HardwareSet) 
 def test_load_validates_data(validate_mock: Mock) -> None:
     """Check that HardwareSet.load() validates data against the schema."""
     data = {
+        "version": 1,
         "name": NAME,
         "devices": {"stepper_motor": {"class_name": "MyStepperMotor"}},
     }
@@ -202,6 +207,7 @@ def test_load_validates_data(validate_mock: Mock) -> None:
         # Valid, no params
         (
             {
+                "version": 1,
                 "name": NAME,
                 "devices": {"stepper_motor": {"class_name": "MyStepperMotor"}},
             },
@@ -210,6 +216,7 @@ def test_load_validates_data(validate_mock: Mock) -> None:
         # Valid, with params
         (
             {
+                "version": 1,
                 "name": NAME,
                 "devices": {
                     "stepper_motor": {
@@ -359,7 +366,7 @@ def test_add_hardware_set_success(
     get_path_mock.return_value = out_path
     hw_set_list: list = []
     with patch("finesse.gui.hardware_set.hardware_set._hw_sets", hw_set_list):
-        hw_set_new = HardwareSet(NAME, hw_sets[0].devices, out_path, built_in=False)
+        hw_set_new = HardwareSet(1, NAME, hw_sets[0].devices, out_path, built_in=False)
         _add_hardware_set(hw_set)
         get_path_mock.assert_called_once_with(in_path.stem)
         hw_set.save.assert_called_once_with(out_path)
@@ -465,7 +472,7 @@ def test_remove_hardware_set_fail(
 
 def test_remove_hardware_set_fail_built_in(hw_sets: Sequence[HardwareSet]) -> None:
     """Test with a built-in hardware set as argument."""
-    hw_set = HardwareSet(NAME, hw_sets[0].devices, FILE_PATH, built_in=True)
+    hw_set = HardwareSet(1, NAME, hw_sets[0].devices, FILE_PATH, built_in=True)
     with pytest.raises(ValueError):
         _remove_hardware_set(hw_set)
 

--- a/tests/gui/hardware_set/test_hardware_sets_combo_box.py
+++ b/tests/gui/hardware_set/test_hardware_sets_combo_box.py
@@ -47,6 +47,7 @@ def test_load_hardware_set_list(
 
 
 _HW_SET = HardwareSet(
+    1,
     "Test 1",
     frozenset(
         (
@@ -90,11 +91,11 @@ def test_add_hardware_set(
     """Test the _add_hardware_set() method."""
     combo.clear()
     for hw_set in existing_hw_sets:
-        hw_set = HardwareSet(hw_set.name, hw_set.devices, hw_set.file_path, built_in)
+        hw_set = HardwareSet(1, hw_set.name, hw_set.devices, hw_set.file_path, built_in)
         combo._add_hardware_set(hw_set)
 
     with patch.object(combo, "addItem") as add_mock:
-        hw_set = HardwareSet(hw_set_name, frozenset(), Path(), built_in)
+        hw_set = HardwareSet(1, hw_set_name, frozenset(), Path(), built_in)
         combo._add_hardware_set(hw_set)
         add_mock.assert_called_once_with(expected_name, hw_set)
 

--- a/tests/gui/measure_script/conftest.py
+++ b/tests/gui/measure_script/conftest.py
@@ -15,7 +15,7 @@ from finesse.gui.measure_script.script_run_dialog import ScriptRunDialog
 @pytest.fixture
 def runner(subscribe_mock: MagicMock, sendmsg_mock: MagicMock) -> ScriptRunner:
     """Fixture for a ScriptRunner in its initial state."""
-    script = Script(Path(), 1, ({"angle": 0.0, "measurements": 3},))
+    script = Script(Path(), 1, 1, ({"angle": 0.0, "measurements": 3},))
     runner = ScriptRunner(script)
     subscribe_mock.reset_mock()
     sendmsg_mock.reset_mock()

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -43,6 +43,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
             {"angle": 4.0, "measurements": 1},
         ]
     data = {
+        "version": 1,
         "repeats": repeats,
         "sequence": angles,
         "extra_attribute": "hello",
@@ -57,7 +58,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
         (
             get_data(repeats, angle, num_attributes),
             does_not_raise()
-            if repeats > 0 and is_valid_angle(angle) and num_attributes == 2
+            if repeats > 0 and is_valid_angle(angle) and num_attributes == 3
             else pytest.raises(ParseError),
         )
         for repeats in range(-5, 5)
@@ -65,7 +66,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
             (float(i) for i in range(-180, 541, 60)),
             (4, "nadir", "NADIR", "badger", "kevin", "", ()),
         )
-        for num_attributes in range(3)
+        for num_attributes in range(4)
     ],
 )
 def test_parse_script(data: dict[str, Any], raises: Any) -> None:
@@ -125,7 +126,7 @@ _MEASUREMENTS = [Measurement(float(i), i) for i in range(1, 4)]
 )
 def test_script_iterator(num_measurements: int, repeats: int) -> None:
     """Test the ScriptIterator class."""
-    script = Script(Path(), repeats, [])
+    script = Script(Path(), 1, repeats, [])
     script.sequence = _MEASUREMENTS[:num_measurements]
     it = iter(script)
     assert it.current_repeat == 0
@@ -152,7 +153,7 @@ def test_script_run(script_runner_mock: Mock) -> None:
     """Test Script's run() method."""
     mock2 = MagicMock()
     script_runner_mock.return_value = mock2
-    script = Script(Path(), 1, ())
+    script = Script(Path(), 1, 1, ())
     script.run()
     script_runner_mock.assert_called_once()
     mock2.start_moving.assert_called_once()

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -21,7 +21,7 @@ def dlg(qtbot: QtBot):
     yield ScriptEditDialog(parent)
 
 
-_TEST_SCRIPT = Script(Path("/my/path"), 2, ({"angle": "nadir", "measurements": 3},))
+_TEST_SCRIPT = Script(Path("/my/path"), 1, 2, ({"angle": "nadir", "measurements": 3},))
 
 
 @pytest.mark.parametrize(

--- a/tests/gui/measure_script/test_script_run_dialog.py
+++ b/tests/gui/measure_script/test_script_run_dialog.py
@@ -18,7 +18,7 @@ from finesse.gui.measure_script.script_run_dialog import (
 @pytest.mark.parametrize("repeats", range(1, 4))
 def test_get_total_steps_single(repeats: int) -> None:
     """Test the get_total_steps() function for a single measurement."""
-    script = Script(Path(), 1, ({"angle": 90, "measurements": repeats},))
+    script = Script(Path(), 1, 1, ({"angle": 90, "measurements": repeats},))
     assert get_total_steps(script) == 1 + repeats
 
 
@@ -31,7 +31,7 @@ def test_get_total_steps_multi(measurements_count: int) -> None:
     measurements = [
         {"angle": 90, "measurements": m} for m in _MEASUREMENTS[:measurements_count]
     ]
-    script = Script(Path(), 1, measurements)
+    script = Script(Path(), 1, 1, measurements)
     assert get_total_steps(script) == measurements_count + sum(
         _MEASUREMENTS[:measurements_count]
     )
@@ -41,7 +41,7 @@ def test_get_total_steps_multi(measurements_count: int) -> None:
 def test_get_total_steps_with_repeats(repeats: int) -> None:
     """Test the get_total_steps() function works with multiple repeats."""
     measurements = [{"angle": 90, "measurements": m} for m in _MEASUREMENTS]
-    script = Script(Path(), repeats, measurements)
+    script = Script(Path(), 1, repeats, measurements)
     assert get_total_steps(script) == repeats * (
         len(_MEASUREMENTS) + sum(_MEASUREMENTS)
     )

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -15,7 +15,7 @@ from finesse.spectrometer_status import SpectrometerStatus
 
 def test_init(subscribe_mock: MagicMock, sendmsg_mock: MagicMock) -> None:
     """Test ScriptRunner's constructor."""
-    script = Script(Path(), 1, ())
+    script = Script(Path(), 1, 1, ())
     runner = ScriptRunner(script)
 
     # Check we're stopping the motor
@@ -82,7 +82,7 @@ def test_finish_moving(
     sendmsg_mock: MagicMock,
 ):
     """Test that the ScriptRunner terminates after n repeats."""
-    script = Script(Path(), repeats, ({"angle": 0.0, "measurements": 1},))
+    script = Script(Path(), 1, repeats, ({"angle": 0.0, "measurements": 1},))
     script_runner = ScriptRunner(script)
     assert script_runner.current_state == ScriptRunner.not_running
 


### PR DESCRIPTION
# Description

Adds a version number to the hardware sets and the measure scripts. For now, this is not really used for anything, but set the basis in case we need to make backwards incompatible changes.

As the version field is mandatory, existing scripts and hardware sets will fail to work. If this is not the desired behaviour, we can easily make the field optional and give it a default value of 1. 

Fixes #443 
Fixes #444

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [x] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
