### PR TITLE
Add functional test that all hardware set files are valid

### DIFF
--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -519,6 +519,11 @@ def test_load_builtin_hardware_sets(load_mock: Mock) -> None:
     load_mock.assert_has_calls([call(file, built_in=True) for file in yaml_files])
 
 
+def test_builtin_hardware_sets_valid() -> None:
+    """Test that the built-in hardware set YAML files are all valid."""
+    list(_load_builtin_hardware_sets())
+
+
 @patch("finesse.gui.hardware_set.hardware_set._load_hardware_sets")
 def test_load_all_hardware_sets(load_mock: Mock) -> None:
     """Test _load_all_hardware_sets()."""


### PR DESCRIPTION
While we test the `_load_builtin_hardware_sets()` does what it's supposed to by using mocking, we don't test that the actual YAML files bundled with FINESSE are valid, which is a potential error source (e.g. if a device class name changes and a config file isn't updated, then we won't notice until a user tries to actually use the file).

Let's just ensure that all the built-in hardware set config files load properly.

I'm not sure why we don't do this already tbh.

@dalonsoa I thought this might be useful for your PR #669.