### PR TITLE
Add version to hw sets and script files

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,4 @@
 MD013: false
 MD041: false
+MD001:
+  "line_length": 88

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -3,8 +3,5 @@
         {
             "pattern": "^\\.\\./reference/"
         }
-    ],
-    "MD001": {
-        "line_length": 88
-    }
+    ]
 }

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -3,5 +3,8 @@
         {
             "pattern": "^\\.\\./reference/"
         }
-    ]
+    ],
+    "MD001": {
+        "line_length": 88
+    }
 }

--- a/docs/hardware_sets.md
+++ b/docs/hardware_sets.md
@@ -10,6 +10,7 @@ Hardware sets are represented in a [YAML](https://yaml.org) format. Custom hardw
 can be created and imported into FINESSE. Here is an example:
 
 ```yaml
+version: 1
 name: My hardware set
 devices:
   stepper_motor:
@@ -41,6 +42,7 @@ devices:
       port: 80
 ```
 
+The `version` indicates the version number of the hardware set definition, currently 1.
 The `name` property defines a human-readable name for the hardware set, to be displayed
 in the GUI and the `devices` property contains information about the devices in this
 hardware set. The `devices` array consists of key-value pairs, with the keys

--- a/finesse/gui/hardware_set/dummy.yaml
+++ b/finesse/gui/hardware_set/dummy.yaml
@@ -1,3 +1,4 @@
+version: 1
 name: "Dummy devices"
 devices:
   stepper_motor:

--- a/finesse/gui/hardware_set/dummy_ftsw500.yaml
+++ b/finesse/gui/hardware_set/dummy_ftsw500.yaml
@@ -1,3 +1,4 @@
+version: 1
 name: "Dummy devices + FTSW500 spectrometer"
 devices:
   stepper_motor:

--- a/finesse/gui/hardware_set/finesse.yaml
+++ b/finesse/gui/hardware_set/finesse.yaml
@@ -1,3 +1,4 @@
+version: 1
 name: FINESSE
 devices:
   stepper_motor:

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -15,12 +15,15 @@ from frozendict import frozendict
 from pubsub import pub
 from PySide6.QtCore import QFile
 from PySide6.QtWidgets import QMessageBox
-from schema import And, Optional, Schema
+from schema import And, Const, Optional, Schema
 
 from finesse.config import HARDWARE_SET_USER_PATH
 from finesse.device_info import DeviceInstanceRef
 from finesse.gui.error_message import show_error_message
 from finesse.gui.hardware_set.device_connection import close_device, open_device
+
+CURRENT_HW_SET_VERSION = 1
+"""The current version of the hardware set schema."""
 
 
 @dataclass(frozen=True)
@@ -82,6 +85,7 @@ def _non_empty(x: Any) -> bool:
 
 _hw_set_schema = Schema(
     {
+        "version": Const(1, "Version number must be 1"),
         "name": str,
         "devices": And(
             _non_empty,
@@ -128,7 +132,7 @@ class HardwareSet:
         """Save this hardware set as a YAML file."""
         with file_path.open("w") as file:
             devices = dict(map(_device_to_plain_data, self.devices))
-            data = dict(name=self.name, devices=devices)
+            data = dict(version=CURRENT_HW_SET_VERSION, name=self.name, devices=devices)
             yaml.dump(data, file, sort_keys=False)
 
     @classmethod

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -85,7 +85,7 @@ def _non_empty(x: Any) -> bool:
 
 _hw_set_schema = Schema(
     {
-        "version": Const(1, "Version number must be 1"),
+        "version": Const(CURRENT_HW_SET_VERSION, "Version number must be 1"),
         "name": str,
         "devices": And(
             _non_empty,

--- a/finesse/gui/hardware_set/hardware_set.py
+++ b/finesse/gui/hardware_set/hardware_set.py
@@ -85,7 +85,9 @@ def _non_empty(x: Any) -> bool:
 
 _hw_set_schema = Schema(
     {
-        "version": Const(CURRENT_HW_SET_VERSION, "Version number must be 1"),
+        "version": Const(
+            CURRENT_HW_SET_VERSION, f"Version number must be {CURRENT_HW_SET_VERSION}"
+        ),
         "name": str,
         "devices": And(
             _non_empty,

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -15,7 +15,7 @@ from typing import Any
 import yaml
 from pubsub import pub
 from PySide6.QtWidgets import QWidget
-from schema import And, Or, Schema, SchemaError
+from schema import And, Const, Or, Schema, SchemaError
 from statemachine import State, StateMachine
 
 from finesse.config import ANGLE_PRESETS, SPECTROMETER_TOPIC, STEPPER_MOTOR_TOPIC
@@ -109,7 +109,10 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
 
     schema = Schema(
         {
-            "version": CURRENT_SCRIPT_VERSION,
+            "version": Const(
+                CURRENT_SCRIPT_VERSION,
+                f"Current script version number must be {CURRENT_SCRIPT_VERSION}",
+            ),
             "repeats": measurements_type,
             "sequence": And(
                 nonempty_list,

--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -23,6 +23,9 @@ from finesse.device_info import DeviceInstanceRef
 from finesse.gui.error_message import show_error_message
 from finesse.spectrometer_status import SpectrometerStatus
 
+CURRENT_SCRIPT_VERSION = 1
+"""The current version of the measure script format."""
+
 
 @dataclass(frozen=True)
 class Measurement:
@@ -106,6 +109,7 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
 
     schema = Schema(
         {
+            "version": CURRENT_SCRIPT_VERSION,
             "repeats": measurements_type,
             "sequence": And(
                 nonempty_list,
@@ -120,7 +124,9 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
     )
 
     try:
-        return schema.validate(yaml.safe_load(script))
+        output = schema.validate(yaml.safe_load(script))
+        output.pop("version")
+        return output
     except (yaml.YAMLError, SchemaError) as e:
         raise ParseError() from e
 

--- a/tests/gui/hardware_set/test_hardware_set.py
+++ b/tests/gui/hardware_set/test_hardware_set.py
@@ -18,6 +18,7 @@ from finesse.config import HARDWARE_SET_USER_PATH
 from finesse.device_info import DeviceInstanceRef
 from finesse.gui.hardware_set import hardware_set
 from finesse.gui.hardware_set.hardware_set import (
+    CURRENT_HW_SET_VERSION,
     HardwareSet,
     HardwareSetLoadError,
     OpenDeviceArgs,
@@ -75,7 +76,11 @@ def test_hardware_set_save(dump_mock: Mock, to_plain_mock: Mock) -> None:
     to_plain_mock.side_effect = ((f"key{i}", i) for i in range(2))
     hw_set = HardwareSet(NAME, frozenset(devices), FILE_PATH, False)
     hw_set.save(file_path)
-    expected = {"name": NAME, "devices": {"key0": 0, "key1": 1}}
+    expected = {
+        "version": CURRENT_HW_SET_VERSION,
+        "name": NAME,
+        "devices": {"key0": 0, "key1": 1},
+    }
     assert dump_mock.call_count == 1
     assert dump_mock.mock_calls[0].args[0] == expected
 
@@ -202,6 +207,7 @@ def test_load_validates_data(validate_mock: Mock) -> None:
         # Valid, no params
         (
             {
+                "version": CURRENT_HW_SET_VERSION,
                 "name": NAME,
                 "devices": {"stepper_motor": {"class_name": "MyStepperMotor"}},
             },
@@ -210,6 +216,7 @@ def test_load_validates_data(validate_mock: Mock) -> None:
         # Valid, with params
         (
             {
+                "version": CURRENT_HW_SET_VERSION,
                 "name": NAME,
                 "devices": {
                     "stepper_motor": {

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import QWidget
 
 from finesse.config import ANGLE_PRESETS
 from finesse.gui.measure_script.script import (
+    CURRENT_SCRIPT_VERSION,
     Measurement,
     ParseError,
     Script,
@@ -43,6 +44,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
             {"angle": 4.0, "measurements": 1},
         ]
     data = {
+        "version": CURRENT_SCRIPT_VERSION,
         "repeats": repeats,
         "sequence": angles,
         "extra_attribute": "hello",
@@ -57,7 +59,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
         (
             get_data(repeats, angle, num_attributes),
             does_not_raise()
-            if repeats > 0 and is_valid_angle(angle) and num_attributes == 2
+            if repeats > 0 and is_valid_angle(angle) and num_attributes == 3
             else pytest.raises(ParseError),
         )
         for repeats in range(-5, 5)
@@ -65,7 +67,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
             (float(i) for i in range(-180, 541, 60)),
             (4, "nadir", "NADIR", "badger", "kevin", "", ()),
         )
-        for num_attributes in range(3)
+        for num_attributes in range(4)
     ],
 )
 def test_parse_script(data: dict[str, Any], raises: Any) -> None:

--- a/tests/gui/measure_script/test_script.yaml
+++ b/tests/gui/measure_script/test_script.yaml
@@ -1,3 +1,4 @@
+version: 1
 repeats: 1
 sequence:
   - angle: zenith


### PR DESCRIPTION
# Description

Second take at this issue, leaving the version number just for the schema wihout actually saving it in any object. 

Fixes #443 
Fixes #444

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [x] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
