### PR TITLE
:memo: Add user guide file to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ plugins:
 
 nav:
   - FINESSE documentation: index.md
+  - User guide: user_guide.md
   - Hardware: hardware.md
   - Hardware sets: hardware_sets.md
   - Measure scripts: measure_scripts.md


### PR DESCRIPTION
# Description

Adds the existing `user_guide.md` file to the MkDocs documentation, so it is rendered alongside everything else. This file is just a placeholder. Populating the guide will be done in #350 .

Fixes #346 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
