### PR TITLE
Display mirror angle

### DIFF
--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -40,7 +40,7 @@ class StepperMotorControl(DevicePanel):
 
         # Create widgets to show the current mirror position
         layout.addWidget(QLabel("Current position"), 0, 4)
-        self.mirror_position_display = QLabel("")
+        self.mirror_position_display = QLabel()
         self.mirror_position_display.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.mirror_position_display, 1, 4)
 

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -1,7 +1,8 @@
 """Code for controlling the stepper motor which moves the mirror."""
 
 from pubsub import pub
-from PySide6.QtWidgets import QButtonGroup, QGridLayout, QPushButton, QSpinBox
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QButtonGroup, QGridLayout, QLabel, QPushButton, QSpinBox
 
 from finesse.config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
 from finesse.gui.device_panel import DevicePanel
@@ -36,6 +37,12 @@ class StepperMotorControl(DevicePanel):
 
         layout.addWidget(self.angle, 1, 2)
         layout.addWidget(self.goto, 1, 3)
+
+        # Create widgets to show the current mirror position
+        layout.addWidget(QLabel("Current position"), 0, 4)
+        self.mirror_position_display = QLabel("")
+        self.mirror_position_display.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.mirror_position_display, 1, 4)
 
         self.setLayout(layout)
 

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -78,10 +78,8 @@ class StepperMotorControl(DevicePanel):
         if moved_to is None:
             self.mirror_position_display.setText("Moving...")
         else:
-            if moved_to in ANGLE_PRESETS.values():
-                preset = list(ANGLE_PRESETS.keys())[
-                    list(ANGLE_PRESETS.values()).index(moved_to)
-                ]
+            preset = next((k for k, v in ANGLE_PRESETS.items() if v == moved_to), None)
+            if preset:
                 self.mirror_position_display.setText(preset.upper())
             else:
                 self.mirror_position_display.setText(f"{moved_to}°")

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -80,11 +80,9 @@ class StepperMotorControl(DevicePanel):
     def _update_mirror_position_display(self, moved_to: float) -> None:
         """Display the angle the mirror has moved to.
 
-        If angle corresponds to a preset, show the associated name, otherwise just show
-        the value.
+        If angle corresponds to a preset, show the associated name as well as the value.
         """
-        preset = next((k for k, v in ANGLE_PRESETS.items() if v == moved_to), None)
-        if preset:
-            self.mirror_position_display.setText(preset.upper())
-        else:
-            self.mirror_position_display.setText(f"{moved_to}°")
+        text = f"{moved_to}°"
+        if preset := next((k for k, v in ANGLE_PRESETS.items() if v == moved_to), None):
+            text += f" ({preset})"
+        self.mirror_position_display.setText(text)

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -63,9 +63,9 @@ class StepperMotorControl(DevicePanel):
     def _preset_clicked(self, btn: QPushButton) -> None:
         """Move the stepper motor to preset position."""
         # If the motor is already moving, stop it now
-        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.notify_on_stopped")
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.stop")
 
+        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.notify_on_stopped")
         target = float(self.angle.value()) if btn is self.goto else btn.text().lower()
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target=target)
 

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -98,4 +98,4 @@ class DummyStepperMotor(
         logging.info("Move finished")
         if self._notify_requested:
             self._notify_requested = False
-            self.send_message("move.end", moved_to=self.angle)
+            self.send_move_end_message()

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -98,4 +98,4 @@ class DummyStepperMotor(
         logging.info("Move finished")
         if self._notify_requested:
             self._notify_requested = False
-            self.send_message("move.end")
+            self.send_message("move.end", moved_to=self.angle)

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -232,7 +232,7 @@ class ST10Controller(
 
     @Slot()
     def _send_move_end_message(self) -> None:
-        self.send_message("move.end")
+        self.send_message("move.end", moved_to=self.angle)
 
     def _check_device_id(self) -> None:
         """Check that the ID is the correct one for an ST10.

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -10,7 +10,7 @@ The specification is available online:
 import logging
 from queue import Queue
 
-from PySide6.QtCore import QThread, QTimer, Signal, Slot
+from PySide6.QtCore import QThread, QTimer, Signal
 from serial import Serial, SerialException, SerialTimeoutException
 
 from finesse.config import STEPPER_MOTOR_HOMING_TIMEOUT
@@ -225,14 +225,10 @@ class ST10Controller(
 
         # For future move end messages, use a different handler
         self._reader.async_read_completed.disconnect(self._on_initial_move_end)
-        self._reader.async_read_completed.connect(self._send_move_end_message)
+        self._reader.async_read_completed.connect(self.send_move_end_message)
 
         # Signal that this device is ready to be used
         self.signal_is_opened()
-
-    @Slot()
-    def _send_move_end_message(self) -> None:
-        self.send_message("move.end", moved_to=self.angle)
 
     def _check_device_id(self) -> None:
         """Check that the ID is the correct one for an ST10.

--- a/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -103,3 +103,7 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
             raise ValueError("Angle must be between 0° and 270°")
 
         self.step = round(self.steps_per_rotation * target / 360.0)
+
+    def send_move_end_message(self) -> None:
+        """Send a message containing the angle moved to, once move ends."""
+        self.send_message("move.end", moved_to=self.angle)

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -70,12 +70,17 @@ def test_goto_clicked(sendmsg_mock: MagicMock, qtbot: QtBot) -> None:
         )
 
 
-def test_update_mirror_position_display(qtbot: QtBot) -> None:
+def test_indicate_moving(qtbot: QtBot) -> None:
     """Test the mirror position display updates correctly."""
     control = StepperMotorControl()
 
-    control._update_mirror_position_display(moved_to=None)
+    control._indicate_moving(target="target")
     assert control.mirror_position_display.text() == "Moving..."
+
+
+def test_update_mirror_position_display(qtbot: QtBot) -> None:
+    """Test the mirror position display updates correctly."""
+    control = StepperMotorControl()
 
     control._update_mirror_position_display(moved_to=ANGLE_PRESETS["zenith"])
     assert control.mirror_position_display.text() == "ZENITH"

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -66,3 +66,17 @@ def test_goto_clicked(sendmsg_mock: MagicMock, qtbot: QtBot) -> None:
         sendmsg_mock.assert_any_call(
             f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target=123.0
         )
+
+
+def test_update_mirror_position_display(qtbot: QtBot) -> None:
+    """Test the mirror position display updates correctly."""
+    control = StepperMotorControl()
+
+    control._update_mirror_position_display(moved_to=None)
+    assert control.mirror_position_display.text() == "Moving..."
+
+    control._update_mirror_position_display(moved_to=ANGLE_PRESETS["zenith"])
+    assert control.mirror_position_display.text() == "ZENITH"
+
+    control._update_mirror_position_display(moved_to=12.34)
+    assert control.mirror_position_display.text() == "12.34" + "\u00b0"

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -4,7 +4,7 @@ from typing import cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from PySide6.QtWidgets import QButtonGroup, QPushButton
+from PySide6.QtWidgets import QButtonGroup, QLabel, QPushButton
 from pytestqt.qtbot import QtBot
 
 from finesse.config import ANGLE_PRESETS, STEPPER_MOTOR_TOPIC
@@ -30,7 +30,9 @@ def test_init(button_group_mock: Mock, qtbot: QtBot) -> None:
         assert "goto" in btn_labels
 
     # Check that mirror position widgets have been created
-    assert control.layout().itemAt(8).widget().text() == "Current position"
+    current_position_label = control.layout().itemAt(8).widget()
+    assert isinstance(current_position_label, QLabel)
+    assert current_position_label.text() == "Current position"
     assert control.mirror_position_display.text() == ""
 
 

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -83,7 +83,7 @@ def test_update_mirror_position_display(qtbot: QtBot) -> None:
     control = StepperMotorControl()
 
     control._update_mirror_position_display(moved_to=ANGLE_PRESETS["zenith"])
-    assert control.mirror_position_display.text() == "ZENITH"
+    assert control.mirror_position_display.text() == "180.0\u00b0 (zenith)"
 
     control._update_mirror_position_display(moved_to=12.34)
     assert control.mirror_position_display.text() == "12.34" + "\u00b0"

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -86,4 +86,4 @@ def test_update_mirror_position_display(qtbot: QtBot) -> None:
     assert control.mirror_position_display.text() == "180.0\u00b0 (zenith)"
 
     control._update_mirror_position_display(moved_to=12.34)
-    assert control.mirror_position_display.text() == "12.34" + "\u00b0"
+    assert control.mirror_position_display.text() == "12.34\u00b0"

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -29,6 +29,10 @@ def test_init(button_group_mock: Mock, qtbot: QtBot) -> None:
         # Check that there's also a goto button
         assert "goto" in btn_labels
 
+    # Check that mirror position widgets have been created
+    assert control.layout().itemAt(8).widget().text() == "Current position"
+    assert control.mirror_position_display.text() == ""
+
 
 @pytest.mark.parametrize("preset", ANGLE_PRESETS.keys())
 def test_preset_clicked(preset: str, sendmsg_mock: MagicMock, qtbot: QtBot) -> None:

--- a/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
+++ b/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
@@ -133,7 +133,9 @@ def test_on_move_end_notify(
     stepper._move_end_timer.timeout.emit()
 
     assert not stepper._notify_requested
-    sendmsg_mock.assert_called_once_with(f"device.{STEPPER_MOTOR_TOPIC}.move.end")
+    sendmsg_mock.assert_called_once_with(
+        f"device.{STEPPER_MOTOR_TOPIC}.move.end", moved_to=stepper.angle
+    )
 
 
 def test_on_move_end_no_notify(

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -137,10 +137,19 @@ def test_on_initial_move_end(dev: ST10Controller) -> None:
                 signal_mock.assert_called_once_with()
 
 
-def test_send_move_end_message(sendmsg_mock: MagicMock, dev: ST10Controller) -> None:
+@patch(
+    "finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller.angle",
+    new_callable=PropertyMock,
+)
+def test_send_move_end_message(
+    angle_mock: PropertyMock, sendmsg_mock: MagicMock, dev: ST10Controller
+) -> None:
     """Test the _send_move_end_message() method."""
+    angle_mock.return_value = 12.34
     dev._send_move_end_message()
-    sendmsg_mock.assert_called_once_with(f"device.{STEPPER_MOTOR_TOPIC}.move.end")
+    sendmsg_mock.assert_called_once_with(
+        f"device.{STEPPER_MOTOR_TOPIC}.move.end", moved_to=12.34
+    )
 
 
 def read_mock(dev: ST10Controller, return_value: str):

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -130,7 +130,7 @@ def test_on_initial_move_end(dev: ST10Controller) -> None:
                     dev._on_initial_move_end
                 )
                 reader_mock.async_read_completed.connect.assert_called_once_with(
-                    dev._send_move_end_message
+                    dev.send_move_end_message
                 )
                 timer_mock.stop.assert_called_once_with()
                 signal_mock.assert_called_once_with()
@@ -143,7 +143,7 @@ def test_on_initial_move_end(dev: ST10Controller) -> None:
 def test_send_move_end_message(
     angle_mock: PropertyMock, sendmsg_mock: MagicMock, dev: ST10Controller
 ) -> None:
-    """Test the _send_move_end_message() method."""
+    """Test the send_move_end_message() method."""
     angle_mock.return_value = 12.34
     dev.send_move_end_message()
     sendmsg_mock.assert_called_once()

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 import pytest
 from serial import SerialException, SerialTimeoutException
 
-from finesse.config import STEPPER_MOTOR_TOPIC
 from finesse.hardware.plugins.stepper_motor.st10_controller import (
     ST10Controller,
     ST10ControllerError,
@@ -146,10 +145,8 @@ def test_send_move_end_message(
 ) -> None:
     """Test the _send_move_end_message() method."""
     angle_mock.return_value = 12.34
-    dev._send_move_end_message()
-    sendmsg_mock.assert_called_once_with(
-        f"device.{STEPPER_MOTOR_TOPIC}.move.end", moved_to=12.34
-    )
+    dev.send_move_end_message()
+    sendmsg_mock.assert_called_once()
 
 
 def read_mock(dev: ST10Controller, return_value: str):


### PR DESCRIPTION
# Description

This PR adds the ability to display the current mirror angle on the GUI, as determined by the stepper motor controller.

The GUI should display the angle moved to (broadcast by the device once it has finished moving), or the name of the corresponding preset.

We'd like to also have the GUI indicate that the mirror is moving, however I don't think this is possible to test with the dummy device.

Fixes #583 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [X] Pre-commit hooks run successfully (`pre-commit run -a`)
- [X] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [X] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
