### PR TITLE
Add dummy stepper motor delay in default configuration

### DIFF
--- a/finesse/gui/hardware_set/dummy.yaml
+++ b/finesse/gui/hardware_set/dummy.yaml
@@ -3,6 +3,8 @@ name: "Dummy devices"
 devices:
   stepper_motor:
     class_name: stepper_motor.dummy.DummyStepperMotor
+    params:
+      move_duration: 1.5
   temperature_controller.hot_bb:
     class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_controller.cold_bb:

--- a/finesse/gui/hardware_set/dummy_ftsw500.yaml
+++ b/finesse/gui/hardware_set/dummy_ftsw500.yaml
@@ -3,6 +3,8 @@ name: "Dummy devices + FTSW500 spectrometer"
 devices:
   stepper_motor:
     class_name: stepper_motor.dummy.DummyStepperMotor
+    params:
+      move_duration: 1.5
   temperature_controller.hot_bb:
     class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_controller.cold_bb:

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -7,7 +7,14 @@ from PySide6.QtCore import QTimer
 from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 
 
-class DummyStepperMotor(StepperMotorBase, description="Dummy stepper motor"):
+class DummyStepperMotor(
+    StepperMotorBase,
+    description="Dummy stepper motor",
+    parameters={
+        "steps_per_rotation": "Number of steps in a full rotation",
+        "move_duration": "How long each move takes (seconds)",
+    },
+):
     """A fake stepper motor device used for testing the GUI without the hardware.
 
     This class uses a simple timer to notify when the move is complete after a fixed
@@ -26,6 +33,8 @@ class DummyStepperMotor(StepperMotorBase, description="Dummy stepper motor"):
         """
         if steps_per_rotation < 1:
             raise ValueError("steps_per_rotation must be at least one")
+        if move_duration < 0.0:
+            raise ValueError("move_duration cannot be negative")
 
         self._move_end_timer = QTimer()
         self._move_end_timer.setSingleShot(True)


### PR DESCRIPTION
# Description

It turns out that while the `DummyStepperMotor` has the facility to add a delay between starting and stopping a movement, we're not actually using this facility anywhere, for some reason, which is a bit of an oversight. The parameter wasn't changeable via the frontend either. Let's fix this, as it's useful for testing things like @dc2917's work on #680.