### PR TITLE
Updates and fixes for the stepper motor controller

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -73,6 +73,9 @@ DEFAULT_HTTP_TIMEOUT = 10.0
 STEPPER_MOTOR_TOPIC = "stepper_motor"
 """The topic name to use for stepper motor-related messages."""
 
+STEPPER_MOTOR_HOMING_TIMEOUT = 10.0
+"""The number of seconds to wait for the motor to home."""
+
 TEMPERATURE_MONITOR_TOPIC = "temperature_monitor"
 """The topic name to use for temperature monitor-related messages."""
 

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -86,15 +86,6 @@ class DummyStepperMotor(
         self._move_end_timer.stop()
         self._on_move_end()
 
-    def wait_until_stopped(self, timeout: float | None = None) -> None:
-        """Wait until the motor has stopped moving.
-
-        For this dummy class, this is a no-op.
-
-        Args:
-            timeout: Time to wait for motor to finish moving (None == forever)
-        """
-
     def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done.
 

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -133,17 +133,10 @@ class _SerialReader(QThread):
         while self._process_read():
             pass
 
-    def read_sync(self, timeout: float | None = None) -> str:
-        """Read synchronously from the serial device.
-
-        Args:
-            timeout: Amount of time to wait for a response (None==default)
-        """
-        if timeout is None:
-            timeout = self.sync_timeout
-
+    def read_sync(self) -> str:
+        """Read synchronously from the serial device."""
         try:
-            response = self.out_queue.get(timeout=timeout)
+            response = self.out_queue.get(timeout=self.sync_timeout)
         except Exception:
             raise SerialTimeoutException()
 
@@ -390,18 +383,14 @@ class ST10Controller(
         # "Send string"
         self._write_check(f"SS{string}")
 
-    def _read_sync(self, timeout: float | None = None) -> str:
+    def _read_sync(self) -> str:
         """Read the next message from the device synchronously.
-
-        Args:
-            timeout: Amount of time to wait for a response (None==default)
 
         Raises:
             SerialException: Error communicating with device
-            SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
         """
-        return self._reader.read_sync(timeout)
+        return self._reader.read_sync()
 
     def _write(self, message: str) -> None:
         """Send the specified message to the device.

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -37,8 +37,8 @@ class _SerialReader(QThread):
     The one exception is the send string command ("SS"), which, in addition to eliciting
     an immediate ack (or nack) response, also leads to another response being sent when
     the motor has finished moving. Note that while the motor is moving, other commands
-    can be sent and even processed, e.g. you can request the motor's current position
-    while it is moving.
+    can be sent and even processed, e.g. you can request that another move happens after
+    the first is complete.
 
     All of the reading we do from the device goes via this class, as conceivably the
     magic send string response could be sent at any point after the send string command

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -68,11 +68,6 @@ class _SerialReader(QThread):
         self.out_queue: Queue[str | BaseException] = Queue()
         self.stopping = False
 
-    def __del__(self) -> None:
-        """Wait for the thread to stop on exit."""
-        self.quit()
-        self.wait()
-
     def quit(self) -> None:
         """Flag that the thread is stopping so we can ignore exceptions."""
         self.stopping = True

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -292,13 +292,13 @@ class ST10Controller(
         # Tell the controller that this is step 0 ("set variable SP to 0")
         self._write_check("SP0")
 
-        # Receive a notification when motor has finished moving
-        self.notify_on_stopped()
-
         # Use a timer to show an error if the motor doesn't finish moving within the
         # given timeframe. (Note that the move commands are not run synchronously, so
         # this time is the time taken for all of these commands to finish.)
         self._init_error_timer.start()
+
+        # Receive a notification when motor has finished moving
+        self.notify_on_stopped()
 
     def _relative_move(self, steps: int) -> None:
         """Move the stepper motor to the specified relative position.

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -249,15 +249,18 @@ class ST10Controller(
     def _get_input_status(self, index: int) -> bool:
         """Read the status of the device's inputs.
 
-        The inputs to the controller are boolean values represented as a series of zeros
-        (==closed) and ones (==open). They include digital inputs, as well as other
-        properties like alarm status. The exact meaning seems to vary between boards.
+        The inputs to the controller are boolean values, which include digital inputs,
+        as well as other properties like alarm status. For a list of input values, see
+        the manual.
 
         Args:
             index: Which boolean value in the input status array to check
         """
         input_status = self._request_value("IS")
-        return input_status[index] == "1"
+
+        # The inputs are represented as ASCII zeroes and ones. The lowest input's value
+        # is on the right.
+        return input_status[-1 - index] == "1"
 
     @property
     def steps_per_rotation(self) -> int:
@@ -275,10 +278,8 @@ class ST10Controller(
         # In case the motor is still moving, stop it now
         self.stop_moving()
 
-        # If the third (boolean) value of the input status array is set, then move the
-        # motor first. I don't know what the input status actually means, but this is
-        # how it was done in the old program, so I'm copying it here.
-        if self._get_input_status(3):
+        # If the homing switch is already active, move the motor a bit
+        if self._get_input_status(6):
             self._relative_move(-5000)
 
         # Home the motor, leaving mirror facing upwards. The command means "seek home

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -201,9 +201,6 @@ class ST10Controller(
         """
         StepperMotorBase.close(self)
 
-        # Set flag that indicates the thread should quit
-        self._reader.quit()
-
         if not self.serial.is_open:
             return
 
@@ -212,6 +209,9 @@ class ST10Controller(
             self.move_to("nadir")
         except Exception as e:
             logging.error(f"Failed to reset mirror to downward position: {e}")
+
+        # Set flag that indicates the thread should quit
+        self._reader.quit()
 
         # If _reader is blocking on a read (which is likely), we could end up waiting
         # forever, so close the socket so that the read operation will terminate

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -491,24 +491,6 @@ class ST10Controller(
         """Immediately stop moving the motor."""
         self._write_check("ST")
 
-    def wait_until_stopped(self, timeout: float | None = None) -> None:
-        """Wait until the motor has stopped moving.
-
-        Args:
-            timeout: Time to wait for motor to finish moving (None == forever)
-
-        Raises:
-            SerialException: Error communicating with device
-            SerialTimeoutException: Timed out waiting for motor to finish moving
-            ST10ControllerError: Malformed message received from device
-        """
-        # Tell device to send "X" when current operations are complete
-        self._send_string("X")
-
-        # Wait for expected response
-        if self._read_sync(timeout) != "X":
-            raise ST10ControllerError("Invalid response received when waiting for X")
-
     def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done."""
         self._send_string(_SEND_STRING_MAGIC)

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -13,6 +13,7 @@ from queue import Queue
 from PySide6.QtCore import QThread, QTimer, Signal, Slot
 from serial import Serial, SerialException, SerialTimeoutException
 
+from finesse.config import STEPPER_MOTOR_HOMING_TIMEOUT
 from finesse.hardware.plugins.stepper_motor.stepper_motor_base import StepperMotorBase
 from finesse.hardware.serial_device import SerialDevice
 
@@ -178,7 +179,7 @@ class ST10Controller(
 
         self._init_error_timer = QTimer()
         """A timer to raise an error if the motor takes too long to move."""
-        self._init_error_timer.setInterval(10000)  # 10 seconds
+        self._init_error_timer.setInterval(round(STEPPER_MOTOR_HOMING_TIMEOUT * 1000))
         self._init_error_timer.setSingleShot(True)
         self._init_error_timer.timeout.connect(
             lambda: self.send_error_message(

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -260,7 +260,7 @@ class ST10Controller(
 
         # The inputs are represented as ASCII zeroes and ones. The lowest input's value
         # is on the right.
-        return input_status[-1 - index] == "1"
+        return input_status[-index] == "1"
 
     @property
     def steps_per_rotation(self) -> int:

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -246,7 +246,7 @@ class ST10Controller(
         if self._read_sync() != self.ST10_MODEL_ID:
             raise ST10ControllerError("Device ID indicates this is not an ST10")
 
-    def _get_input_status(self, index: int) -> bool:
+    def _get_input_status(self, input: int) -> bool:
         """Read the status of the device's inputs.
 
         The inputs to the controller are boolean values, which include digital inputs,
@@ -254,13 +254,19 @@ class ST10Controller(
         the manual.
 
         Args:
-            index: Which boolean value in the input status array to check
+            input: Which input to retrieve value for
         """
+        if input <= 0:
+            raise ValueError("index must be greater than 0")
+
         input_status = self._request_value("IS")
 
         # The inputs are represented as ASCII zeroes and ones. The lowest input's value
         # is on the right.
-        return input_status[-index] == "1"
+        try:
+            return input_status[-input] == "1"
+        except IndexError:
+            raise ValueError(f"index exceeded number of inputs ({len(input_status)})")
 
     @property
     def steps_per_rotation(self) -> int:

--- a/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -63,14 +63,6 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
         """Immediately stop moving the motor."""
 
     @abstractmethod
-    def wait_until_stopped(self, timeout: float | None = None) -> None:
-        """Wait until the motor has stopped moving.
-
-        Args:
-            timeout: Time to wait for motor to finish moving (None == forever)
-        """
-
-    @abstractmethod
     def notify_on_stopped(self) -> None:
         """Wait until the motor has stopped moving and send a message when done.
 

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -66,7 +66,7 @@ def test_init(subscribe_mock: MagicMock, serial_mock: MagicMock) -> None:
             st10 = ST10Controller(*_SERIAL_ARGS)
             r = cast(MagicMock, st10._reader)
             r.async_read_completed.connect.assert_called_once_with(
-                st10._send_move_end_message
+                st10._on_initial_move_end
             )
             r.read_error.connect.assert_called_once_with(st10.send_error_message)
             check_mock.assert_called_once()

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -267,7 +267,7 @@ _ALL_BITS = 0b101
 
 @pytest.mark.parametrize(
     "all_bits,index,expected",
-    ((_ALL_BITS, i, ((1 << i) & _ALL_BITS != 0)) for i in range(3)),
+    ((_ALL_BITS, i, ((1 << (2 - i)) & _ALL_BITS != 0)) for i in range(3)),
 )
 def test_get_input_status(
     dev: ST10Controller,

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -30,10 +30,10 @@ class MockSerialReader(_SerialReader):
     def run(self) -> None:
         """Override the run method to make the thread do nothing."""
 
-    def read_sync(self, timeout: float | None = None) -> str:
+    def read_sync(self) -> str:
         """Read synchronously (mocked)."""
         self._process_read()
-        return super().read_sync(timeout)
+        return super().read_sync()
 
 
 @pytest.fixture

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -266,20 +266,29 @@ _ALL_BITS = 0b101
 
 
 @pytest.mark.parametrize(
-    "all_bits,index,expected",
+    "all_bits,input,expected",
     ((_ALL_BITS, i, ((1 << (3 - i)) & _ALL_BITS != 0)) for i in range(1, 4)),
 )
 def test_get_input_status(
     dev: ST10Controller,
     all_bits: int,
-    index: int,
+    input: int,
     expected: bool,
 ) -> None:
     """Test the _get_input_status() method."""
     with patch.object(dev, "_request_value") as request_mock:
         request_mock.return_value = f"{all_bits:3b}"
-        assert dev._get_input_status(index) == expected
+        assert dev._get_input_status(input) == expected
         request_mock.assert_called_once_with("IS")
+
+
+@pytest.mark.parametrize("input", (-1, 0, 4, 10))
+def test_get_input_status_bad(dev: ST10Controller, input: int):
+    """Test the _get_input_status() method fails for an out-of-range input."""
+    with patch.object(dev, "_request_value") as request_mock:
+        request_mock.return_value = f"{_ALL_BITS:3b}"
+        with pytest.raises(ValueError):
+            dev._get_input_status(input)
 
 
 def test_steps_per_rotation(dev: ST10Controller) -> None:

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -267,7 +267,7 @@ _ALL_BITS = 0b101
 
 @pytest.mark.parametrize(
     "all_bits,index,expected",
-    ((_ALL_BITS, i, ((1 << (2 - i)) & _ALL_BITS != 0)) for i in range(3)),
+    ((_ALL_BITS, i, ((1 << (3 - i)) & _ALL_BITS != 0)) for i in range(1, 4)),
 )
 def test_get_input_status(
     dev: ST10Controller,

--- a/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
@@ -32,9 +32,6 @@ class _MockStepperMotor(StepperMotorBase, description="Mock stepper motor"):
     def stop_moving(self) -> None:
         pass
 
-    def wait_until_stopped(self, timeout: float | None = None) -> None:
-        pass
-
     def notify_on_stopped(self) -> None:
         pass
 


### PR DESCRIPTION
# Description

The primary motivation for this PR was to add async device opening for the `ST10Controller` device so it doesn't hang the GUI (#668), which has been bothering me for a while. The implementation for this is fairly simple: it's just a case of waiting till the motor has stopped its initial move before invoking `signal_is_opened()`. The only detail is that the motor may become stuck before this happens, so I've added a timer to check that it reaches the home position within 10s. By doing things in this way, it means we can also get rid of some other functionality, which is a bonus.

I also found some other things while in the lab the other day (with @jonemurray's help), which make the homing logic I copied over from the old code make a bit more sense. So I've tweaked some comments and fixed up the `_get_input_status` function. This should help for when we need to rejig the code for the new UNIRAS rig, which will likely be set up differently.

I also discovered the source of some annoying log spam messages (#116) and fixed that. I added tests for all the parts of the `ST10Controller` code which are currently untested.

All in all this was quite satisfying :smile:.

Closes #668. Closes #116.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
