### PR TITLE
Fix: Missing "version" property when writing measure script files

### DIFF
--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from finesse.config import DEFAULT_SCRIPT_PATH
 from finesse.gui.error_message import show_error_message
 from finesse.gui.measure_script.count_widget import CountWidget
-from finesse.gui.measure_script.script import Script
+from finesse.gui.measure_script.script import CURRENT_SCRIPT_VERSION, Script
 from finesse.gui.measure_script.sequence_widget import SequenceWidget
 from finesse.gui.path_widget import SaveFileWidget
 
@@ -97,6 +97,7 @@ class ScriptEditDialog(QDialog):
         logging.info(f"Saving file to {file_path}")
 
         script = {
+            "version": CURRENT_SCRIPT_VERSION,
             "repeats": self.count.value(),
             "sequence": [asdict(seq) for seq in self.sequence_widget.sequence],
         }


### PR DESCRIPTION
As this is a bug, I thought it best to try to merge a fix ASAP so it doesn't get in the way of development.

As @dalonsoa suggested, it would be better if we had a unit test that checks whether the measure script YAML files we're saving are actually valid according to the schema, but I didn't have time to do this properly now, so I've opened an issue: #700.

Fixes #699.