### PR TITLE
Add better project description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ will also help to validate emissivity retrievals from upcoming satellite instrum
 focusing on the far-infrared which will be deployed by ESA ([FORUM]) and NASA
 ([PREFIRE]).
 
-This software is currently being adapted as part of a second project to deploy a
-modified version of the equipment on the UK’s [Facility for Airborne Atmospheric
-Measurements] aircraft.
+This software is currently being adapted as part of a second project &ndash; [UNIRAS]
+&ndash; to deploy a modified version of the equipment on the UK’s [Facility for Airborne
+Atmospheric Measurements] aircraft.
 
 [Space and Atmospheric Physics group]: https://www.imperial.ac.uk/physics/research/communities/space-plasma-climate/
 [PySide6 Qt bindings]: https://pypi.org/project/PySide6/
 [FORUM]: https://www.esa.int/Applications/Observing_the_Earth/FutureEO/FORUM
 [PREFIRE]: https://science.nasa.gov/mission/prefire/
+[UNIRAS]: https://www.imperial.ac.uk/space-and-atmospheric-physics/research/missions-and-projects/atmospheric-missions/uniras/
 [Facility for Airborne Atmospheric Measurements]: https://www.faam.ac.uk/
 
 ## For developers

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Emissivity of the Earth's different surface types helps determine the efficiency
 which the planet radiatively cools to space and is a critical variable in climate
 models. However, to date, most measurements of surface emissivity have been made in the
 mid-infrared. The FINESSE project is novel in employing a ground-based system capable of
-extending these datasets into the Far-infrared. The system is tuned in particular for
+extending these datasets into the far-infrared. The system is tuned in particular for
+
 targeting ice and snow, as the response of the climate to global warming is observed to
 be most rapid in Arctic regions. Far-infrared emissivity data provided by FINESSE will
 inform climate modelling studies seeking to better understand this rapid change. They

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 # FINESSE
 
-FINESSE is open-source graphical software to control a spectrometer system developed at
-Imperial College London's [Space and Atmospheric Physics group].
+FINESSE is software for controlling a spectrometer system developed by Imperial College
+London's [Space and Atmospheric Physics group], written in Python and with a graphical
+interface using the [PySide6 Qt bindings].
 
 Emissivity of the Earth's different surface types helps determine the efficiency with
 which the planet radiatively cools to space and is a critical variable in climate
@@ -23,22 +24,14 @@ will also help to validate emissivity retrievals from upcoming satellite instrum
 focusing on the far-infrared which will be deployed by ESA ([FORUM]) and NASA
 ([PREFIRE]).
 
-The software was developed by Imperial's [RSE team]. It is written in Python and uses
-the [PySide6 Qt bindings] for the GUI components. It provides a convenient interface for
-controlling the various hardware components and viewing data produced, including a
-[Bruker EM27 spectrometer], a stepper motor for controlling the mirror, two temperature
-controllers and a separate temperature monitoring array.
-
 This software is currently being adapted as part of a second project to deploy a
 modified version of the equipment on the UK’s [Facility for Airborne Atmospheric
 Measurements] aircraft.
 
 [Space and Atmospheric Physics group]: https://www.imperial.ac.uk/physics/research/communities/space-plasma-climate/
+[PySide6 Qt bindings]: https://pypi.org/project/PySide6/
 [FORUM]: https://www.esa.int/Applications/Observing_the_Earth/FutureEO/FORUM
 [PREFIRE]: https://science.nasa.gov/mission/prefire/
-[RSE team]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/
-[PySide6 Qt bindings]: https://pypi.org/project/PySide6/
-[Bruker EM27 spectrometer]: https://www.bruker.com/en/products-and-solutions/infrared-and-raman/remote-sensing/em27-open-path-spectrometer.html
 [Facility for Airborne Atmospheric Measurements]: https://www.faam.ac.uk/
 
 ## For developers

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# FINESSE
-
-A graphical user interface for controlling and monitoring an interferometer device.
-
----
-
 ![GitHub tag (with filter)](https://img.shields.io/github/v/tag/ImperialCollegeLondon/FINESSE)
 [![GitHub](https://img.shields.io/github/license/ImperialCollegeLondon/FINESSE)](https://raw.githubusercontent.com/ImperialCollegeLondon/FINESSE/main/LICENCE.txt)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
@@ -11,6 +5,10 @@ A graphical user interface for controlling and monitoring an interferometer devi
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ImperialCollegeLondon/FINESSE/main.svg)](https://results.pre-commit.ci/latest/github/ImperialCollegeLondon/FINESSE/main)
 [![Test and build](https://github.com/ImperialCollegeLondon/FINESSE/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/FINESSE/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ImperialCollegeLondon/FINESSE/graph/badge.svg?token=4UILYHPMJT)](https://codecov.io/gh/ImperialCollegeLondon/FINESSE)
+
+# FINESSE
+
+A graphical user interface for controlling and monitoring an interferometer device.
 
 ## For developers
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,38 @@
 
 # FINESSE
 
-A graphical user interface for controlling and monitoring an interferometer device.
+FINESSE is open-source graphical software to control a spectrometer system developed at
+Imperial College London's [Space and Atmospheric Physics group].
+
+Emissivity of the Earth's different surface types helps determine the efficiency with
+which the planet radiatively cools to space and is a critical variable in climate
+models. However, to date, most measurements of surface emissivity have been made in the
+mid-infrared. The FINESSE project is novel in employing a ground-based system capable of
+extending these datasets into the Far-infrared. The system is tuned in particular for
+targeting ice and snow, as the response of the climate to global warming is observed to
+be most rapid in Arctic regions. Far-infrared emissivity data provided by FINESSE will
+inform climate modelling studies seeking to better understand this rapid change. They
+will also help to validate emissivity retrievals from upcoming satellite instruments
+focusing on the far-infrared which will be deployed by ESA ([FORUM]) and NASA
+([PREFIRE]).
+
+The software was developed by Imperial's [RSE team]. It is written in Python and uses
+the [PySide6 Qt bindings] for the GUI components. It provides a convenient interface for
+controlling the various hardware components and viewing data produced, including a
+[Bruker EM27 spectrometer], a stepper motor for controlling the mirror, two temperature
+controllers and a separate temperature monitoring array.
+
+This software is currently being adapted as part of a second project to deploy a
+modified version of the equipment on the UK’s [Facility for Airborne Atmospheric
+Measurements] aircraft.
+
+[Space and Atmospheric Physics group]: https://www.imperial.ac.uk/physics/research/themes/space-plasma-and-climate/
+[FORUM]: https://www.esa.int/Applications/Observing_the_Earth/FutureEO/FORUM
+[PREFIRE]: https://science.nasa.gov/mission/prefire/
+[RSE team]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/
+[PySide6 Qt bindings]: https://pypi.org/project/PySide6/
+[Bruker EM27 spectrometer]: https://www.bruker.com/en/products-and-solutions/infrared-and-raman/remote-sensing/em27-open-path-spectrometer.html
+[Facility for Airborne Atmospheric Measurements]: https://www.faam.ac.uk/
 
 ## For developers
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This software is currently being adapted as part of a second project to deploy a
 modified version of the equipment on the UK’s [Facility for Airborne Atmospheric
 Measurements] aircraft.
 
-[Space and Atmospheric Physics group]: https://www.imperial.ac.uk/physics/research/themes/space-plasma-and-climate/
+[Space and Atmospheric Physics group]: https://www.imperial.ac.uk/physics/research/communities/space-plasma-climate/
 [FORUM]: https://www.esa.int/Applications/Observing_the_Earth/FutureEO/FORUM
 [PREFIRE]: https://science.nasa.gov/mission/prefire/
 [RSE team]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ which the planet radiatively cools to space and is a critical variable in climat
 models. However, to date, most measurements of surface emissivity have been made in the
 mid-infrared. The FINESSE project is novel in employing a ground-based system capable of
 extending these datasets into the far-infrared. The system is tuned in particular for
-
 targeting ice and snow, as the response of the climate to global warming is observed to
 be most rapid in Arctic regions. Far-infrared emissivity data provided by FINESSE will
 inform climate modelling studies seeking to better understand this rapid change. They


### PR DESCRIPTION
I found this issue in the backlog and figured we should just do it already. I shamelessly plagiarised the description of FINESSE we used for the RS Community newsletter last year. The text obviously focuses on the FINESSE project, but in any case I think it's a useful introduction to what the code is actually for. We can open another issue to add some UNIRAS-specific content further down the line.

Closes #140.