### PR TITLE
Always notify motor move end

### DIFF
--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -317,9 +317,6 @@ class ScriptRunner(StateMachine):
             target=self.current_measurement.angle,
         )
 
-        # Flag that we want a message when the movement has stopped
-        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.notify_on_stopped")
-
     def on_exit_measuring(self) -> None:
         """Unsubscribe from pubsub topics."""
         pub.unsubscribe(

--- a/finesse/gui/stepper_motor_view.py
+++ b/finesse/gui/stepper_motor_view.py
@@ -69,7 +69,6 @@ class StepperMotorControl(DevicePanel):
         # If the motor is already moving, stop it now
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.stop")
 
-        pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.notify_on_stopped")
         target = float(self.angle.value()) if btn is self.goto else btn.text().lower()
         pub.sendMessage(f"device.{STEPPER_MOTOR_TOPIC}.move.begin", target=target)
 

--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -40,7 +40,6 @@ class DummyStepperMotor(
         self._move_end_timer.setSingleShot(True)
         self._move_end_timer.setInterval(round(move_duration * 1000))
         self._move_end_timer.timeout.connect(self._on_move_end)
-        self._notify_requested = False
 
         self._steps_per_rotation = steps_per_rotation
         self._step = 0
@@ -86,16 +85,7 @@ class DummyStepperMotor(
         self._move_end_timer.stop()
         self._on_move_end()
 
-    def notify_on_stopped(self) -> None:
-        """Wait until the motor has stopped moving and send a message when done.
-
-        The message is stepper.move.end.
-        """
-        self._notify_requested = True
-
     def _on_move_end(self) -> None:
         """Run when the timer signals that the move has finished."""
         logging.info("Move finished")
-        if self._notify_requested:
-            self._notify_requested = False
-            self.send_move_end_message()
+        self.send_move_end_message()

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -301,7 +301,7 @@ class ST10Controller(
         self._init_error_timer.start()
 
         # Receive a notification when motor has finished moving
-        self.notify_on_stopped()
+        self._send_string(_SEND_STRING_MAGIC)
 
     def _relative_move(self, steps: int) -> None:
         """Move the stepper motor to the specified relative position.
@@ -478,7 +478,3 @@ class ST10Controller(
     def stop_moving(self) -> None:
         """Immediately stop moving the motor."""
         self._write_check("ST")
-
-    def notify_on_stopped(self) -> None:
-        """Wait until the motor has stopped moving and send a message when done."""
-        self._send_string(_SEND_STRING_MAGIC)

--- a/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -18,7 +18,6 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
 
         self.subscribe(self.move_to, "move.begin")
         self.subscribe(self.stop_moving, "stop")
-        self.subscribe(self.notify_on_stopped, "notify_on_stopped")
 
     @staticmethod
     def preset_angle(name: str) -> float:
@@ -61,13 +60,6 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
     @abstractmethod
     def stop_moving(self) -> None:
         """Immediately stop moving the motor."""
-
-    @abstractmethod
-    def notify_on_stopped(self) -> None:
-        """Wait until the motor has stopped moving and send a message when done.
-
-        The message is stepper.move.end.
-        """
 
     @property
     @abstractmethod

--- a/tests/gui/measure_script/test_script_runner.py
+++ b/tests/gui/measure_script/test_script_runner.py
@@ -59,7 +59,6 @@ def test_start_moving(
                 f"device.{STEPPER_MOTOR_TOPIC}.move.begin",
                 target=runner.script.sequence[0].angle,
             ),
-            call(f"device.{STEPPER_MOTOR_TOPIC}.notify_on_stopped"),
         )
     )
 

--- a/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
+++ b/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
@@ -22,7 +22,6 @@ def test_init(qtbot) -> None:
     stepper = DummyStepperMotor(360, 1.0)
     assert stepper._move_end_timer.interval() == 1000
     assert stepper._move_end_timer.isSingleShot()
-    assert not stepper._notify_requested
     assert stepper._step == 0
 
 
@@ -115,37 +114,14 @@ def test_stop_moving(stepper: DummyStepperMotor, qtbot) -> None:
             move_end_mock.assert_called_once()
 
 
-def test_notify_on_stopped(stepper: DummyStepperMotor, qtbot) -> None:
-    """Test the notify_on_stopped() method."""
-    assert not stepper._notify_requested
-    stepper.notify_on_stopped()
-    assert stepper._notify_requested
-
-
-def test_on_move_end_notify(
+def test_on_move_end(
     stepper: DummyStepperMotor, sendmsg_mock: MagicMock, qtbot
 ) -> None:
     """Test the _on_move_end() method when notification is requested."""
-    stepper.notify_on_stopped()
-    assert stepper._notify_requested
-
     # Trigger move end timer
     stepper._move_end_timer.timeout.emit()
 
-    assert not stepper._notify_requested
+    # Check message is sent with final angle moved to
     sendmsg_mock.assert_called_once_with(
         f"device.{STEPPER_MOTOR_TOPIC}.move.end", moved_to=stepper.angle
     )
-
-
-def test_on_move_end_no_notify(
-    stepper: DummyStepperMotor, sendmsg_mock: MagicMock, qtbot
-) -> None:
-    """Test the _on_move_end() method when notification is not requested."""
-    assert not stepper._notify_requested
-
-    # Trigger move end timer
-    stepper._move_end_timer.timeout.emit()
-
-    assert not stepper._notify_requested
-    sendmsg_mock.assert_not_called()

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -305,17 +305,19 @@ def test_steps_per_rotation(dev: ST10Controller) -> None:
 @pytest.mark.parametrize("in_position", (True, False))
 def test_home_and_reset(dev: ST10Controller, in_position: bool) -> None:
     """Test the _home_and_reset() method."""
-    with patch.object(dev, "stop_moving") as stop_mock:
-        with patch.object(dev, "_relative_move"):
-            with patch.object(dev, "_write_check"):
-                with patch.object(dev, "_init_error_timer") as timer_mock:
-                    with patch.object(dev, "_get_input_status") as status_mock:
-                        # Let's not bother checking everything as we can't ensure the
-                        # sequence is correct in any case
-                        status_mock.return_value = in_position
-                        dev._home_and_reset()
-                        stop_mock.assert_called_once_with()
-                        timer_mock.start.assert_called_once_with()
+    with patch.object(dev, "_send_string") as ss_mock:
+        with patch.object(dev, "stop_moving") as stop_mock:
+            with patch.object(dev, "_relative_move"):
+                with patch.object(dev, "_write_check"):
+                    with patch.object(dev, "_init_error_timer") as timer_mock:
+                        with patch.object(dev, "_get_input_status") as status_mock:
+                            # Let's not bother checking everything as we can't ensure
+                            # the sequence is correct in any case
+                            status_mock.return_value = in_position
+                            dev._home_and_reset()
+                            stop_mock.assert_called_once_with()
+                            timer_mock.start.assert_called_once_with()
+                            ss_mock.assert_called_once_with("Z")
 
 
 @pytest.mark.parametrize("steps", range(0, 40, 7))
@@ -415,16 +417,17 @@ def test_stop_moving(dev: ST10Controller) -> None:
 
 def test_notify_on_stopped(dev: ST10Controller) -> None:
     """Test the notify_on_stopped() method."""
-    dev.serial.read_until.return_value = b"Z\r"
+    pass
 
-    with patch.object(dev, "_send_string") as ss_mock:
-        dev.notify_on_stopped()
-        ss_mock.assert_called_once_with("Z")
 
-    # As the _SerialReader is not actually running on a separate thread, we have to
-    # explicitly trigger a read here
-    assert dev._reader._process_read()
+#    dev.serial.read_until.return_value = b"Z\r"
 
-    # Check that the signal was triggered
-    signal = cast(MagicMock, dev._reader.async_read_completed)
-    signal.emit.assert_called_once()
+#        dev.notify_on_stopped()
+
+# As the _SerialReader is not actually running on a separate thread, we have to
+# explicitly trigger a read here
+#    assert dev._reader._process_read()
+
+# Check that the signal was triggered
+#    signal = cast(MagicMock, dev._reader.async_read_completed)
+#    signal.emit.assert_called_once()

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -413,21 +413,3 @@ def test_stop_moving(dev: ST10Controller) -> None:
     with patch.object(dev, "_write_check") as write_mock:
         dev.stop_moving()
         write_mock.assert_called_once_with("ST")
-
-
-def test_notify_on_stopped(dev: ST10Controller) -> None:
-    """Test the notify_on_stopped() method."""
-    pass
-
-
-#    dev.serial.read_until.return_value = b"Z\r"
-
-#        dev.notify_on_stopped()
-
-# As the _SerialReader is not actually running on a separate thread, we have to
-# explicitly trigger a read here
-#    assert dev._reader._process_read()
-
-# Check that the signal was triggered
-#    signal = cast(MagicMock, dev._reader.async_read_completed)
-#    signal.emit.assert_called_once()

--- a/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
@@ -32,9 +32,6 @@ class _MockStepperMotor(StepperMotorBase, description="Mock stepper motor"):
     def stop_moving(self) -> None:
         pass
 
-    def notify_on_stopped(self) -> None:
-        pass
-
 
 @pytest.fixture
 def stepper(subscribe_mock: MagicMock) -> StepperMotorBase:
@@ -46,13 +43,12 @@ def test_init() -> None:
     """Test that StepperMotorBase's constructor subscribes to the right messages."""
     with patch.object(_MockStepperMotor, "subscribe") as subscribe_mock:
         stepper = _MockStepperMotor()
-        assert subscribe_mock.call_count == 3
+        assert subscribe_mock.call_count == 2
         subscribe_mock.assert_any_call(
             stepper.move_to,
             "move.begin",
         )
         subscribe_mock.assert_any_call(stepper.stop_moving, "stop")
-        subscribe_mock.assert_any_call(stepper.notify_on_stopped, "notify_on_stopped")
 
 
 def test_angle(stepper: _MockStepperMotor) -> None:


### PR DESCRIPTION
# Description

This PR removes the `notify_on_stopped` method from `stepper_motor` devices, on the basis that we will *always* send the `"move.end"` message once the mirror has stopped moving.

Fixes #704

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [X] Pre-commit hooks run successfully (`pre-commit run -a`)
- [X] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [X] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [X] Code is commented, particularly in hard-to-understand areas
- [X] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
