### PR TITLE
Add async open support for various network-based devices

### DIFF
--- a/finesse/hardware/plugins/sensors/decades.py
+++ b/finesse/hardware/plugins/sensors/decades.py
@@ -119,13 +119,12 @@ class Decades(
         self._params: list[DecadesParameter]
         """Parameters returned by the server."""
 
+        super().__init__(poll_interval, start_polling=False)
+
         # Obtain full parameter list in order to parse received data
         self.obtain_parameter_list(
             frozenset(params.split(",")) if params else frozenset()
         )
-
-        # We only want to start polling after we have loaded the parameter list
-        super().__init__(poll_interval, start_polling=False)
 
     def obtain_parameter_list(self, params: Set[str]) -> None:
         """Request the parameter list from the DECADES server and wait for response."""

--- a/finesse/hardware/plugins/sensors/decades.py
+++ b/finesse/hardware/plugins/sensors/decades.py
@@ -97,6 +97,7 @@ class Decades(
             "documentation."
         ),
     },
+    async_open=True,
 ):
     """A class for monitoring a DECADES sensor server."""
 
@@ -203,6 +204,9 @@ class Decades(
             ]
         else:
             self._params = list(_get_selected_params(all_params_info, params))
+
+        # Tell the frontend that the device is ready
+        self.signal_is_opened()
 
         # Now we have enough information to start parsing sensor readings
         self.start_polling()

--- a/finesse/hardware/plugins/sensors/decades.py
+++ b/finesse/hardware/plugins/sensors/decades.py
@@ -207,3 +207,4 @@ class Decades(
 
         # Now we have enough information to start parsing sensor readings
         self.start_polling()
+        self.request_readings()

--- a/finesse/hardware/plugins/sensors/decades.py
+++ b/finesse/hardware/plugins/sensors/decades.py
@@ -120,7 +120,7 @@ class Decades(
         self._params: list[DecadesParameter]
         """Parameters returned by the server."""
 
-        super().__init__(poll_interval, start_polling=False)
+        super().__init__(poll_interval)
 
         # Obtain full parameter list in order to parse received data
         self.obtain_parameter_list(

--- a/finesse/hardware/plugins/sensors/em27_sensors.py
+++ b/finesse/hardware/plugins/sensors/em27_sensors.py
@@ -51,7 +51,11 @@ class EM27Error(Exception):
     """Indicates than an error occurred while parsing the webpage."""
 
 
-class EM27SensorsBase(SensorsBase, class_type=DeviceClassType.IGNORE):
+class EM27SensorsBase(
+    SensorsBase,
+    class_type=DeviceClassType.IGNORE,
+    async_open=True,
+):
     """An interface for monitoring EM27 properties."""
 
     def __init__(self, url: str, poll_interval: float = float("nan")) -> None:
@@ -63,8 +67,11 @@ class EM27SensorsBase(SensorsBase, class_type=DeviceClassType.IGNORE):
         """
         self._url: str = url
         self._requester = HTTPRequester()
+        self._connected = False
 
-        super().__init__(poll_interval)
+        super().__init__(poll_interval, start_polling=False)
+
+        self.request_readings()
 
     def request_readings(self) -> None:
         """Request the EM27 property data from the web server.
@@ -89,6 +96,12 @@ class EM27SensorsBase(SensorsBase, class_type=DeviceClassType.IGNORE):
         data: bytes = reply.readAll().data()
         content = data.decode()
         readings = get_em27_sensor_data(content)
+
+        if not self._connected:
+            self._connected = True
+            self.signal_is_opened()
+            self.start_polling()
+
         self.send_readings_message(readings)
 
 

--- a/finesse/hardware/plugins/sensors/em27_sensors.py
+++ b/finesse/hardware/plugins/sensors/em27_sensors.py
@@ -69,7 +69,7 @@ class EM27SensorsBase(
         self._requester = HTTPRequester()
         self._connected = False
 
-        super().__init__(poll_interval, start_polling=False)
+        super().__init__(poll_interval)
 
         self.request_readings()
 

--- a/finesse/hardware/plugins/sensors/sensors_base.py
+++ b/finesse/hardware/plugins/sensors/sensors_base.py
@@ -23,24 +23,18 @@ class SensorsBase(
     calling send_readings_message() with new sensor values (at some point).
     """
 
-    def __init__(
-        self, poll_interval: float = float("nan"), start_polling: bool = True
-    ) -> None:
+    def __init__(self, poll_interval: float = float("nan")) -> None:
         """Create a new SensorsBase.
 
         Args:
             poll_interval: How often to poll the sensor device (seconds). If set to nan,
                            the device will only be polled once on device open
-            start_polling: Whether to start polling the device immediately
         """
         super().__init__()
 
         self._poll_timer = QTimer()
         self._poll_timer.timeout.connect(self.request_readings)
         self._poll_interval = poll_interval
-
-        if start_polling:
-            self.start_polling()
 
     def start_polling(self) -> None:
         """Begin polling the device."""

--- a/finesse/hardware/plugins/sensors/sensors_base.py
+++ b/finesse/hardware/plugins/sensors/sensors_base.py
@@ -47,11 +47,6 @@ class SensorsBase(
         if not isnan(self._poll_interval):
             self._poll_timer.start(int(self._poll_interval * 1000))
 
-        # Poll device once on open.
-        # TODO: Run this synchronously so we can check that things work before the
-        # device.opened message is sent
-        self.request_readings()
-
     @abstractmethod
     def request_readings(self) -> None:
         """Request new sensor readings from the device."""

--- a/finesse/hardware/plugins/spectrometer/opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface.py
@@ -96,7 +96,7 @@ class OPUSInterface(
         self._url = f"http://{host}:{port}/opusrs"
         """URL to make requests."""
 
-        self._status = SpectrometerStatus.UNDEFINED
+        self._status: SpectrometerStatus | None = None
         """The last known status of the spectrometer."""
         self._status_timer = QTimer()
         self._status_timer.timeout.connect(self._request_status)
@@ -124,7 +124,7 @@ class OPUSInterface(
         # If the status has changed, notify listeners
         if new_status != self._status:
             # On first update, we need to signal that the device is now open
-            if self._status == SpectrometerStatus.UNDEFINED:
+            if self._status is None:
                 self.signal_is_opened()
 
             self._status = new_status

--- a/finesse/hardware/plugins/spectrometer/opus_interface.py
+++ b/finesse/hardware/plugins/spectrometer/opus_interface.py
@@ -71,6 +71,7 @@ class OPUSInterface(
             "This is rate limited to around one request every two seconds by OPUS."
         ),
     },
+    async_open=True,
 ):
     """Interface for communicating with the OPUS program.
 
@@ -122,6 +123,10 @@ class OPUSInterface(
 
         # If the status has changed, notify listeners
         if new_status != self._status:
+            # On first update, we need to signal that the device is now open
+            if self._status == SpectrometerStatus.UNDEFINED:
+                self.signal_is_opened()
+
             self._status = new_status
             self.send_status_message(new_status)
 

--- a/tests/hardware/plugins/sensors/test_sensors_base.py
+++ b/tests/hardware/plugins/sensors/test_sensors_base.py
@@ -16,34 +16,27 @@ def device(timer_mock: Mock) -> SensorsBase:
 
 
 class _MockSensorsDevice(SensorsBase, description="Mock sensors device"):
-    def __init__(self, poll_interval: float = float("nan"), start_polling=True):
+    def __init__(self, poll_interval: float = float("nan")):
         self.request_readings_mock = MagicMock()
-        super().__init__(poll_interval, start_polling)
+        super().__init__(poll_interval)
 
     def request_readings(self) -> None:
         self.request_readings_mock()
 
 
-@pytest.mark.parametrize("start_polling", (False, True))
 @patch("finesse.hardware.plugins.sensors.sensors_base.QTimer")
-def test_init(timer_mock: Mock, start_polling: bool) -> None:
+def test_init(timer_mock: Mock) -> None:
     """Test for the constructor."""
-    with patch.object(_MockSensorsDevice, "start_polling") as start_mock:
-        device = _MockSensorsDevice(1.0, start_polling)
-        assert device._poll_interval == 1.0
-        timer = cast(Mock, device._poll_timer)
-        timer.timeout.connect.assert_called_once_with(device.request_readings)
-
-        if start_polling:
-            start_mock.assert_called_once_with()
-        else:
-            start_mock.assert_not_called()
+    device = _MockSensorsDevice(1.0)
+    assert device._poll_interval == 1.0
+    timer = cast(Mock, device._poll_timer)
+    timer.timeout.connect.assert_called_once_with(device.request_readings)
 
 
 @patch("finesse.hardware.plugins.sensors.sensors_base.QTimer")
 def test_start_polling_oneshot(timer_mock: Mock) -> None:
     """Test the start_polling() method when polling is only done once."""
-    device = _MockSensorsDevice(start_polling=False)
+    device = _MockSensorsDevice()
 
     device.start_polling()
     timer = cast(Mock, device._poll_timer)
@@ -53,7 +46,7 @@ def test_start_polling_oneshot(timer_mock: Mock) -> None:
 @patch("finesse.hardware.plugins.sensors.sensors_base.QTimer")
 def test_start_polling_repeated(timer_mock: Mock) -> None:
     """Test the start_polling() method when polling is only done repeatedly."""
-    device = _MockSensorsDevice(1.0, start_polling=False)
+    device = _MockSensorsDevice(1.0)
 
     device.start_polling()
     timer = cast(Mock, device._poll_timer)

--- a/tests/hardware/plugins/sensors/test_sensors_base.py
+++ b/tests/hardware/plugins/sensors/test_sensors_base.py
@@ -46,7 +46,6 @@ def test_start_polling_oneshot(timer_mock: Mock) -> None:
     device = _MockSensorsDevice(start_polling=False)
 
     device.start_polling()
-    device.request_readings_mock.assert_called_once_with()
     timer = cast(Mock, device._poll_timer)
     timer.start.assert_not_called()
 
@@ -57,7 +56,6 @@ def test_start_polling_repeated(timer_mock: Mock) -> None:
     device = _MockSensorsDevice(1.0, start_polling=False)
 
     device.start_polling()
-    device.request_readings_mock.assert_called_once_with()
     timer = cast(Mock, device._poll_timer)
     timer.start.assert_called_once_with(1000)
 
@@ -68,7 +66,6 @@ def test_init_no_timer(timer_mock: Mock) -> None:
     device = _MockSensorsDevice()
     timer = cast(Mock, device._poll_timer)
     timer.start.assert_not_called()
-    device.request_readings_mock.assert_called_once_with()
 
 
 def test_send_readings_message(device: SensorsBase) -> None:

--- a/tests/hardware/plugins/spectrometer/test_opus_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_opus_interface.py
@@ -36,7 +36,7 @@ def test_init(timer_mock: Mock, subscribe_mock: Mock) -> None:
         assert opus._url == f"http://{DEFAULT_OPUS_HOST}:{DEFAULT_OPUS_PORT}/opusrs"
         status_mock.assert_called_once_with()
 
-        assert opus._status == SpectrometerStatus.UNDEFINED
+        assert opus._status is None
         timer.setSingleShot.assert_called_once_with(True)
         timer.setInterval.assert_called_once_with(1000)
         timer.timeout.connect.assert_called_once_with(opus._request_status)


### PR DESCRIPTION
# Description

This PR changes the various network-based devices to use the `async_open` feature. While I haven't been able to test this on the real hardware, unfortunately, I have checked that HTTP requests are sent after device opening (of course, they time out). I'm pretty confident it will work with the real hardware as the changes are pretty minimal, though you can never be sure. Jon has volunteered to test it while he's away, so I think we should just merge it; if it breaks things we can always revert and we don't want to be hanging around waiting to merge this.

Closes #415. Closes #666. Closes #667.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
