### PR TITLE
:white_check_mark: Add test for roundtrip saving of scripts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock
 import pytest
 from pubsub import pub
 
-from finesse.hardware.serial_device import SerialDevice
-
 
 @pytest.fixture
 def serial_mock(monkeypatch) -> MagicMock:
     """Fixture for Serial's constructor."""
+    from finesse.hardware.serial_device import SerialDevice
+
     mock = MagicMock()
 
     def new_init(self, *args, **kwargs):

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -98,7 +98,7 @@ def test_try_save(
 
 
 def test_save_load_roundtrip(dlg: ScriptEditDialog, tmp_path: Path) -> None:
-    """Test the _try_save() method."""
+    """Test the _try_save() and try_load() methods in tandem."""
     path = tmp_path / "test_script.yaml"
     with patch.object(dlg.script_path, "try_get_path") as path_mock:
         path_mock.return_value = path

--- a/tests/gui/measure_script/test_script_edit_dialog.py
+++ b/tests/gui/measure_script/test_script_edit_dialog.py
@@ -97,6 +97,18 @@ def test_try_save(
                     errmsg_mock.assert_called_once()
 
 
+def test_save_load_roundtrip(dlg: ScriptEditDialog, tmp_path: Path) -> None:
+    """Test the _try_save() method."""
+    path = tmp_path / "test_script.yaml"
+    with patch.object(dlg.script_path, "try_get_path") as path_mock:
+        path_mock.return_value = path
+
+        dlg.sequence_widget.sequence = _MEASUREMENTS
+        assert dlg._try_save()
+
+    Script.try_load(QWidget(), path)
+
+
 @pytest.mark.parametrize("saved", (True, False))
 def test_accept(saved: bool, qtbot: QtBot, dlg: ScriptEditDialog) -> None:
     """Check the Save button."""


### PR DESCRIPTION
# Description

Simply checks that a measure script saved with `dlg._try_save()` can be loaded without errors by `Script.try_load()`. It does not check if the loaded contents are the same, just if the saved script is a valid script to re-load.

NOTE: On MacOS, there's a bunch of errors everywhere saying: `ValueError: Port /dev/cu.BLTH does not end with a number`. Not a big deal because the chances of UNIRAS/FINESSE to be used in MacOS are slim, but just mentioning it as it makes development under MacOS a bit painful as it is unclear whats a genuine error and what is not. 

Fixes #700

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [x] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [x] Check the code works with actual hardware (if relevant)
- [x] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
