### PR TITLE
Fix sorting of port names without terminating numbers

### DIFF
--- a/tests/hardware/test_serial_device.py
+++ b/tests/hardware/test_serial_device.py
@@ -9,7 +9,7 @@ from serial import SerialException
 from finesse.hardware.serial_device import (
     SerialDevice,
     _create_serial,
-    _get_port_number,
+    _get_port_parts,
     _get_usb_serial_ports,
     _port_info_to_str,
 )
@@ -57,23 +57,14 @@ def test_get_usb_serial_ports(
         }
 
 
-@pytest.mark.parametrize(
-    "port,number",
-    (
-        (f"{prefix}{number}", number)
-        for number in (1, 2, 10)
-        for prefix in ("COM", "/dev/ttyUSB")
-    ),
-)
-def test_get_port_number(port: str, number: int) -> None:
-    """Test _get_port_number()."""
-    assert _get_port_number(port) == number
-
-
-def test_get_port_number_bad() -> None:
-    """Test _get_port_number() when a bad value is provided."""
-    with pytest.raises(ValueError):
-        _get_port_number("NO_NUMBER")
+def test_get_port_parts() -> None:
+    """Test _get_port_parts()."""
+    for prefix in ("COM", "/dev/ttyUSB"):
+        assert _get_port_parts(f"{prefix}1") < _get_port_parts(f"{prefix}2")
+        assert _get_port_parts(f"{prefix}1") < _get_port_parts(f"{prefix}10")
+    assert _get_port_parts("A1") < _get_port_parts("B1")
+    assert _get_port_parts("A") < _get_port_parts("A0")
+    assert _get_port_parts("A") < _get_port_parts("B")
 
 
 @pytest.mark.parametrize("refresh", (False, True))


### PR DESCRIPTION
# Description

As reported by @dalonsoa, not all USB device port names end in a number on MacOS, in contrast to Windows and Linux (at least as far as I've seen).

This breaks our current code for sorting the ports, which will throw an error if a port name doesn't end in a number. Fix by making the number optional and also including the rest of the string in the sorting operation.

While we won't actually be deploying on MacOS, the fix is easy and we want to make life easy for developers.

@dalonsoa Would you mind verifying that this fixes things for you? If you're happy with this, feel free to just merge it.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
