### PR TITLE
Reduce precision of temperatures written to CSV file

### DIFF
--- a/finesse/config.py
+++ b/finesse/config.py
@@ -126,6 +126,9 @@ TEMPERATURE_MONITOR_HOT_BB_IDX = 6
 TEMPERATURE_MONITOR_COLD_BB_IDX = 7
 """Position of the cold blackbody on the temperature monitoring device."""
 
+TEMPERATURE_PRECISION = 2
+"""Number of decimal places used when writing temperatures to data files (Kelvin)."""
+
 SENECA_MIN_TEMP = -80
 """The default minimum temperature limit of the Seneca K107 device."""
 

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -175,7 +175,7 @@ class DataFileWriter:
             (
                 time.strftime("%Y%m%d"),
                 time.strftime("%H:%M:%S"),
-                *temperatures,
+                *(round(t, config.TEMPERATURE_PRECISION) for t in temperatures),
                 secs_since_midnight,
                 angle,
                 int(is_moving),


### PR DESCRIPTION
Currently temperatures will be written with the maximum precision possible for the `Decimal` type, which equates to a lot of decimal places. This wasn't such an issue when using the DP9800 as it uses a protocol with plain text numbers to a limited number of decimal places, but now that we are using the Seneca device with a binary encoding this can end up being a lot longer. Let's just cap the precision to 0.01 Kelvin.

This was requested by @jonemurray and given that it is only a small change I thought it would be easier to just do it now.