### PR TITLE
Fix skipped test

### DIFF
--- a/tests/hardware/plugins/spectrometer/test_ftsw500_interface.py
+++ b/tests/hardware/plugins/spectrometer/test_ftsw500_interface.py
@@ -179,7 +179,7 @@ def test_get_status_bad(input: str, ftsw: FTSW500Interface) -> None:
             ftsw._get_status()
 
 
-VALID_STATUSES = map(SpectrometerStatus, range(4))
+VALID_STATUSES = list(map(SpectrometerStatus, range(4)))
 """All possible statuses for the FTSW500."""
 
 


### PR DESCRIPTION
Sorry about making a PR for this silly one-liner, but I wasn't sure where else to put it...

It seems that `test_update_status_not_changed` is never actually run, because it is a parameterised test, taking `VALID_STATUSES` as the arguments. The problem is that `VALID_STATUSES` is an iterator and it is consumed by another test, so no test cases are actually run. Fix this.

Interestingly, `pytest` treats this as being a "skipped" test, which is how I noticed. Not sure if this is a new feature or if it's been treated as skipped for ages and I just hadn't noticed.