### PR TITLE
Allow for reading measure scripts generated with FINESSE v2.0.0

### DIFF
--- a/finesse/gui/measure_script/script.py
+++ b/finesse/gui/measure_script/script.py
@@ -127,7 +127,14 @@ def parse_script(script: str | TextIOBase) -> dict[str, Any]:
     )
 
     try:
-        output = schema.validate(yaml.safe_load(script))
+        output = yaml.safe_load(script)
+
+        # v2.0.0 and older didn't have a version field, but the file formats are
+        # otherwise identical
+        if "version" not in output:
+            output["version"] = 1
+
+        output = schema.validate(output)
         output.pop("version")
         return output
     except (yaml.YAMLError, SchemaError) as e:

--- a/finesse/gui/measure_script/script_edit_dialog.py
+++ b/finesse/gui/measure_script/script_edit_dialog.py
@@ -103,7 +103,7 @@ class ScriptEditDialog(QDialog):
 
         try:
             with open(file_path, "w") as f:
-                yaml.safe_dump(script, f)
+                yaml.safe_dump(script, f, sort_keys=False)
         except Exception as e:
             show_error_message(
                 self, f"Error occurred while saving file {file_path}:\n{e!s}"

--- a/tests/gui/measure_script/test_script.py
+++ b/tests/gui/measure_script/test_script.py
@@ -44,9 +44,9 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
             {"angle": 4.0, "measurements": 1},
         ]
     data = {
-        "version": CURRENT_SCRIPT_VERSION,
         "repeats": repeats,
         "sequence": angles,
+        "version": CURRENT_SCRIPT_VERSION,
         "extra_attribute": "hello",
     }
 
@@ -59,7 +59,7 @@ def get_data(repeats: int, angle: Any, num_attributes: int) -> dict[str, Any]:
         (
             get_data(repeats, angle, num_attributes),
             does_not_raise()
-            if repeats > 0 and is_valid_angle(angle) and num_attributes == 3
+            if repeats > 0 and is_valid_angle(angle) and 2 <= num_attributes <= 3
             else pytest.raises(ParseError),
         )
         for repeats in range(-5, 5)


### PR DESCRIPTION
# Description

I was hoping that by adding a version field to measure scripts and hardware sets for this next release we could ensure that that field is always present, but it seems like Jon has been doing quite a lot of testing with v2.0.0 (quite reasonably!) so he already has some measure scripts that don't have this field. I don't want him to have to put up with error messages when he upgrades, so let's just assume that measure scripts without a version are version 1. At least going forward we will have this field.

(NB: This isn't a problem for hardware sets, because those are currently all bundled with FINESSE, though we will have user-generated ones in future: #393.)

Fixes #741.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
