### PR TITLE
Get mirror immediate position

### DIFF
--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -56,7 +56,6 @@ def _create_writer(path: Path) -> Writer:
             *(f"Temp{i+1}" for i in range(config.NUM_TEMPERATURE_MONITOR_CHANNELS)),
             "TimeAsSeconds",
             "Angle",
-            "IsMoving",
             "TemperatureControllerPower",
         )
     )
@@ -64,28 +63,24 @@ def _create_writer(path: Path) -> Writer:
     return writer
 
 
-def _get_stepper_motor_angle() -> tuple[float, bool]:
+def _get_stepper_motor_angle() -> float:
     """Get the current angle of the stepper motor.
 
-    This function returns a float indicating the angle in degrees and a boolean
-    indicating whether the motor is currently moving. If an error occurs or the motor is
-    moving, the angle returned will be nan.
+    This function returns a float indicating the angle in degrees. If an error occurs,
+    the angle returned will be nan.
     """
     stepper = get_stepper_motor_instance()
 
     # Stepper motor not connected
     if not stepper:
-        return (float("nan"), False)
+        return float("nan")
 
     try:
         angle = stepper.angle
-        if angle is None:
-            return (float("nan"), True)
-        else:
-            return (angle, False)
+        return angle
     except Exception as error:
         stepper.send_error_message(error)
-        return (float("nan"), False)
+        return float("nan")
 
 
 def _get_hot_bb_power() -> float:
@@ -170,7 +165,7 @@ class DataFileWriter:
         midnight = datetime(time.year, time.month, time.day)
         secs_since_midnight = floor((time - midnight).total_seconds())
 
-        angle, is_moving = _get_stepper_motor_angle()
+        angle = _get_stepper_motor_angle()
         self._writer.writerow(
             (
                 time.strftime("%Y%m%d"),
@@ -178,7 +173,6 @@ class DataFileWriter:
                 *(round(t, config.TEMPERATURE_PRECISION) for t in temperatures),
                 secs_since_midnight,
                 angle,
-                int(is_moving),
                 _get_hot_bb_power(),
             )
         )

--- a/finesse/hardware/data_file_writer.py
+++ b/finesse/hardware/data_file_writer.py
@@ -68,8 +68,8 @@ def _get_stepper_motor_angle() -> tuple[float, bool]:
     """Get the current angle of the stepper motor.
 
     This function returns a float indicating the angle in degrees and a boolean
-    indicating whether the motor is currently moving. If an error occurs or the motor is
-    moving, the angle returned will be nan.
+    indicating whether the motor is currently moving. If an error occurs, the angle
+    returned will be nan.
     """
     stepper = get_stepper_motor_instance()
 
@@ -79,10 +79,8 @@ def _get_stepper_motor_angle() -> tuple[float, bool]:
 
     try:
         angle = stepper.angle
-        if angle is None:
-            return (float("nan"), True)
-        else:
-            return (angle, False)
+        is_moving = stepper.is_moving
+        return (angle, is_moving)
     except Exception as error:
         stepper.send_error_message(error)
         return (float("nan"), False)

--- a/finesse/hardware/plugins/stepper_motor/st10_controller.py
+++ b/finesse/hardware/plugins/stepper_motor/st10_controller.py
@@ -335,21 +335,19 @@ class ST10Controller(
         return self.status_code & 0x0010 == 0x0010
 
     @property
-    def step(self) -> int | None:
+    def step(self) -> int:
         """The current state of the device's step counter.
 
-        As this can only be requested when the motor is stationary, if the motor is
-        moving then None will be returned.
+        This makes use of the "IP" command, which estimates the immediate position of
+        the motor. If the motor is moving, this is an estimated (calculated trajectory)
+        position. If the motor is stationary, this is the actual position.
 
         Raises:
             SerialException: Error communicating with device
             SerialTimeoutException: Timed out waiting for response from device
             ST10ControllerError: Malformed message received from device
         """
-        if self.is_moving:
-            return None
-
-        step = self._request_value("SP")
+        step = self._request_value("IP")
         try:
             return int(step)
         except ValueError:

--- a/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
+++ b/finesse/hardware/plugins/stepper_motor/stepper_motor_base.py
@@ -41,12 +41,8 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
 
     @property
     @abstractmethod
-    def step(self) -> int | None:
-        """The current state of the device's step counter.
-
-        As this can only be requested when the motor is stationary, if the motor is
-        moving then None will be returned.
-        """
+    def step(self) -> int:
+        """The current state of the device's step counter."""
 
     @step.setter
     @abstractmethod
@@ -67,20 +63,13 @@ class StepperMotorBase(Device, name=STEPPER_MOTOR_TOPIC, description="Stepper mo
         """Whether the motor is currently moving."""
 
     @property
-    def angle(self) -> float | None:
+    def angle(self) -> float:
         """The current angle of the motor in degrees.
 
-        As this can only be requested when the motor is stationary, if the motor is
-        moving then None will be returned.
-
         Returns:
-            The current angle or None if the stepper motor is moving
+            The current angle
         """
-        step = self.step
-        if step is None:
-            return None
-
-        return step * 360.0 / self.steps_per_rotation
+        return self.step * 360.0 / self.steps_per_rotation
 
     def move_to(self, target: float | str) -> None:
         """Move the motor to a specified rotation and send message when complete.

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -361,26 +361,13 @@ def test_is_moving(
         [(4, "IP=hello", pytest.raises(ST10ControllerError))],
     ),
 )
-@patch(
-    "finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller.is_moving",
-    new_callable=PropertyMock,
-)
 def test_get_step(
-    is_moving_mock: PropertyMock,
     step: int,
     response: str,
     raises: Any,
     dev: ST10Controller,
 ) -> None:
     """Test getting the step property."""
-    # When the motor is stationary:
-    is_moving_mock.return_value = False
-    with read_mock(dev, response):
-        with raises:
-            assert dev.step == step
-
-    # When the motor is moving:
-    is_moving_mock.return_value = True
     with read_mock(dev, response):
         with raises:
             assert dev.step == step

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -365,31 +365,25 @@ def test_is_moving(
     "finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller.is_moving",
     new_callable=PropertyMock,
 )
-def test_get_step_not_moving(
+def test_get_step(
     is_moving_mock: PropertyMock,
     step: int,
     response: str,
     raises: Any,
     dev: ST10Controller,
 ) -> None:
-    """Test getting the step property when the motor is stationary."""
+    """Test getting the step property."""
+    # When the motor is stationary:
     is_moving_mock.return_value = False
     with read_mock(dev, response):
         with raises:
             assert dev.step == step
 
-
-@patch(
-    "finesse.hardware.plugins.stepper_motor.st10_controller.ST10Controller.is_moving",
-    new_callable=PropertyMock,
-)
-def test_get_step_moving(
-    is_moving_mock: PropertyMock,
-    dev: ST10Controller,
-) -> None:
-    """Test getting the step property when the motor is moving."""
+    # When the motor is moving:
     is_moving_mock.return_value = True
-    assert dev.step is None
+    with read_mock(dev, response):
+        with raises:
+            assert dev.step == step
 
 
 @pytest.mark.parametrize("step", range(0, 40, 7))

--- a/tests/hardware/plugins/stepper_motor/test_st10_controller.py
+++ b/tests/hardware/plugins/stepper_motor/test_st10_controller.py
@@ -240,7 +240,7 @@ def test_write_check(dev: ST10Controller) -> None:
             if response.startswith(f"{name}=")
             else pytest.raises(ST10ControllerError),
         )
-        for name in ["hello", "IS", "SP"]
+        for name in ["hello", "IS", "IP"]
         for value in ["", "value", "123"]
         for response in [f"{name}={value}", value, "%", "*", "?4"]
     ],
@@ -357,8 +357,8 @@ def test_is_moving(
 @pytest.mark.parametrize(
     "step,response,raises",
     chain(
-        [(step, f"SP={step}", does_not_raise()) for step in range(0, 250, 50)],
-        [(4, "SP=hello", pytest.raises(ST10ControllerError))],
+        [(step, f"IP={step}", does_not_raise()) for step in range(0, 250, 50)],
+        [(4, "IP=hello", pytest.raises(ST10ControllerError))],
     ),
 )
 @patch(

--- a/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
+++ b/tests/hardware/plugins/stepper_motor/test_stepper_motor_base.py
@@ -22,7 +22,7 @@ class _MockStepperMotor(StepperMotorBase, description="Mock stepper motor"):
         return False
 
     @property
-    def step(self) -> int | None:
+    def step(self) -> int:
         return self._step
 
     @step.setter

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -57,7 +57,6 @@ def test_open(
             "Temp2",
             "TimeAsSeconds",
             "Angle",
-            "IsMoving",
             "TemperatureControllerPower",
         )
     )
@@ -138,7 +137,7 @@ def test_write(
     writer._writer = MagicMock()
     writer.write(time, data)
     writer._writer.writerow.assert_called_once_with(
-        ("20230414", "00:01:00", *data, 60, 90.0, False, 10)
+        ("20230414", "00:01:00", *data, 60, 90.0, 10)
     )
 
     sendmsg_mock.assert_called_once_with("data_file.writing")

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -57,6 +57,7 @@ def test_open(
             "Temp2",
             "TimeAsSeconds",
             "Angle",
+            "IsMoving",
             "TemperatureControllerPower",
         )
     )
@@ -137,7 +138,7 @@ def test_write(
     writer._writer = MagicMock()
     writer.write(time, data)
     writer._writer.writerow.assert_called_once_with(
-        ("20230414", "00:01:00", *data, 60, 90.0, 10)
+        ("20230414", "00:01:00", *data, 60, 90.0, False, 10)
     )
 
     sendmsg_mock.assert_called_once_with("data_file.writing")

--- a/tests/hardware/test_data_file_writer.py
+++ b/tests/hardware/test_data_file_writer.py
@@ -153,7 +153,7 @@ def test_write_moving(
     writer: DataFileWriter,
     sendmsg_mock: Mock,
 ) -> None:
-    """Test the write() method."""
+    """Test the write() method when the stepper motor is moving."""
     get_stepper_mock.return_value = stepper = MagicMock()
     stepper.angle = 95.0
     stepper.is_moving = True


### PR DESCRIPTION
# Description

This PR enables getting the immediate position of stepper motors while they are moving.
Previously, querying the position during motion would return `None`. Now, for the ST10, an estimated position is returned.

I've had a go at making the dummy stepper motor return a position based on its `QTimer` interval and remaining time, but it's not fully complete, so we can either address that separately or I can finish it up here.

Fixes #691 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
