### PR TITLE
Fix: `DummyStepperMotor` returns `None` if moving

### DIFF
--- a/finesse/hardware/plugins/stepper_motor/dummy.py
+++ b/finesse/hardware/plugins/stepper_motor/dummy.py
@@ -42,7 +42,7 @@ class DummyStepperMotor(
         self._move_end_timer.timeout.connect(self._on_move_end)
 
         self._steps_per_rotation = steps_per_rotation
-        self._step = 0
+        self._step = self._new_step = 0
 
         super().__init__()
 
@@ -57,15 +57,8 @@ class DummyStepperMotor(
         return self._move_end_timer.isActive()
 
     @property
-    def step(self) -> int | None:
-        """The number of steps that correspond to a full rotation.
-
-        As this can only be requested when the motor is stationary, if the motor is
-        moving then None will be returned.
-        """
-        if self.is_moving:
-            return None
-
+    def step(self) -> int:
+        """The current state of the device's step counter."""
         return self._step
 
     @step.setter
@@ -76,7 +69,7 @@ class DummyStepperMotor(
             step: Which step position to move to
         """
         logging.info(f"Moving stepper motor to step {step}")
-        self._step = step
+        self._new_step = step
         self._move_end_timer.start()
 
     def stop_moving(self) -> None:
@@ -87,5 +80,6 @@ class DummyStepperMotor(
 
     def _on_move_end(self) -> None:
         """Run when the timer signals that the move has finished."""
+        self._step = self._new_step
         logging.info("Move finished")
         self.send_move_end_message()

--- a/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
+++ b/tests/hardware/plugins/stepper_motor/test_dummy_stepper_motor.py
@@ -62,12 +62,12 @@ def test_move_to_number(
     qtbot,
 ) -> None:
     """Check move_to, when an angle is given."""
-    assert stepper.step == 0
+    assert stepper._new_step == 0
 
     with patch.object(stepper._move_end_timer, "start") as start_mock:
         with raises:
             stepper.move_to(10.0 * float(target))
-            assert stepper.step == target
+            assert stepper._new_step == target
             start_mock.assert_called_once_with()
 
 
@@ -114,12 +114,16 @@ def test_stop_moving(stepper: DummyStepperMotor, qtbot) -> None:
             move_end_mock.assert_called_once()
 
 
-def test_on_move_end(
-    stepper: DummyStepperMotor, sendmsg_mock: MagicMock, qtbot
-) -> None:
-    """Test the _on_move_end() method when notification is requested."""
+def test_move(stepper: DummyStepperMotor, sendmsg_mock: MagicMock, qtbot) -> None:
+    """Test that moving the motor works."""
+    assert stepper.step == 0
+    with patch.object(stepper, "_move_end_timer"):
+        stepper.step = 100
+    assert stepper.step == 0  # the old value should still be returned
+
     # Trigger move end timer
     stepper._move_end_timer.timeout.emit()
+    assert stepper.step == 100
 
     # Check message is sent with final angle moved to
     sendmsg_mock.assert_called_once_with(


### PR DESCRIPTION
# Description

As with the `ST10Controller` before #743, the `DummyStepperMotor` returns an angle of `None` if it is in motion. However, this isn't what we want anymore; if you try to record data while using the `DummyStepperMotor` you now get an error when the code tries to use this `None` value. Change it to return the old angle instead.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
