### PR TITLE
Remove unneeded stub script

### DIFF
--- a/src/FROG.spec
+++ b/src/FROG.spec
@@ -14,7 +14,7 @@ block_cipher = None
 gen_guide.generate_html()
 
 a = Analysis(
-    ["stub.py"],
+    ["frog/__main__.py"],
     pathex=[],
     binaries=[],
     datas=[

--- a/src/stub.py
+++ b/src/stub.py
@@ -1,6 +1,0 @@
-"""Stub script for pyinstaller."""
-
-from frog import run
-
-if __name__ == "__main__":
-    run()


### PR DESCRIPTION
# Description

We currently have a `stub.py` file, which is just used to run the main entry point to the program by PyInstaller. I remember that at some point choosing the `__main__.py` file as the entry point for PyInstaller didn't work, but that seems not to be a problem any more.

I've verified that the generated EXE still launches ok (with wine).

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [ ] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
