### PR TITLE
Check/uncheck relevant preset angle button when motor moves

### DIFF
--- a/src/frog/gui/stepper_motor_view.py
+++ b/src/frog/gui/stepper_motor_view.py
@@ -65,7 +65,7 @@ class StepperMotorControl(DevicePanel):
             f"device.{STEPPER_MOTOR_TOPIC}.move.begin",
         )
         pub.subscribe(
-            self._update_mirror_position_display,
+            self._on_move_end,
             f"device.{STEPPER_MOTOR_TOPIC}.move.end",
         )
 
@@ -91,15 +91,38 @@ class StepperMotorControl(DevicePanel):
         """Update the display the indicate that the mirror is moving."""
         self.mirror_position_display.setText("Moving...")
 
-    def _update_mirror_position_display(self, moved_to: float) -> None:
-        """Display the angle the mirror has moved to.
+    def _on_move_end(self, moved_to: float) -> None:
+        """Update the control to show the angle that the mirror has moved to.
 
-        If angle corresponds to a preset, show the associated name as well as the value.
+        This is displayed in a text label, which will include the preset name, if the
+        angle (approximately) corresponds to a preset. The relevant preset button will
+        also be checked/unchecked as appropriate.
         """
         text = f"{moved_to:.1f}°"
         if preset := next(
             (k for k, v in self.angle_presets.items() if abs(v - moved_to) <= 0.05),
             None,
         ):
+            # If this angle corresponds to a preset, include name in label
             text += f" ({preset})"
+
+            # Also check the corresponding preset button
+            preset_upper = preset.upper()
+            btn = next(
+                btn for btn in self.button_group.buttons() if btn.text() == preset_upper
+            )
+            btn.setChecked(True)
+        elif btn := self.button_group.checkedButton():
+            # This angle isn't a preset. If there is a button already checked, uncheck
+            # it.
+            #
+            # Alas, you can't uncheck a button if it's in an exclusive group, as here,
+            # so we make the group non-exclusive, uncheck the button, then make the
+            # group exclusive again.
+            #
+            # See: https://forum.qt.io/topic/6419/how-to-uncheck-button-in-qbuttongroup
+            self.button_group.setExclusive(False)
+            btn.setChecked(False)
+            self.button_group.setExclusive(True)
+
         self.mirror_position_display.setText(text)

--- a/tests/gui/test_stepper_motor_view.py
+++ b/tests/gui/test_stepper_motor_view.py
@@ -76,13 +76,39 @@ def test_indicate_moving(qtbot: QtBot) -> None:
     assert control.mirror_position_display.text() == "Moving..."
 
 
-def test_update_mirror_position_display(qtbot: QtBot) -> None:
-    """Test the mirror position display updates correctly."""
+def test_on_move_end(qtbot: QtBot) -> None:
+    """Test the control updates correctly when the motor has finished moving."""
     control = StepperMotorControl()
-    control._update_preset_angles({"zenith": 180.0})
+    control._update_preset_angles({"zenith": 180.0, "nadir": 0.0})
 
-    control._update_mirror_position_display(moved_to=180.0)
-    assert control.mirror_position_display.text() == "180.0\u00b0 (zenith)"
+    # Get the preset buttons for testing
+    zenith_btn = next(
+        btn for btn in control.button_group.buttons() if btn.text() == "ZENITH"
+    )
+    nadir_btn = next(
+        btn for btn in control.button_group.buttons() if btn.text() == "NADIR"
+    )
 
-    control._update_mirror_position_display(moved_to=12.34)
-    assert control.mirror_position_display.text() == "12.3\u00b0"
+    # Test moving to a preset position - should check the corresponding button
+    control._on_move_end(moved_to=180.0)
+    assert control.mirror_position_display.text() == "180.0° (zenith)"
+    assert zenith_btn.isChecked()
+    assert not nadir_btn.isChecked()
+
+    # Test moving to a different preset - should check new button and uncheck old one
+    control._on_move_end(moved_to=0.0)
+    assert control.mirror_position_display.text() == "0.0° (nadir)"
+    assert nadir_btn.isChecked()
+    assert not zenith_btn.isChecked()
+
+    # Test moving to a non-preset position - should uncheck any checked button
+    control._on_move_end(moved_to=12.34)
+    assert control.mirror_position_display.text() == "12.3°"
+    assert not zenith_btn.isChecked()
+    assert not nadir_btn.isChecked()
+
+    # Test tolerance - position within 0.05 degrees should still match preset
+    control._on_move_end(moved_to=179.98)  # within tolerance of 180.0
+    assert control.mirror_position_display.text() == "180.0° (zenith)"
+    assert zenith_btn.isChecked()
+    assert not nadir_btn.isChecked()


### PR DESCRIPTION
# Description

This is a small UX improvement. When you click on one of the preset angle buttons in the main window, that button is highlighted ("checked"), but if the motor is subsequently moved to a different position due to something other than a click to one of those buttons, the original preset will remain highlighted, which is a little confusing (e.g. the mirror can be at the zenith with the `NADIR` button still highlighted). I've changed things so that we now check/uncheck the relevant preset button as appropriate.

Fixes #956.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
