### PR TITLE
Make temperature channels for hot and cold black bodies configurable

### DIFF
--- a/src/frog/config.py
+++ b/src/frog/config.py
@@ -107,12 +107,6 @@ TEMPERATURE_MONITOR_POLL_INTERVAL = 2
 TEMPERATURE_PLOT_TIME_RANGE = 900
 """Range of time axis on blackbody temperature plot, in seconds."""
 
-TEMPERATURE_MONITOR_HOT_BB_IDX = 6
-"""Position of the hot blackbody on the temperature monitoring device."""
-
-TEMPERATURE_MONITOR_COLD_BB_IDX = 7
-"""Position of the cold blackbody on the temperature monitoring device."""
-
 TEMPERATURE_PRECISION = 2
 """Number of decimal places used when writing temperatures to data files (Kelvin)."""
 

--- a/src/frog/gui/hardware_set/dummy.yaml
+++ b/src/frog/gui/hardware_set/dummy.yaml
@@ -11,6 +11,9 @@ devices:
     class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_monitor:
     class_name: temperature.dummy_temperature_monitor.DummyTemperatureMonitor
+    params:
+      hot_bb_channel: CH7
+      cold_bb_channel: CH8
   sensors:
     class_name: sensors.dummy_em27_sensors.DummyEM27Sensors
   spectrometer:

--- a/src/frog/gui/hardware_set/dummy_ftsw500.yaml
+++ b/src/frog/gui/hardware_set/dummy_ftsw500.yaml
@@ -11,6 +11,9 @@ devices:
     class_name: temperature.dummy_temperature_controller.DummyTemperatureController
   temperature_monitor:
     class_name: temperature.dummy_temperature_monitor.DummyTemperatureMonitor
+    params:
+      hot_bb_channel: CH7
+      cold_bb_channel: CH8
   sensors:
     class_name: sensors.dummy_em27_sensors.DummyEM27Sensors
   spectrometer:

--- a/src/frog/gui/hardware_set/finesse.yaml
+++ b/src/frog/gui/hardware_set/finesse.yaml
@@ -28,6 +28,8 @@ devices:
       port: "0403:6001"
       baudrate: 57600
       max_attempts: 3
+      hot_bb_channel: CH7
+      cold_bb_channel: CH8
   sensors:
     class_name: sensors.em27_sensors.EM27Sensors
   spectrometer:

--- a/src/frog/gui/main_window.py
+++ b/src/frog/gui/main_window.py
@@ -12,12 +12,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from frog.config import (
-    APP_NAME,
-    APP_VERSION,
-    TEMPERATURE_MONITOR_COLD_BB_IDX,
-    TEMPERATURE_MONITOR_HOT_BB_IDX,
-)
+from frog.config import APP_NAME, APP_VERSION
 from frog.gui.data_file_view import DataFileControl
 from frog.gui.docs_view import DocsViewer
 from frog.gui.hardware_set.hardware_sets_view import HardwareSetsControl
@@ -92,12 +87,8 @@ class MainWindow(QMainWindow):
 
         bb_monitor: QGroupBox = TemperaturePlot()
         temp_monitor: QGroupBox = TemperatureMonitorControl()
-        tc_hot: QGroupBox = TemperatureControllerControl(
-            "hot", TEMPERATURE_MONITOR_HOT_BB_IDX, allow_update=True
-        )
-        tc_cold: QGroupBox = TemperatureControllerControl(
-            "cold", TEMPERATURE_MONITOR_COLD_BB_IDX, allow_update=False
-        )
+        tc_hot: QGroupBox = TemperatureControllerControl("hot", allow_update=True)
+        tc_cold: QGroupBox = TemperatureControllerControl("cold", allow_update=False)
 
         layout_right.addWidget(bb_monitor, 1, 0, 1, 2)
         layout_right.addWidget(temp_monitor, 2, 0, 1, 2)

--- a/src/frog/gui/temperature_controller_view.py
+++ b/src/frog/gui/temperature_controller_view.py
@@ -1,6 +1,6 @@
 """Provides a widget for interacting with temperature controllers."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from decimal import Decimal
 
@@ -29,12 +29,11 @@ from frog.gui.led_icon import LEDIcon
 class TemperatureControllerControl(DevicePanel):
     """A widget to interact with temperature controllers."""
 
-    def __init__(self, name: str, temperature_idx: int, allow_update: bool) -> None:
+    def __init__(self, name: str, allow_update: bool) -> None:
         """Create a new TemperatureControllerControl.
 
         Args:
             name: Name of the blackbody the temperature controller is controlling
-            temperature_idx: Index of the blackbody on the temperature monitor
             allow_update: Whether to allow modifying the temperature
         """
         super().__init__(
@@ -43,7 +42,7 @@ class TemperatureControllerControl(DevicePanel):
         )
         self._name = name
         self._poll_interval = 1000 * TEMPERATURE_CONTROLLER_POLL_INTERVAL
-        self._temperature_idx = temperature_idx
+        self._temperature_idx: int | None = None
 
         layout = self._create_controls(allow_update)
         self.setLayout(layout)
@@ -53,6 +52,14 @@ class TemperatureControllerControl(DevicePanel):
             QSizePolicy.Policy.Fixed,
         )
 
+        pub.subscribe(
+            self._set_temperature_idx,
+            f"device.{TEMPERATURE_MONITOR_TOPIC}.temperature_idx",
+        )
+        pub.subscribe(
+            self._unset_temperature_idx,
+            f"device.closed.{TEMPERATURE_MONITOR_TOPIC}",
+        )
         pub.subscribe(
             self._begin_polling,
             f"device.opened.{TEMPERATURE_CONTROLLER_TOPIC}.{name}_bb",
@@ -136,6 +143,16 @@ class TemperatureControllerControl(DevicePanel):
 
         return layout
 
+    def _set_temperature_idx(self, temperature_idx: Mapping[str, int]) -> None:
+        """Update the temperature channel that this controller corresponds to."""
+        self._temperature_idx = temperature_idx[f"{self._name}_bb"]
+        self._pt100_val.setText("")
+
+    def _unset_temperature_idx(self, instance: DeviceInstanceRef) -> None:
+        """Unset the temperature channel on device close."""
+        self._temperature_idx = None
+        self._pt100_val.setText("")
+
     def _on_update_clicked(self) -> None:
         isDown = self._update_pbtn.isChecked()
         if isDown:
@@ -191,7 +208,10 @@ class TemperatureControllerControl(DevicePanel):
             temperatures: list of temperatures retrieved from device
             time: the timestamp at which the properties were sent
         """
-        self._pt100_val.setText(f"{temperatures[self._temperature_idx]: .2f}")
+        if self._temperature_idx is None:
+            self._pt100_val.setText("")
+        else:
+            self._pt100_val.setText(f"{temperatures[self._temperature_idx]: .2f}")
 
     def _set_new_set_point(self) -> None:
         """Send new target temperature to temperature controller."""

--- a/src/frog/gui/temperature_monitor_view.py
+++ b/src/frog/gui/temperature_monitor_view.py
@@ -97,12 +97,12 @@ class TemperatureMonitorControl(DevicePanel):
 
     def _update_label_colours(self, temperature_idx: Mapping[str, int]) -> None:
         """Change the colours of the labels to show which are the hot and cold."""
-        colours = {temperature_idx["hot_bb"]: "red", temperature_idx["cold_bb"]: "blue"}
+        styles = {
+            temperature_idx["hot_bb"]: "color: red",
+            temperature_idx["cold_bb"]: "color: blue",
+        }
         for idx, label in enumerate(self._labels):
-            if colour := colours.get(idx, None):
-                label.setStyleSheet(f"color: {colour}")
-            else:
-                label.setStyleSheet("")
+            label.setStyleSheet(styles.get(idx, ""))
 
     def _reset_label_colours(self, instance: DeviceInstanceRef) -> None:
         """Reset the label colours."""

--- a/src/frog/gui/temperature_monitor_view.py
+++ b/src/frog/gui/temperature_monitor_view.py
@@ -60,7 +60,7 @@ class TemperatureMonitorControl(DevicePanel):
         layout.addWidget(QLabel("Pt 100"), 1, 0)
         self._channels = []
         for i in range(self._num_channels):
-            channel_label = QLabel(f"CH_{i + 1}")
+            channel_label = QLabel(f"CH{i + 1}")
             channel_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(channel_label, 0, i + 1)
 

--- a/src/frog/gui/temperature_monitor_view.py
+++ b/src/frog/gui/temperature_monitor_view.py
@@ -1,6 +1,6 @@
 """Provides a widget to show the current temperatures."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 
 from pubsub import pub
@@ -17,6 +17,7 @@ from frog.config import (
     TEMPERATURE_MONITOR_POLL_INTERVAL,
     TEMPERATURE_MONITOR_TOPIC,
 )
+from frog.device_info import DeviceInstanceRef
 from frog.gui.device_panel import DevicePanel
 from frog.gui.led_icon import LEDIcon
 
@@ -34,6 +35,7 @@ class TemperatureMonitorControl(DevicePanel):
 
         self._num_channels = num_channels
         self._poll_interval = 1000 * TEMPERATURE_MONITOR_POLL_INTERVAL
+        self._temperature_idx: Mapping[str, int] = {}
 
         layout = self._create_controls()
         self.setLayout(layout)
@@ -43,6 +45,14 @@ class TemperatureMonitorControl(DevicePanel):
             QSizePolicy.Policy.Fixed,
         )
 
+        pub.subscribe(
+            self._update_label_colours,
+            f"device.{TEMPERATURE_MONITOR_TOPIC}.temperature_idx",
+        )
+        pub.subscribe(
+            self._reset_label_colours,
+            f"device.closed.{TEMPERATURE_MONITOR_TOPIC}",
+        )
         pub.subscribe(
             self._update_pt100s, f"device.{TEMPERATURE_MONITOR_TOPIC}.data.response"
         )
@@ -58,11 +68,13 @@ class TemperatureMonitorControl(DevicePanel):
         layout = QGridLayout()
 
         layout.addWidget(QLabel("Pt 100"), 1, 0)
-        self._channels = []
+        self._labels: list[QLabel] = []
+        self._channels: list[QLineEdit] = []
         for i in range(self._num_channels):
             channel_label = QLabel(f"CH{i + 1}")
             channel_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(channel_label, 0, i + 1)
+            self._labels.append(channel_label)
 
             channel_tbox = QLineEdit()
             channel_tbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -82,6 +94,20 @@ class TemperatureMonitorControl(DevicePanel):
         layout.addWidget(self._poll_light, 0, 10, 2, 1)
 
         return layout
+
+    def _update_label_colours(self, temperature_idx: Mapping[str, int]) -> None:
+        """Change the colours of the labels to show which are the hot and cold."""
+        colours = {temperature_idx["hot_bb"]: "red", temperature_idx["cold_bb"]: "blue"}
+        for idx, label in enumerate(self._labels):
+            if colour := colours.get(idx, None):
+                label.setStyleSheet(f"color: {colour}")
+            else:
+                label.setStyleSheet("")
+
+    def _reset_label_colours(self, instance: DeviceInstanceRef) -> None:
+        """Reset the label colours."""
+        for label in self._labels:
+            label.setStyleSheet("")
 
     def _begin_polling(self) -> None:
         """Initiate polling the temperature monitor."""

--- a/src/frog/gui/temperature_plot.py
+++ b/src/frog/gui/temperature_plot.py
@@ -1,6 +1,6 @@
 """Panel showing a plot of temperatures."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from functools import partial
 
@@ -17,12 +17,11 @@ from PySide6.QtWidgets import (
 )
 
 from frog.config import (
-    TEMPERATURE_MONITOR_COLD_BB_IDX,
-    TEMPERATURE_MONITOR_HOT_BB_IDX,
     TEMPERATURE_MONITOR_POLL_INTERVAL,
     TEMPERATURE_MONITOR_TOPIC,
     TEMPERATURE_PLOT_TIME_RANGE,
 )
+from frog.device_info import DeviceInstanceRef
 
 
 class TemperaturePlot(QGroupBox):
@@ -32,9 +31,19 @@ class TemperaturePlot(QGroupBox):
         """Creates a panel with a graph to monitor the blackbody temperatures."""
         super().__init__("BB Monitor")
 
+        self._temperature_idx: Mapping[str, int] = {}
+
         layout = self._create_controls()
         self.setLayout(layout)
 
+        pub.subscribe(
+            self._set_temperature_idx,
+            f"device.{TEMPERATURE_MONITOR_TOPIC}.temperature_idx",
+        )
+        pub.subscribe(
+            self._unset_temperature_idx,
+            f"device.closed.{TEMPERATURE_MONITOR_TOPIC}",
+        )
         pub.subscribe(
             self._plot_bb_temps, f"device.{TEMPERATURE_MONITOR_TOPIC}.data.response"
         )
@@ -160,6 +169,14 @@ class TemperaturePlot(QGroupBox):
         self._ax["hot"].autoscale()
         self._ax["cold"].autoscale()
 
+    def _set_temperature_idx(self, temperature_idx: Mapping[str, int]) -> None:
+        """Update the temperature channels being plotted."""
+        self._temperature_idx = temperature_idx
+
+    def _unset_temperature_idx(self, instance: DeviceInstanceRef) -> None:
+        """Unset the temperature channels being plotted on device close."""
+        self._temperature_idx = {}
+
     def _plot_bb_temps(self, time: datetime, temperatures: Sequence) -> None:
         """Extract blackbody temperatures and plot them.
 
@@ -167,7 +184,15 @@ class TemperaturePlot(QGroupBox):
             time: the time that the temperatures were read
             temperatures: the list of current temperatures
         """
-        hot_bb_temp = float(temperatures[TEMPERATURE_MONITOR_HOT_BB_IDX])
-        cold_bb_temp = float(temperatures[TEMPERATURE_MONITOR_COLD_BB_IDX])
+        hot_bb_idx = self._temperature_idx.get("hot_bb", None)
+        hot_bb_temp = (
+            float(temperatures[hot_bb_idx]) if hot_bb_idx is not None else float("nan")
+        )
+        cold_bb_idx = self._temperature_idx.get("cold_bb", None)
+        cold_bb_temp = (
+            float(temperatures[cold_bb_idx])
+            if cold_bb_idx is not None
+            else float("nan")
+        )
 
         self._update_figure(time.timestamp(), hot_bb_temp, cold_bb_temp)

--- a/src/frog/hardware/plugins/temperature/dp9800.py
+++ b/src/frog/hardware/plugins/temperature/dp9800.py
@@ -94,15 +94,25 @@ class DP9800(SerialDevice, TemperatureMonitorBase, description="DP9800"):
     https://assets.omega.com/manuals/M5210.pdf
     """
 
-    def __init__(self, port: str, baudrate: int = 38400) -> None:
+    def __init__(
+        self,
+        hot_bb_channel: str,
+        cold_bb_channel: str,
+        port: str,
+        baudrate: int = 38400,
+    ) -> None:
         """Create a new DP9800.
 
         Args:
+            hot_bb_channel: Channel name for hot black body
+            cold_bb_channel: Channel name for cold black body
             port: Name/description of serial port
             baudrate: Baud rate of port
         """
         SerialDevice.__init__(self, port, baudrate)
-        TemperatureMonitorBase.__init__(self)
+        TemperatureMonitorBase.__init__(
+            self, hot_bb_channel=hot_bb_channel, cold_bb_channel=cold_bb_channel
+        )
 
     def get_device_settings(self, sysflag: str) -> dict[str, str]:
         """Provide the settings of the device as stored in the system flag.

--- a/src/frog/hardware/plugins/temperature/dummy_temperature_monitor.py
+++ b/src/frog/hardware/plugins/temperature/dummy_temperature_monitor.py
@@ -27,9 +27,18 @@ class DummyTemperatureMonitor(
     """A dummy temperature monitor for GUI testing."""
 
     def __init__(
-        self, temperature_params: Sequence[NoiseParameters] = _DEFAULT_TEMP_PARAMS
+        self,
+        hot_bb_channel: str,
+        cold_bb_channel: str,
+        temperature_params: Sequence[NoiseParameters] = _DEFAULT_TEMP_PARAMS,
     ) -> None:
-        """Create a new DummyTemperatureMonitor."""
+        """Create a new DummyTemperatureMonitor.
+
+        Args:
+            hot_bb_channel: Channel name for hot black body
+            cold_bb_channel: Channel name for cold black body
+            temperature_params: Parameters for generating temperatures
+        """
         if len(temperature_params) != NUM_TEMPERATURE_MONITOR_CHANNELS:
             raise ValueError(
                 f"Must provide {NUM_TEMPERATURE_MONITOR_CHANNELS} parameters"
@@ -40,7 +49,7 @@ class DummyTemperatureMonitor(
             for params in temperature_params
         ]
 
-        super().__init__()
+        super().__init__(hot_bb_channel=hot_bb_channel, cold_bb_channel=cold_bb_channel)
 
     def get_temperatures(self) -> Sequence:
         """Get current temperatures."""

--- a/src/frog/hardware/plugins/temperature/temperature_monitor_base.py
+++ b/src/frog/hardware/plugins/temperature/temperature_monitor_base.py
@@ -1,18 +1,79 @@
 """Provides a base class for temperature monitor devices or mock devices."""
 
+import re
 from abc import abstractmethod
 from collections.abc import Sequence
 
-from frog.config import TEMPERATURE_MONITOR_TOPIC
+from frog.config import (
+    NUM_TEMPERATURE_MONITOR_CHANNELS,
+    TEMPERATURE_MONITOR_TOPIC,
+)
 from frog.hardware.device import Device
+
+
+def _parse_channel_idx(input: str) -> int:
+    """Get the temperature index from a string.
+
+    >>> _parse_channel_idx("CH1")
+    0
+
+    Args:
+        input: String input
+    """
+    if match := re.match(r"^CH([0-9]+)$", input):
+        if num_str := match.group(1):
+            num = int(num_str)
+            if not (1 <= num <= NUM_TEMPERATURE_MONITOR_CHANNELS):
+                raise ValueError(
+                    "Channel number must be between 1 and "
+                    f"{NUM_TEMPERATURE_MONITOR_CHANNELS} inclusive"
+                )
+
+            # Subtract one because we want the index starting at zero
+            return num - 1
+
+    raise ValueError(f"{input} is not a well-formed channel name")
+
+
+_CHANNEL_NAMES = tuple(f"CH{i + 1}" for i in range(NUM_TEMPERATURE_MONITOR_CHANNELS))
+"""Names for different temperature channels."""
 
 
 class TemperatureMonitorBase(
     Device,
     name=TEMPERATURE_MONITOR_TOPIC,
     description="Temperature monitor",
+    parameters={
+        "hot_bb_channel": ("The channel for the hot black body", _CHANNEL_NAMES),
+        "cold_bb_channel": ("The channel for the cold black body", _CHANNEL_NAMES),
+    },
 ):
     """The base class for temperature monitor devices or mock devices."""
+
+    def __init__(self, hot_bb_channel: str, cold_bb_channel: str) -> None:
+        """Create a new TemperatureMonitorBase.
+
+        Args:
+            hot_bb_channel: Channel name for hot black body
+            cold_bb_channel: Channel name for cold black body
+        """
+        super().__init__()
+
+        hot_bb_idx = _parse_channel_idx(hot_bb_channel)
+        cold_bb_idx = _parse_channel_idx(cold_bb_channel)
+        if hot_bb_idx == cold_bb_idx:
+            raise ValueError("Hot and cold black body channels cannot be the same")
+
+        self._temperature_idx = {"hot_bb": hot_bb_idx, "cold_bb": cold_bb_idx}
+
+    def signal_is_opened(self) -> None:
+        """Signal that the device is now open.
+
+        Send a message to frontend indicating what channels correspond to the hot and
+        cold black bodies.
+        """
+        super().signal_is_opened()
+        self.send_message("temperature_idx", temperature_idx=self._temperature_idx)
 
     @abstractmethod
     def get_temperatures(self) -> Sequence:

--- a/src/frog/hardware/plugins/temperature/z8ai.py
+++ b/src/frog/hardware/plugins/temperature/z8ai.py
@@ -61,6 +61,8 @@ class Z8AI(
 
     def __init__(
         self,
+        hot_bb_channel: str,
+        cold_bb_channel: str,
         port: str,
         baudrate: int = 57600,
         min_temp: int = Z8AI_MIN_TEMP,
@@ -72,6 +74,8 @@ class Z8AI(
         """Create a new Z8AI.
 
         Args:
+            hot_bb_channel: Channel name for hot black body
+            cold_bb_channel: Channel name for cold black body
             port: Description of USB port (vendor ID + product ID)
             baudrate: Baud rate of port
             min_temp: The minimum temperature limit of the device.
@@ -81,7 +85,9 @@ class Z8AI(
             max_attempts: Maximum number of attempts for requests.
         """
         SerialDevice.__init__(self, port, baudrate)
-        TemperatureMonitorBase.__init__(self)
+        TemperatureMonitorBase.__init__(
+            self, hot_bb_channel=hot_bb_channel, cold_bb_channel=cold_bb_channel
+        )
 
         if max_attempts < 1:
             raise ValueError("max_attempts must be at least 1")

--- a/tests/hardware/plugins/temperature/test_dp9800.py
+++ b/tests/hardware/plugins/temperature/test_dp9800.py
@@ -37,7 +37,7 @@ def data() -> bytes:
 @pytest.fixture
 def dev(serial_mock: MagicMock) -> DP9800:
     """Get an instance of a DP9800 object."""
-    return DP9800("COM1", 38400)
+    return DP9800("CH7", "CH8", "COM1", 38400)
 
 
 def test_check_data(data: bytes) -> None:

--- a/tests/hardware/plugins/temperature/test_z8ai.py
+++ b/tests/hardware/plugins/temperature/test_z8ai.py
@@ -7,13 +7,13 @@ import pytest
 
 from frog.hardware.plugins.temperature.z8ai import Z8AI, Z8AIError
 
-_SERIAL_ARGS = ("0403:6001 AB0LMVI5A", 57600)
+_Z8AI_ARGS = ("CH7", "CH8", "0403:6001 AB0LMVI5A", 57600)
 
 
 @pytest.fixture
 def dev(serial_mock: MagicMock) -> Z8AI:
     """Get an instance of a Seneca Z-8AI object."""
-    return Z8AI(*_SERIAL_ARGS)
+    return Z8AI(*_Z8AI_ARGS)
 
 
 @pytest.fixture
@@ -25,14 +25,14 @@ def data() -> bytes:
 def test_init(serial_mock: MagicMock) -> None:
     """Test Seneca Z-8AI's constructor."""
     # Test default values
-    dev = Z8AI(*_SERIAL_ARGS)
+    dev = Z8AI(*_Z8AI_ARGS)
     assert dev.MIN_TEMP == -80
     assert dev.MAX_TEMP == 105
     assert dev.MIN_MILLIVOLT == 4
     assert dev.MAX_MILLIVOLT == 20
 
     # Test arg values
-    dev = Z8AI(*_SERIAL_ARGS, 1, 2, 3, 4)
+    dev = Z8AI(*_Z8AI_ARGS, 1, 2, 3, 4)
     assert dev.MIN_TEMP == 1
     assert dev.MAX_TEMP == 2
     assert dev.MIN_MILLIVOLT == 3


### PR DESCRIPTION
# Description

At present, we hardcode which channels on the temperature monitor correspond to the hot and cold black bodies (CH7 and CH8, respectively). For UNIRAS, though, it seems the channels will be ordered differently, so we need to make this configurable, which is what I've done here.

My initial thought was that we should just rewire the UNIRAS rig so that we can keep the channel numbering the same, but this doesn't actually make much sense, as the way it's wired now is so that the first four channels relate to the hot BB and the rest to the cold BB, which seems logical. And rewiring FINESSE isn't really an option either.

I've implemented this by adding device parameters indicating which channels are for the hot and cold BBs. I've done this for the `TemperatureMonitorBase` class, so it applies to all of them, including the dummy device. I considered doing it just for the `Z8AI`, but I figured it would be good to be able to play with this functionality with the dummy class too.

This required a few changes to the frontend. `TemperaturePlot` and `TemperatureControllerControl` had to be updated to use the channel numbers dynamically supplied from the backend rather than the hardcoded values for channel numbers. I also changed `TemperatureMonitorControl` so that the channels for the hot and cold BBs are labelled with red and blue text, respectively, to make it easy to keep track of it (I can imagine it would be easy to select the wrong channel by mistake).

Closes #957.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [x] Pre-commit hooks run successfully (`pre-commit run -a`)
- [x] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [x] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
