### PR TITLE
Dependabot: Pin versions of `python-statemachine` and `mkdocs`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     groups:
       python:
         patterns: ["*"]
+    ignore:
+      # NB: mkdocs v2 will include breaking changes.
+      # See: https://github.com/imperialcollegelondon/python-template/discussions/530
+      - dependency-name: mkdocs
+        update-types: [version-update:semver-major]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       # See: https://github.com/imperialcollegelondon/python-template/discussions/530
       - dependency-name: mkdocs
         update-types: [version-update:semver-major]
+      # v2.4 not working: https://github.com/ImperialCollegeLondon/FROG/issues/739
+      - dependency-name: python-statemachine
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
         update-types: [version-update:semver-major]
       # v2.4 not working: https://github.com/ImperialCollegeLondon/FROG/issues/739
       - dependency-name: python-statemachine
+        versions: [">=2.4.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "schema<1.0.0,>=0.7.7",
     "pyserial<4.0,>=3.5",
     "beautifulsoup4<5.0.0,>=4.12.3",
+    # v2.4 not working: https://github.com/ImperialCollegeLondon/FROG/issues/739
     "python-statemachine~=2.3.6",
     "numpy<3.0.0,>=2.2.4",
     "decorator<6.0.0,>=5.1.1",


### PR DESCRIPTION
# Description

Dependabot has opened a PR which includes a major version update to `python-statemachine` (#964), although we've pinned the version to v2.3.x in `pyproject.toml` due to #739. It seems we need to tell dependabot explicitly to ignore it, so that's what I've done. The v3 series may fix our bug (though I suspect not), but it also includes other breaking changes, so I figure trying it out is a job for another day.

While I was at it, I've pinned `mkdocs` to the v1 series, as it seems the v2 update, whenever it happens, will break everything (see discussion here: https://github.com/ImperialCollegeLondon/python-template/discussions/530).

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimisation (non-breaking, back-end change that speeds up the code)

## Key checklist

- [ ] Pre-commit hooks run successfully (`pre-commit run -a`)
- [ ] All tests pass (`pytest`)
- [ ] The documentation builds without warnings (`mkdocs build -s`)
- [ ] Check the GUI still works (if relevant)
- [ ] Check the code works with actual hardware (if relevant)
- [ ] Check the `pyinstaller`-built executable works (if relevant)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
