### PR TITLE
Fix README.md: `uv sync` should be called with `--all-groups` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To get started:
 1. Set up the virtual environment:
 
    ```bash
-   uv sync
+   uv sync --all-groups
    ```
 
 1. Install the git hooks:


### PR DESCRIPTION
If you call `uv sync` without the `--all-groups` flag, it won't install the deps in the `dev` and `docs` groups, which you kinda need as a developer. Fix this.

I've noticed this is a problem in the Python template repo, so I'll open a PR there too.