### PR TITLE
Bump version to v3.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: If you use this software, please cite it as below.
 title: FROG
-version: 3.0.0
-date-released: 2025-05-02
+version: 3.1.0
+date-released: 2026-04-17
 authors:
     - family-names: Dewar
       given-names: Alex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "FROG"
-version = "3.0.0"
+version = "3.1.0"
 description = "A graphical user interface for controlling and monitoring an interferometer device."
 authors = [
     { name = "Alex Dewar", email = "a.dewar@imperial.ac.uk" },

--- a/tests/test_citation.py
+++ b/tests/test_citation.py
@@ -1,0 +1,15 @@
+"""Check that the CITATION.cff file is valid."""
+
+import yaml
+
+from frog.config import APP_VERSION
+
+
+def test_version() -> None:
+    """Check that the version field. matches the package version."""
+    with open("CITATION.cff", encoding="utf-8") as f:
+        citation_version = yaml.safe_load(f)["version"]
+
+    assert APP_VERSION == citation_version, (
+        "version field in CITATION.cff does not match package version"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "frog"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -405,6 +405,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
# Description

Bump the version to v3.1.0 in preparation for the next release.

Now that we have a `CITATION.cff` file, there is another place where the program version needs to be updated. I tried using [`bump-my-version`](https://pypi.org/project/bump-my-version/) to update the version strings together, but the configuration was annoying so I gave up. In the end, I added a test to check that the `version` field in `CITATION.cff` matches the one in `pyproject.toml`, which is similar to what I've done for MUSE2.